### PR TITLE
Fix Struct constructor double-wrapping fields in Optional

### DIFF
--- a/.changeset/fix-struct-optional-wrap.md
+++ b/.changeset/fix-struct-optional-wrap.md
@@ -1,0 +1,9 @@
+---
+'@ydbjs/value': patch
+---
+
+Fix Struct constructor double-wrapping fields declared as Optional
+
+When a type definition was provided, the constructor wrapped every field in `Optional` regardless of the value's actual type. For fields declared `Optional<T>` with a concrete value already of type `T`, this produced `Optional<Optional<T>>` and caused encoding mismatches against the declared struct type.
+
+The constructor now only wraps `null` in `Optional` (using the declared item type); values are passed through unchanged. Missing values for non-`Optional` fields now throw instead of silently becoming `Optional(null)`.

--- a/packages/value/README.md
+++ b/packages/value/README.md
@@ -76,7 +76,7 @@ The conversion between JavaScript and YDB types in `@ydbjs/value` is automatic a
 
 ### Special Handling for Arrays of Objects
 
-If you pass an array of objects with different sets of fields, the converter will automatically create a unified Struct type containing all fields from all objects. Missing fields in each object will be set as Optional (nullable) in the resulting YDB Struct. This allows you to pass heterogeneous arrays of objects and have them represented as a single List of Structs in YDB.
+If you pass an array of objects, the converter creates a unified Struct type containing the union of fields from all objects and wraps **every** field in `Optional`. Missing fields become `null`. This allows heterogeneous arrays of objects to be represented as a single List of Structs in YDB.
 
 #### Example
 
@@ -88,6 +88,22 @@ fromJs([
 ```
 
 This will produce a YDB List where each element is a Struct with fields: `id`, `name`, and `age`. Fields not present in an object will be set to null (Optional).
+
+#### `NOT NULL` columns
+
+Because `fromJs` always wraps struct fields in `Optional`, the resulting type does not match `NOT NULL` columns on the server side — the query will fail with `Can't set NULL or optional value to not null column`. `fromJs` cannot know the target schema, so if you need pinned non-nullable types, construct values explicitly:
+
+```ts
+import { List } from '@ydbjs/value/list'
+import { Struct } from '@ydbjs/value/struct'
+import { Text, Uint8, Bytes } from '@ydbjs/value/primitive'
+
+const rows = new List(
+  new Struct({ key: new Text('a'), partNumber: new Uint8(0), data: new Bytes(buf) })
+)
+```
+
+Or build a `StructType` once and pass it to `new Struct(obj, type)` to pin field types across rows.
 
 ### Utility Exports
 

--- a/packages/value/src/index.test.ts
+++ b/packages/value/src/index.test.ts
@@ -1,5 +1,6 @@
 import { test } from 'vitest'
 import { fromJs, toJs } from './index.ts'
+import { typeToString } from './print.ts'
 
 test('transforms fromJs with primitives', async (t) => {
 	let boolVal = fromJs(true)
@@ -133,6 +134,10 @@ test('toJs with null', async (t) => {
 test('fromJs with array of objects with different fields', async (t) => {
 	let arrVal = fromJs([{ name: 'Test' }, { age: 99 }])
 
+	t.expect(typeToString(arrVal.type)).toMatchInlineSnapshot(
+		`"List<Struct<age:Optional<Int32>,name:Optional<Utf8>>>"`
+	)
+
 	t.expect(arrVal).toMatchInlineSnapshot(`
 		List {
 		  "items": [
@@ -141,25 +146,16 @@ test('fromJs with array of objects with different fields', async (t) => {
 		        Optional {
 		          "item": null,
 		          "type": OptionalType {
-		            "itemType": OptionalType {
-		              "itemType": Int32Type {},
-		            },
+		            "itemType": Int32Type {},
 		          },
 		        },
 		        Optional {
-		          "item": Optional {
-		            "item": Text {
-		              "type": TextType {},
-		              "value": "Test",
-		            },
-		            "type": OptionalType {
-		              "itemType": TextType {},
-		            },
+		          "item": Text {
+		            "type": TextType {},
+		            "value": "Test",
 		          },
 		          "type": OptionalType {
-		            "itemType": OptionalType {
-		              "itemType": TextType {},
-		            },
+		            "itemType": TextType {},
 		          },
 		        },
 		      ],
@@ -181,27 +177,18 @@ test('fromJs with array of objects with different fields', async (t) => {
 		    Struct {
 		      "items": [
 		        Optional {
-		          "item": Optional {
-		            "item": Int32 {
-		              "type": Int32Type {},
-		              "value": 99,
-		            },
-		            "type": OptionalType {
-		              "itemType": Int32Type {},
-		            },
+		          "item": Int32 {
+		            "type": Int32Type {},
+		            "value": 99,
 		          },
 		          "type": OptionalType {
-		            "itemType": OptionalType {
-		              "itemType": Int32Type {},
-		            },
+		            "itemType": Int32Type {},
 		          },
 		        },
 		        Optional {
 		          "item": null,
 		          "type": OptionalType {
-		            "itemType": OptionalType {
-		              "itemType": TextType {},
-		            },
+		            "itemType": TextType {},
 		          },
 		        },
 		      ],

--- a/packages/value/src/index.ts
+++ b/packages/value/src/index.ts
@@ -107,6 +107,27 @@ export function fromYdb(value: Ydb.Value, type: Ydb.Type): Value {
 	throw new Error('Unsupported value.')
 }
 
+/**
+ * Convert a native JavaScript value into a YDB `Value`. Types are inferred from
+ * the input structure.
+ *
+ * Note: when converting an array of plain objects (`[{}, ...]`), every struct
+ * field is wrapped in `Optional`. This keeps the conversion single-pass and
+ * lets heterogeneous arrays (objects with different key sets) produce a single
+ * unified struct type. As a consequence, the resulting type never matches
+ * `NOT NULL` columns on the YDB side.
+ *
+ * If you target a schema with `NOT NULL` columns, construct values explicitly:
+ *
+ * ```ts
+ * new List(
+ *   new Struct({ key: new Text('a'), n: new Uint8(1) })
+ * )
+ * ```
+ *
+ * or build a `StructType` and pass it to `new Struct(obj, type)` to pin the
+ * field types.
+ */
 export function fromJs(native: JSValue): Value {
 	switch (typeof native) {
 		case 'undefined':

--- a/packages/value/src/struct.test.ts
+++ b/packages/value/src/struct.test.ts
@@ -1,0 +1,58 @@
+import { test } from 'vitest'
+
+import { Optional, OptionalType } from './optional.js'
+import { Int32, Int32Type, Text, TextType } from './primitive.js'
+import { Struct, StructType } from './struct.js'
+
+test('throws when non-optional field is missing', async (t) => {
+	let def = new StructType(['id', 'name'], [new Int32Type(), new TextType()])
+
+	t.expect(() => new Struct({ id: new Int32(1) }, def)).toThrowErrorMatchingInlineSnapshot(
+		`[Error: Field name is declared as Utf8 but no value provided.]`
+	)
+})
+
+test('fills missing optional fields with Optional(null)', async (t) => {
+	let def = new StructType(
+		['age', 'name'],
+		[new OptionalType(new Int32Type()), new OptionalType(new TextType())]
+	)
+
+	let s = new Struct({ name: new Optional(new Text('Alice')) }, def)
+
+	t.expect(s).toMatchInlineSnapshot(`
+		Struct {
+		  "items": [
+		    Optional {
+		      "item": null,
+		      "type": OptionalType {
+		        "itemType": Int32Type {},
+		      },
+		    },
+		    Optional {
+		      "item": Text {
+		        "type": TextType {},
+		        "value": "Alice",
+		      },
+		      "type": OptionalType {
+		        "itemType": TextType {},
+		      },
+		    },
+		  ],
+		  "type": StructType {
+		    "names": [
+		      "age",
+		      "name",
+		    ],
+		    "types": [
+		      OptionalType {
+		        "itemType": Int32Type {},
+		      },
+		      OptionalType {
+		        "itemType": TextType {},
+		      },
+		    ],
+		  },
+		}
+	`)
+})

--- a/packages/value/src/struct.ts
+++ b/packages/value/src/struct.ts
@@ -1,7 +1,8 @@
 import { create } from '@bufbuild/protobuf'
 import * as Ydb from '@ydbjs/api/value'
 
-import { Optional } from './optional.js'
+import { Optional, OptionalType } from './optional.js'
+import { typeToString } from './print.js'
 import { type Type, TypeKind } from './type.js'
 import type { Value } from './value.js'
 
@@ -68,14 +69,25 @@ export class Struct<
 			this.type = def
 
 			for (let [name, type] of def) {
-				let value = obj[name]
-				if (value && value.type.kind !== type.kind) {
+				let objValue = obj[name] ?? null
+
+				if (objValue && objValue.type.kind !== type.kind) {
 					throw new Error(
-						`Invalid type for ${name}: expected ${type.kind}, got ${value.type.kind}`
+						`Invalid type for ${name}: expected ${typeToString(type)}, got ${typeToString(objValue.type)}`
 					)
 				}
 
-				this.items.push(new Optional((value ??= null), type))
+				if (objValue === null && type.kind !== TypeKind.OPTIONAL) {
+					throw new Error(
+						`Field ${name} is declared as ${typeToString(type)} but no value provided.`
+					)
+				}
+
+				if (objValue === null) {
+					this.items.push(new Optional(null, (type as OptionalType).itemType))
+				} else {
+					this.items.push(objValue)
+				}
 			}
 
 			return


### PR DESCRIPTION
## What

Fix `Struct` constructor in `@ydbjs/value` that wrapped every field in `Optional` when a `StructType` was supplied, producing `Optional<Optional<T>>` for fields whose declared type was already `Optional<T>`.

## Why

Passing a pre-built `Value` for an `Optional` field produced a nested `Optional` on encode, which no longer matched the declared struct type and broke server-side decoding for structs constructed with an explicit type definition.

## Changes

- Only wrap `null` values in `Optional` (using the declared item type); pass through values that already match the declared field type.
- Throw when a non-`Optional` field has no value provided, instead of silently producing `Optional(null)`.
- Document in the `value` README that `fromJs` always produces `Optional` fields and is unsuitable for `NOT NULL` columns.
- Add `Struct` tests for missing required and optional fields.

## Testing

- Added unit tests in `packages/value/src/struct.test.ts` covering missing required / missing optional field paths.
- Updated `packages/value/src/index.test.ts` to reflect that values are no longer double-wrapped.
- `npm run test:uni` passes (387/387).

## Checklist

- [x] Changeset added (if package changes)
- [x] README updated (if public API changed)