### PR TITLE
fix: Получение UUID

### DIFF
--- a/packages/value/src/index.ts
+++ b/packages/value/src/index.ts
@@ -28,7 +28,7 @@ export type JSValue =
 export function fromYdb(value: Ydb.Value, type: Ydb.Type): Value {
 	switch (type.type.case) {
 		case 'typeId':
-			return new Primitive({ value: value.value }, new PrimitiveType(type.type.value))
+			return new Primitive({ value: value.value, high128: value.high128 }, new PrimitiveType(type.type.value))
 		case 'listType':
 			return new List(...value.items.map((v) => fromYdb(v, (type.type.value as unknown as Ydb.ListType).item!)))
 		case 'tupleType':

--- a/packages/value/src/primitive.ts
+++ b/packages/value/src/primitive.ts
@@ -51,6 +51,7 @@ export class Primitive implements Value<PrimitiveType> {
 		this.type = type
 		this.value = value?.value?.value
 		this.#value = value
+		this.high128 = value.high128
 	}
 
 	encode(): Ydb.Value {


### PR DESCRIPTION
 # Описание PR:
## Предпосылки
На данный момент, при извлечении поля с типом `Uuid` возникает следующая ошибка:
```
backend\node_modules\@ydbjs\retry\dist\cjs\index.js:92
    if (error instanceof error_1.CommitError) {
              ^

TypeError: Right-hand side of 'instanceof' is not an object
    at Object.isRetryableError [as retry] (backend\node_modules\@ydbjs\retry\dist\cjs\index.js:92:15)
    at retry (backend\node_modules\@ydbjs\retry\dist\cjs\index.js:50:69)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async RefreshTokenRepository.list (backend\src\services\id\refresh_token\refresh_token.repository.ts:18:20)
Emitted 'error' event on Query instance at:
    at backend\node_modules\@ydbjs\query\dist\cjs\query.js:345:18
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async RefreshTokenRepository.list (backend\src\services\id\refresh_token\refresh_token.repository.ts:18:20)
```

Проблема связана с ньюансами отображения ошибками. Я не стал углубляться в это и перешёл к сути.

## Суть

Через debugger я определил действительную ошибку. Ею оказалась:
```
TypeError: Cannot mix BigInt and other types, use explicit conversions
    at writeBigU_Int64LE (node:internal/buffer:583:25)
    at Buffer.writeBigUInt64LE (node:internal/buffer:603:10)
    at uuidFromBigInts backend\node_modules\@ydbjs\query\node_modules\@ydbjs\value\dist\cjs\uuid.js:10:11)
    at toJs (backend\node_modules\@ydbjs\query\node_modules\@ydbjs\value\dist\cjs\index.js:176:58)
    at backend\node_modules\@ydbjs\query\dist\cjs\query.js:330:120
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async retry (backend\node_modules\@ydbjs\retry\dist\cjs\index.js:37:20)
    at async RefreshTokenRepository.list (backend\src\services\id\refresh_token\refresh_token.repository.ts:18:20)
```

С помощью нехитрых действий и, опять де, дебаггера, я выяснил, что функция Buffer.writeBigUInt64LE не получает то, что должно, а получает undefined. Суть оказалась в недописанном коде класса Primitive и функции fromYdb. 
Собственно, этот PR это исправляет