### PR TITLE
feat: implement prefer-local and prefer-locations balancing strategies

### DIFF
--- a/.changeset/rtt-based-balancing.md
+++ b/.changeset/rtt-based-balancing.md
@@ -1,0 +1,65 @@
+---
+'@ydbjs/core': minor
+---
+
+Add RTT-based local DC detection and location-aware client balancing
+
+**New Features:**
+
+- Add `createClientWithOptions()` method for location-aware client balancing
+- Add `ClientOptions` interface with `preferLocalDC`, `preferredLocations`, `preferNodeId`, and `allowFallback` options
+- Add automatic local DC detection via RTT measurement during discovery
+- Add driver options: `ydb.sdk.enable_local_dc_detection` and `ydb.sdk.local_dc_detection_timeout_ms`
+
+**New Modules:**
+
+- `rtt.ts` - TCP RTT measurement utilities (`measureTCPRTT`, `measureFastest`, `measureAll`)
+- `local-dc.ts` - Local DC detection algorithm with endpoint sampling
+
+**Usage:**
+
+```typescript
+// Enable automatic local DC detection during discovery
+let driver = new Driver('grpcs://ydb.example.com:2135/mydb', {
+  'ydb.sdk.enable_local_dc_detection': true,
+  'ydb.sdk.local_dc_detection_timeout_ms': 5000, // optional, default 5000ms
+})
+
+// Create client that prefers detected local DC
+let client = driver.createClientWithOptions(QueryService, {
+  preferLocalDC: true, // use auto-detected local DC
+  allowFallback: true, // fallback to other DCs if local unavailable
+})
+
+// Or prefer specific locations with strict filtering
+let client = driver.createClientWithOptions(QueryService, {
+  preferredLocations: ['VLA', 'SAS'],
+  allowFallback: false, // only use VLA or SAS, fail if unavailable
+})
+
+// Or prefer specific node by ID
+let client = driver.createClientWithOptions(QueryService, {
+  preferNodeId: 12345n,
+})
+
+// Combine options: prefer node in specific locations
+let client = driver.createClientWithOptions(QueryService, {
+  preferNodeId: 12345n,
+  preferredLocations: ['VLA'],
+  allowFallback: true,
+})
+```
+
+**Implementation Details:**
+
+- Local DC detection samples 5 random endpoints per location to reduce overhead
+- Uses `Promise.any()` to race TCP connections and find fastest location
+- Connection pool filters by location when `preferredLocations` or `preferLocalDC` specified
+- `preferredLocations` takes precedence over `preferLocalDC`
+- Round-robin balancing within filtered connection set
+- `allowFallback: false` ensures strict location filtering (no fallback to all endpoints)
+- `preferNodeId` works within filtered connection set
+
+**Backward Compatibility:**
+
+All existing APIs remain unchanged. The new `createClientWithOptions()` method and driver options are additive.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -61,6 +61,21 @@ await driver.ready()
 
 You can also use `AccessTokenCredentialsProvider`, `AnonymousCredentialsProvider`, or `MetadataCredentialsProvider` from `@ydbjs/auth`.
 
+### Location-Aware Balancing
+
+For multi-datacenter deployments, enable local DC detection and prefer specific locations:
+
+```ts
+let driver = new Driver('grpcs://ydb.example.com:2135/mydb', {
+  'ydb.sdk.enable_local_dc_detection': true,
+})
+
+let client = driver.createClientWithOptions(QueryServiceDefinition, {
+  preferLocalDC: true, // or preferredLocations: ['VLA', 'SAS']
+  allowFallback: true,
+})
+```
+
 ### Closing the Driver
 
 Always close the driver when done to release resources:

--- a/packages/core/src/conn.ts
+++ b/packages/core/src/conn.ts
@@ -12,6 +12,7 @@ let dbg = loggers.driver.extend('conn')
 export interface Connection {
 	readonly nodeId: bigint
 	readonly address: string
+	readonly endpoint: EndpointInfo
 	readonly channel: Channel
 	pessimizedUntil?: number
 
@@ -37,6 +38,10 @@ export class LazyConnection implements Connection {
 			'grpc.ssl_target_name_override': endpoint.sslTargetNameOverride,
 		}
 		this.#channelCredentials = channelCredentials
+	}
+
+	get endpoint(): EndpointInfo {
+		return this.#endpoint
 	}
 
 	get nodeId(): bigint {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,2 @@
 export * from './driver.js'
+export type { ClientOptions } from './pool.js'

--- a/packages/core/src/local-dc.ts
+++ b/packages/core/src/local-dc.ts
@@ -1,0 +1,128 @@
+import type { EndpointInfo } from '@ydbjs/api/discovery'
+import { loggers } from '@ydbjs/debug'
+import { measureFastest } from './rtt.js'
+
+let dbg = loggers.driver.extend('local-dc')
+
+const MAX_ENDPOINTS_PER_LOCATION = 5
+
+/**
+ * Group endpoints by location (DC)
+ */
+function groupByLocation(
+	endpoints: EndpointInfo[]
+): Map<string, EndpointInfo[]> {
+	let groups = new Map<string, EndpointInfo[]>()
+
+	for (let endpoint of endpoints) {
+		let location = endpoint.location
+		let group = groups.get(location) ?? []
+		group.push(endpoint)
+		groups.set(location, group)
+	}
+
+	return groups
+}
+
+/**
+ * Shuffle array in place
+ */
+function shuffle<T>(array: T[]): T[] {
+	for (let i = array.length - 1; i > 0; --i) {
+		let j = Math.floor(Math.random() * (i + 1))
+		let tmp = array[i]!
+		array[i] = array[j]!
+		array[j] = tmp
+	}
+	return array
+}
+
+/**
+ * Get random sample of endpoints
+ */
+function sampleEndpoints(
+	endpoints: EndpointInfo[],
+	count: number
+): EndpointInfo[] {
+	if (endpoints.length <= count) {
+		return endpoints
+	}
+
+	return shuffle([...endpoints]).slice(0, count)
+}
+
+/**
+ * Detect local DC by measuring RTT to endpoints
+ *
+ * Algorithm:
+ * 1. Group endpoints by location
+ * 2. If only 1 location → return it
+ * 3. Sample up to 5 endpoints per location
+ * 4. Race TCP connections to all sampled endpoints
+ * 5. Return location of fastest endpoint
+ *
+ * @param endpoints - List of YDB endpoints
+ * @param timeoutMs - Connection timeout in milliseconds
+ * @returns Promise with detected local DC location or null
+ *
+ * @example
+ * ```typescript
+ * let localDC = await detectLocalDC(endpoints, 5000)
+ * if (localDC) {
+ *     console.log(`Local DC: ${localDC}`)
+ * }
+ * ```
+ */
+export async function detectLocalDC(
+	endpoints: EndpointInfo[],
+	timeoutMs: number = 5000
+): Promise<string | null> {
+	if (endpoints.length === 0) {
+		dbg.log('no endpoints to detect local DC')
+		return null
+	}
+
+	let groups = groupByLocation(endpoints)
+
+	dbg.log(
+		'grouped endpoints by location: %O',
+		Array.from(groups.entries()).map(
+			([loc, eps]) => `${loc}: ${eps.length} endpoints`
+		)
+	)
+
+	if (groups.size === 1) {
+		let location = Array.from(groups.keys())[0]!
+		dbg.log('only one location found: %s', location)
+		return location
+	}
+
+	let sampled: EndpointInfo[] = []
+	for (let [location, locationEndpoints] of groups) {
+		let sample = sampleEndpoints(
+			locationEndpoints,
+			MAX_ENDPOINTS_PER_LOCATION
+		)
+		dbg.log('sampled %d endpoints from %s', sample.length, location)
+		sampled.push(...sample)
+	}
+
+	dbg.log('measuring RTT to %d endpoints', sampled.length)
+
+	try {
+		let fastest = await measureFastest(sampled, timeoutMs)
+		let localDC = fastest.location
+
+		dbg.log(
+			'detected local DC: %s (fastest endpoint: %s:%d)',
+			localDC,
+			fastest.address,
+			fastest.port
+		)
+
+		return localDC
+	} catch (error) {
+		dbg.log('failed to detect local DC: %O', error)
+		return null
+	}
+}

--- a/packages/core/src/rtt.ts
+++ b/packages/core/src/rtt.ts
@@ -1,0 +1,153 @@
+import { Socket } from 'node:net'
+import type { EndpointInfo } from '@ydbjs/api/discovery'
+import { loggers } from '@ydbjs/debug'
+
+let dbg = loggers.driver.extend('rtt')
+
+export interface RTTResult {
+	endpoint: EndpointInfo
+	rtt: number
+	error?: Error
+}
+
+/**
+ * Measure TCP connection time (RTT) to an endpoint
+ *
+ * @param endpoint - YDB endpoint to measure
+ * @param timeoutMs - Connection timeout in milliseconds
+ * @param signal - AbortSignal to cancel the measurement
+ * @returns Promise with RTT result
+ *
+ * @example
+ * ```typescript
+ * let result = await measureTCPRTT(endpoint, 5000)
+ * if (!result.error) {
+ *     console.log(`RTT: ${result.rtt}ms`)
+ * }
+ * ```
+ */
+export function measureTCPRTT(
+	endpoint: EndpointInfo,
+	timeoutMs: number = 5000,
+	signal?: AbortSignal
+): Promise<RTTResult> {
+	return new Promise((resolve) => {
+		let start = performance.now()
+		let socket = new Socket()
+
+		let done = (result: RTTResult) => {
+			signal?.removeEventListener('abort', onAbort)
+			socket.destroy()
+			resolve(result)
+		}
+
+		let onAbort = () => {
+			dbg.log(
+				'aborted connection to %s:%d',
+				endpoint.address,
+				endpoint.port
+			)
+			done({
+				endpoint,
+				rtt: Infinity,
+				error: new Error('Aborted'),
+			})
+		}
+
+		if (signal?.aborted) {
+			return onAbort()
+		}
+
+		socket.once('connect', () => {
+			let rtt = performance.now() - start
+			dbg.log(
+				'connected to %s:%d in %dms',
+				endpoint.address,
+				endpoint.port,
+				rtt.toFixed(2)
+			)
+			done({ endpoint, rtt })
+		})
+
+		socket.once('error', (err) => {
+			dbg.log(
+				'error connecting to %s:%d: %O',
+				endpoint.address,
+				endpoint.port,
+				err
+			)
+			done({ endpoint, rtt: Infinity, error: err as Error })
+		})
+
+		socket.setTimeout(timeoutMs)
+		socket.once('timeout', () => {
+			dbg.log(
+				'timeout connecting to %s:%d',
+				endpoint.address,
+				endpoint.port
+			)
+			done({
+				endpoint,
+				rtt: Infinity,
+				error: new Error('Connection timeout'),
+			})
+		})
+
+		signal?.addEventListener('abort', onAbort, { once: true })
+
+		dbg.log('measuring RTT to %s:%d', endpoint.address, endpoint.port)
+
+		socket.connect(endpoint.port, endpoint.address)
+	})
+}
+
+/**
+ * Race TCP connections to multiple endpoints and return the fastest
+ *
+ * @param endpoints - List of YDB endpoints to test
+ * @param timeoutMs - Connection timeout in milliseconds
+ * @returns Promise with the fastest endpoint
+ *
+ * @example
+ * ```typescript
+ * let fastest = await measureFastest(endpoints, 5000)
+ * console.log(`Fastest: ${fastest.address}:${fastest.port}`)
+ * ```
+ */
+export async function measureFastest(
+	endpoints: EndpointInfo[],
+	timeoutMs: number = 5000
+): Promise<EndpointInfo> {
+	if (endpoints.length === 0) {
+		throw new Error('No endpoints to measure')
+	}
+
+	dbg.log('racing %d endpoints', endpoints.length)
+
+	let controller = new AbortController()
+
+	let promises = endpoints.map(async (endpoint) => {
+		let result = await measureTCPRTT(endpoint, timeoutMs, controller.signal)
+
+		if (!result.error && result.rtt < Infinity) {
+			controller.abort()
+			return result
+		}
+
+		throw result.error || new Error('Failed to measure RTT')
+	})
+
+	try {
+		let fastest = await Promise.any(promises)
+		dbg.log(
+			'fastest endpoint: %s:%d (RTT: %dms)',
+			fastest.endpoint.address,
+			fastest.endpoint.port,
+			fastest.rtt.toFixed(2)
+		)
+		return fastest.endpoint
+	} catch (error) {
+		dbg.log('all endpoints failed: %O', error)
+		throw new Error('Failed to connect to any endpoint', { cause: error })
+	}
+}

--- a/packages/core/tests/local-dc.test.ts
+++ b/packages/core/tests/local-dc.test.ts
@@ -1,0 +1,56 @@
+import { create } from '@bufbuild/protobuf'
+import { EndpointInfoSchema } from '@ydbjs/api/discovery'
+import { expect, test } from 'vitest'
+import { detectLocalDC } from '../src/local-dc.js'
+
+test('returns single location when only one DC', async () => {
+	let endpoints = [
+		create(EndpointInfoSchema, {
+			address: 'ydb-1.vla.example.com',
+			port: 2135,
+			nodeId: 1,
+			location: 'VLA',
+		}),
+		create(EndpointInfoSchema, {
+			address: 'ydb-2.vla.example.com',
+			port: 2135,
+			nodeId: 2,
+			location: 'VLA',
+		}),
+	]
+
+	let localDC = await detectLocalDC(endpoints, 5000)
+	expect(localDC).toBe('VLA')
+})
+
+test('returns null when no endpoints', async () => {
+	let localDC = await detectLocalDC([], 5000)
+	expect(localDC).toBeNull()
+})
+
+test("returns null when couldn't compute rtt for any of the endpoints", async () => {
+	let endpoints = [
+		create(EndpointInfoSchema, {
+			address: 'ydb-1.vla.example.com',
+			port: 2135,
+			nodeId: 1,
+			location: 'VLA',
+		}),
+		create(EndpointInfoSchema, {
+			address: 'ydb-2.vla.example.com',
+			port: 2135,
+			nodeId: 2,
+			location: 'VLA',
+		}),
+		create(EndpointInfoSchema, {
+			address: 'ydb-1.sas.example.com',
+			port: 2135,
+			nodeId: 3,
+			location: 'SAS',
+		}),
+	]
+
+	let localDC = await detectLocalDC(endpoints, 0)
+
+	expect(localDC).toBeNull()
+})

--- a/packages/core/tests/pool.test.ts
+++ b/packages/core/tests/pool.test.ts
@@ -1,0 +1,229 @@
+import { create } from '@bufbuild/protobuf'
+import { credentials } from '@grpc/grpc-js'
+import { EndpointInfoSchema } from '@ydbjs/api/discovery'
+import { expect, test } from 'vitest'
+import { ConnectionPool } from '../src/pool.js'
+
+test('acquires connection with preferNodeId', () => {
+	let pool = new ConnectionPool(credentials.createInsecure())
+
+	let endpoint1 = create(EndpointInfoSchema, {
+		address: 'localhost',
+		port: 2135,
+		nodeId: 1,
+		location: 'VLA',
+	})
+
+	let endpoint2 = create(EndpointInfoSchema, {
+		address: 'localhost',
+		port: 2136,
+		nodeId: 2,
+		location: 'VLA',
+	})
+
+	pool.add(endpoint1)
+	pool.add(endpoint2)
+
+	let conn = pool.acquire(2n)
+	expect(conn.nodeId).toBe(2n)
+})
+
+test('acquires connection with round-robin', () => {
+	let pool = new ConnectionPool(credentials.createInsecure())
+
+	let endpoint1 = create(EndpointInfoSchema, {
+		address: 'localhost',
+		port: 2135,
+		nodeId: 1,
+		location: 'VLA',
+	})
+
+	let endpoint2 = create(EndpointInfoSchema, {
+		address: 'localhost',
+		port: 2136,
+		nodeId: 2,
+		location: 'VLA',
+	})
+
+	pool.add(endpoint1)
+	pool.add(endpoint2)
+
+	let conn1 = pool.acquire()
+	let conn2 = pool.acquire()
+	let conn3 = pool.acquire()
+
+	expect(conn1.nodeId).toBe(1n)
+	expect(conn2.nodeId).toBe(2n)
+	expect(conn3.nodeId).toBe(1n)
+})
+
+test('filters connections by preferredLocations', () => {
+	let pool = new ConnectionPool(credentials.createInsecure())
+
+	let endpointVLA = create(EndpointInfoSchema, {
+		address: 'localhost',
+		port: 2135,
+		nodeId: 1,
+		location: 'VLA',
+	})
+
+	let endpointSAS = create(EndpointInfoSchema, {
+		address: 'localhost',
+		port: 2136,
+		nodeId: 2,
+		location: 'SAS',
+	})
+
+	let endpointMAN = create(EndpointInfoSchema, {
+		address: 'localhost',
+		port: 2137,
+		nodeId: 3,
+		location: 'MAN',
+	})
+
+	pool.add(endpointVLA)
+	pool.add(endpointSAS)
+	pool.add(endpointMAN)
+
+	let conn = pool.acquireWithOptions({
+		preferredLocations: ['SAS', 'MAN'],
+	})
+
+	expect(['SAS', 'MAN']).toContain(conn.endpoint.location)
+})
+
+test('filters connections by preferLocalDC', () => {
+	let pool = new ConnectionPool(credentials.createInsecure())
+
+	let endpointVLA = create(EndpointInfoSchema, {
+		address: 'localhost',
+		port: 2135,
+		nodeId: 1,
+		location: 'VLA',
+	})
+
+	let endpointSAS = create(EndpointInfoSchema, {
+		address: 'localhost',
+		port: 2136,
+		nodeId: 2,
+		location: 'SAS',
+	})
+
+	pool.add(endpointVLA)
+	pool.add(endpointSAS)
+
+	pool.setLocalDC('VLA')
+
+	let conn = pool.acquireWithOptions({
+		preferLocalDC: true,
+	})
+
+	expect(conn.endpoint.location).toBe('VLA')
+})
+
+test('preferredLocations takes precedence over preferLocalDC', () => {
+	let pool = new ConnectionPool(credentials.createInsecure())
+
+	let endpointVLA = create(EndpointInfoSchema, {
+		address: 'localhost',
+		port: 2135,
+		nodeId: 1,
+		location: 'VLA',
+	})
+
+	let endpointSAS = create(EndpointInfoSchema, {
+		address: 'localhost',
+		port: 2136,
+		nodeId: 2,
+		location: 'SAS',
+	})
+
+	pool.add(endpointVLA)
+	pool.add(endpointSAS)
+
+	pool.setLocalDC('VLA')
+
+	let conn = pool.acquireWithOptions({
+		preferLocalDC: true,
+		preferredLocations: ['SAS'],
+	})
+
+	expect(conn.endpoint.location).toBe('SAS')
+})
+
+test('falls back to all connections when no preferred available', () => {
+	let pool = new ConnectionPool(credentials.createInsecure())
+
+	let endpointVLA = create(EndpointInfoSchema, {
+		address: 'localhost',
+		port: 2135,
+		nodeId: 1,
+		location: 'VLA',
+	})
+
+	pool.add(endpointVLA)
+
+	let conn = pool.acquireWithOptions({
+		preferredLocations: ['SAS'],
+		allowFallback: true,
+	})
+
+	expect(conn.endpoint.location).toBe('VLA')
+})
+
+test('throws error when no preferred available and fallback disabled', () => {
+	let pool = new ConnectionPool(credentials.createInsecure())
+
+	let endpointVLA = create(EndpointInfoSchema, {
+		address: 'localhost',
+		port: 2135,
+		nodeId: 1,
+		location: 'VLA',
+	})
+
+	pool.add(endpointVLA)
+
+	expect(() => {
+		pool.acquireWithOptions({
+			preferredLocations: ['SAS'],
+			allowFallback: false,
+		})
+	}).toThrow('No connections matching client options')
+})
+
+test('combines preferNodeId with location filtering', () => {
+	let pool = new ConnectionPool(credentials.createInsecure())
+
+	let endpointVLA1 = create(EndpointInfoSchema, {
+		address: 'localhost',
+		port: 2135,
+		nodeId: 1,
+		location: 'VLA',
+	})
+
+	let endpointVLA2 = create(EndpointInfoSchema, {
+		address: 'localhost',
+		port: 2136,
+		nodeId: 2,
+		location: 'VLA',
+	})
+
+	let endpointSAS = create(EndpointInfoSchema, {
+		address: 'localhost',
+		port: 2137,
+		nodeId: 3,
+		location: 'SAS',
+	})
+
+	pool.add(endpointVLA1)
+	pool.add(endpointVLA2)
+	pool.add(endpointSAS)
+
+	let conn = pool.acquireWithOptions({
+		preferredLocations: ['VLA'],
+		preferNodeId: 2n,
+	})
+
+	expect(conn.nodeId).toBe(2n)
+	expect(conn.endpoint.location).toBe('VLA')
+})


### PR DESCRIPTION
## What

Add RTT-based local DC detection and location-aware client balancing to `@ydbjs/core`

## Why

Multi-datacenter YDB deployments benefit from routing requests to the nearest datacenter to reduce latency. This PR adds automatic local DC detection via RTT measurement and provides flexible client balancing options to prefer specific locations or nodes.

## Changes

- Add `createClientWithOptions()` method to [`Driver`](packages/core/src/driver.ts:555) for advanced client balancing
- Add [`ClientOptions`](packages/core/src/pool.ts:10) interface with `preferLocalDC`, `preferredLocations`, `preferNodeId`, and `allowFallback` options
- Add driver options: `ydb.sdk.enable_local_dc_detection` and `ydb.sdk.local_dc_detection_timeout_ms`
- Implement [`rtt.ts`](packages/core/src/rtt.ts:1) module with TCP RTT measurement utilities (`measureTCPRTT`, `measureFastest`)
- Implement [`local-dc.ts`](packages/core/src/local-dc.ts:1) module with local DC detection algorithm (samples 5 random endpoints per location, uses `Promise.any()` to race connections)
- Add [`ConnectionPool#acquireWithOptions()`](packages/core/src/pool.ts:80) method for location-aware connection selection
- Add comprehensive unit tests: [`pool.test.ts`](packages/core/tests/pool.test.ts:1) (8 tests), [`local-dc.test.ts`](packages/core/tests/local-dc.test.ts:1) (3 tests)

**No breaking changes** - all existing APIs remain unchanged, new functionality is additive.

## Testing

**Unit tests added:**
- [`packages/core/tests/pool.test.ts`](packages/core/tests/pool.test.ts:1) - 8 tests covering connection pool balancing logic (preferNodeId, round-robin, location filtering, fallback behavior, error cases)
- [`packages/core/tests/local-dc.test.ts`](packages/core/tests/local-dc.test.ts:1) - 3 tests covering local DC detection (single DC, no endpoints, timeout)

## Checklist

- [x] Changeset added (if package changes)
- [x] README updated (if public API changed)
