### PR TITLE
A: publish-points

### DIFF
--- a/packages/auth/src/metadata.ts
+++ b/packages/auth/src/metadata.ts
@@ -5,7 +5,7 @@ import { type RetryConfig, retry } from '@ydbjs/retry'
 import { backoff } from '@ydbjs/retry/strategy'
 import { CredentialsProvider } from './index.js'
 
-const authTokenFetchCh = tracingChannel('tracing:ydb:auth.token.fetch')
+let authTokenFetchCh = tracingChannel('tracing:ydb:auth.token.fetch')
 
 let dbg = loggers.auth.extend('metadata')
 

--- a/packages/auth/src/metadata.ts
+++ b/packages/auth/src/metadata.ts
@@ -1,7 +1,11 @@
+import { channel as dcChannel, tracingChannel } from 'node:diagnostics_channel'
+
 import { loggers } from '@ydbjs/debug'
 import { type RetryConfig, retry } from '@ydbjs/retry'
 import { backoff } from '@ydbjs/retry/strategy'
 import { CredentialsProvider } from './index.js'
+
+const authTokenFetchCh = tracingChannel('tracing:ydb:auth.token.fetch')
 
 let dbg = loggers.auth.extend('metadata')
 
@@ -72,6 +76,10 @@ export class MetadataCredentialsProvider extends CredentialsProvider {
 			return this.#token.value
 		}
 
+		if (this.#token && this.#token.expired_at <= Date.now()) {
+			dcChannel('ydb:auth.token.expired').publish({ provider: 'metadata' })
+		}
+
 		if (this.#promise) {
 			dbg.log('token fetch already in progress, waiting for result')
 			return this.#promise
@@ -89,50 +97,57 @@ export class MetadataCredentialsProvider extends CredentialsProvider {
 			},
 		}
 
-		this.#promise = retry(retryConfig, async (signal) => {
-			dbg.log('attempting to fetch token from %s', this.#endpoint)
-			let response = await fetch(this.#endpoint, {
-				headers: {
-					'Metadata-Flavor': this.#flavor,
-				},
-				signal,
+		this.#promise = authTokenFetchCh
+			.tracePromise(() => retry(retryConfig, (s) => this.#fetchTokenAttempt(s)), {
+				provider: 'metadata',
+			})
+			.catch((err) => {
+				dcChannel('ydb:auth.provider.failed').publish({ provider: 'metadata' })
+				throw err
+			})
+			.finally(() => {
+				this.#promise = null
 			})
 
-			dbg.log(
-				'%s %s %s',
-				this.#endpoint,
-				response.status,
-				response.headers.get('Content-Type')
-			)
+		return this.#promise
+	}
 
-			if (!response.ok) {
-				let error = new Error(
-					`Failed to fetch token: ${response.status} ${response.statusText}`
-				)
-				dbg.log('error fetching token: %O', error)
-				throw error
-			}
-
-			let token = JSON.parse(await response.text()) as {
-				access_token?: string
-				expires_in?: number
-			}
-			if (!token.access_token) {
-				dbg.log('missing access token in response, response: %O', token)
-				throw new Error('No access token exists in response')
-			}
-
-			this.#token = {
-				value: token.access_token,
-				expired_at: Date.now() + (token.expires_in ?? 3600) * 1000,
-			}
-
-			dbg.log('token fetched successfully, expires in %d seconds', token.expires_in ?? 3600)
-			return this.#token.value
-		}).finally(() => {
-			this.#promise = null
+	async #fetchTokenAttempt(signal: AbortSignal): Promise<string> {
+		dbg.log('attempting to fetch token from %s', this.#endpoint)
+		let response = await fetch(this.#endpoint, {
+			headers: { 'Metadata-Flavor': this.#flavor },
+			signal,
 		})
 
-		return this.#promise
+		dbg.log('%s %s %s', this.#endpoint, response.status, response.headers.get('Content-Type'))
+
+		if (!response.ok) {
+			let error = new Error(
+				`Failed to fetch token: ${response.status} ${response.statusText}`
+			)
+			dbg.log('error fetching token: %O', error)
+			throw error
+		}
+
+		let token = JSON.parse(await response.text()) as {
+			access_token?: string
+			expires_in?: number
+		}
+		if (!token.access_token) {
+			dbg.log('missing access token in response, response: %O', token)
+			throw new Error('No access token exists in response')
+		}
+
+		this.#token = {
+			value: token.access_token,
+			expired_at: Date.now() + (token.expires_in ?? 3600) * 1000,
+		}
+
+		dbg.log('token fetched successfully, expires in %d seconds', token.expires_in ?? 3600)
+		dcChannel('ydb:auth.token.refreshed').publish({
+			provider: 'metadata',
+			expiresIn: token.expires_in ?? 3600,
+		})
+		return this.#token.value
 	}
 }

--- a/packages/auth/src/static.ts
+++ b/packages/auth/src/static.ts
@@ -18,10 +18,10 @@ let debug = loggers.auth.extend('static')
 let authTokenFetchCh = tracingChannel('tracing:ydb:auth.token.fetch')
 
 // Token refresh strategy configuration
-let ACQUIRE_TOKEN_TIMEOUT_MS = 5_000 // 5 seconds timeout for token acquisition
-let HARD_EXPIRY_BUFFER_SECONDS = 30 // Hard limit - must refresh
-let SOFT_EXPIRY_BUFFER_SECONDS = 120 // Soft limit - start background refresh
-let BACKGROUND_REFRESH_TIMEOUT_MS = 30_000 // 30 seconds timeout for background refresh
+const ACQUIRE_TOKEN_TIMEOUT_MS = 5_000 // 5 seconds timeout for token acquisition
+const HARD_EXPIRY_BUFFER_SECONDS = 30 // Hard limit - must refresh
+const SOFT_EXPIRY_BUFFER_SECONDS = 120 // Soft limit - start background refresh
+const BACKGROUND_REFRESH_TIMEOUT_MS = 30_000 // 30 seconds timeout for background refresh
 
 export type StaticCredentialsToken = {
 	value: string

--- a/packages/auth/src/static.ts
+++ b/packages/auth/src/static.ts
@@ -1,4 +1,5 @@
 import * as tls from 'node:tls'
+import { channel as dcChannel, tracingChannel } from 'node:diagnostics_channel'
 
 import { anyUnpack } from '@bufbuild/protobuf/wkt'
 import { type ChannelOptions, credentials } from '@grpc/grpc-js'
@@ -13,6 +14,8 @@ import { CredentialsProvider } from './index.js'
 import { linkSignals } from '@ydbjs/abortable'
 
 let debug = loggers.auth.extend('static')
+
+const authTokenFetchCh = tracingChannel('tracing:ydb:auth.token.fetch')
 
 // Token refresh strategy configuration
 const ACQUIRE_TOKEN_TIMEOUT_MS = 5_000 // 5 seconds timeout for token acquisition
@@ -131,6 +134,10 @@ export class StaticCredentialsProvider extends CredentialsProvider {
 			return this.#promise
 		}
 
+		if (this.#token && this.#token.exp <= currentTimeSeconds + HARD_EXPIRY_BUFFER_SECONDS) {
+			dcChannel('ydb:auth.token.expired').publish({ provider: 'static' })
+		}
+
 		debug.log(
 			'fetching new token (force=%s, expired=%s)',
 			force,
@@ -161,81 +168,90 @@ export class StaticCredentialsProvider extends CredentialsProvider {
 	 * @returns the new token value
 	 */
 	async #refreshToken(signal: AbortSignal): Promise<string> {
-		this.#promise = retry(
-			{
-				...defaultRetryConfig,
-				signal,
-				idempotent: true,
-				onRetry: (ctx) => {
-					debug.log('retry attempt #%d after error: %s', ctx.attempt, ctx.error)
-				},
+		let retryConfig = {
+			...defaultRetryConfig,
+			signal,
+			idempotent: true,
+			onRetry: (ctx: { attempt: number; error: unknown }) => {
+				debug.log('retry attempt #%d after error: %s', ctx.attempt, ctx.error)
 			},
-			async (signal) => {
-				debug.log('attempting login with user: %s', this.#username)
+		}
 
-				let response = await this.#client.login(
-					{ user: this.#username, password: this.#password },
-					{ signal }
-				)
-				if (!response.operation) {
-					throw new ClientError(
-						AuthServiceDefinition.login.path,
-						Status.UNKNOWN,
-						'No operation in response'
-					)
-				}
-
-				if (response.operation.status !== StatusIds_StatusCode.SUCCESS) {
-					throw new YDBError(response.operation.status, response.operation.issues)
-				}
-
-				let result = anyUnpack(response.operation.result!, LoginResultSchema)
-				if (!result) {
-					throw new ClientError(
-						AuthServiceDefinition.login.path,
-						Status.UNKNOWN,
-						'No result in operation'
-					)
-				}
-
-				debug.log('login successful, parsing JWT token')
-
-				// The result.token is a JWT in the format header.payload.signature.
-				// We attempt to decode the payload to extract token metadata (aud, exp, iat, sub).
-				// If the token is not in the expected format, we fallback to default values.
-				let [header, payload, signature] = result.token.split('.')
-				if (header && payload && signature) {
-					let decodedPayload = JSON.parse(Buffer.from(payload, 'base64').toString())
-
-					this.#token = {
-						value: result.token,
-						...decodedPayload,
-					}
-					debug.log(
-						'token parsed successfully, expires at %s',
-						new Date(decodedPayload.exp * 1000).toISOString()
-					)
-				} else {
-					debug.log('token not in JWT format, using fallback metadata')
-					this.#token = {
-						value: result.token,
-						aud: [],
-						exp: Math.floor(Date.now() / 1000) + 5 * 60, // fallback: 5 minutes from now
-						iat: Math.floor(Date.now() / 1000),
-						sub: '',
-					}
-					debug.log(
-						'token created with fallback expiry: %s',
-						new Date(this.#token.exp * 1000).toISOString()
-					)
-				}
-
-				return this.#token!.value!
-			}
-		).finally(() => {
-			this.#promise = undefined
-		})
+		this.#promise = authTokenFetchCh
+			.tracePromise(() => retry(retryConfig, (s) => this.#loginAttempt(s)), {
+				provider: 'static',
+			})
+			.catch((err) => {
+				dcChannel('ydb:auth.provider.failed').publish({ provider: 'static' })
+				throw err
+			})
+			.finally(() => {
+				this.#promise = undefined
+			})
 
 		return this.#promise
+	}
+
+	async #loginAttempt(signal: AbortSignal): Promise<string> {
+		debug.log('attempting login with user: %s', this.#username)
+
+		let response = await this.#client.login(
+			{ user: this.#username, password: this.#password },
+			{ signal }
+		)
+		if (!response.operation) {
+			throw new ClientError(
+				AuthServiceDefinition.login.path,
+				Status.UNKNOWN,
+				'No operation in response'
+			)
+		}
+
+		if (response.operation.status !== StatusIds_StatusCode.SUCCESS) {
+			throw new YDBError(response.operation.status, response.operation.issues)
+		}
+
+		let result = anyUnpack(response.operation.result!, LoginResultSchema)
+		if (!result) {
+			throw new ClientError(
+				AuthServiceDefinition.login.path,
+				Status.UNKNOWN,
+				'No result in operation'
+			)
+		}
+
+		debug.log('login successful, parsing JWT token')
+
+		// The result.token is a JWT in the format header.payload.signature.
+		// We attempt to decode the payload to extract token metadata (aud, exp, iat, sub).
+		// If the token is not in the expected format, we fallback to default values.
+		let [header, payload, signature] = result.token.split('.')
+		if (header && payload && signature) {
+			let decodedPayload = JSON.parse(Buffer.from(payload, 'base64').toString())
+			this.#token = { value: result.token, ...decodedPayload }
+			debug.log(
+				'token parsed successfully, expires at %s',
+				new Date(decodedPayload.exp * 1000).toISOString()
+			)
+		} else {
+			debug.log('token not in JWT format, using fallback metadata')
+			this.#token = {
+				value: result.token,
+				aud: [],
+				exp: Math.floor(Date.now() / 1000) + 5 * 60, // fallback: 5 minutes from now
+				iat: Math.floor(Date.now() / 1000),
+				sub: '',
+			}
+			debug.log(
+				'token created with fallback expiry: %s',
+				new Date(this.#token.exp * 1000).toISOString()
+			)
+		}
+
+		dcChannel('ydb:auth.token.refreshed').publish({
+			provider: 'static',
+			expiresIn: this.#token!.exp - Math.floor(Date.now() / 1000),
+		})
+		return this.#token!.value!
 	}
 }

--- a/packages/auth/src/static.ts
+++ b/packages/auth/src/static.ts
@@ -8,20 +8,20 @@ import { StatusIds_StatusCode } from '@ydbjs/api/operation'
 import { loggers } from '@ydbjs/debug'
 import { YDBError } from '@ydbjs/error'
 import { defaultRetryConfig, retry } from '@ydbjs/retry'
+import { linkSignals } from '@ydbjs/abortable'
 import { type Client, ClientError, Status, createChannel, createClient } from 'nice-grpc'
 
 import { CredentialsProvider } from './index.js'
-import { linkSignals } from '@ydbjs/abortable'
 
 let debug = loggers.auth.extend('static')
 
-const authTokenFetchCh = tracingChannel('tracing:ydb:auth.token.fetch')
+let authTokenFetchCh = tracingChannel('tracing:ydb:auth.token.fetch')
 
-// Token refresh strategy configuration
-const ACQUIRE_TOKEN_TIMEOUT_MS = 5_000 // 5 seconds timeout for token acquisition
-const HARD_EXPIRY_BUFFER_SECONDS = 30 // Hard limit - must refresh
-const SOFT_EXPIRY_BUFFER_SECONDS = 120 // Soft limit - start background refresh
-const BACKGROUND_REFRESH_TIMEOUT_MS = 30_000 // 30 seconds timeout for background refresh
+// Timeouts sized to typical token-service SLAs and JWT expiry windows
+let ACQUIRE_TOKEN_TIMEOUT_MS = 5_000
+let HARD_EXPIRY_BUFFER_SECONDS = 30
+let SOFT_EXPIRY_BUFFER_SECONDS = 120
+let BACKGROUND_REFRESH_TIMEOUT_MS = 30_000
 
 export type StaticCredentialsToken = {
 	value: string

--- a/packages/auth/src/static.ts
+++ b/packages/auth/src/static.ts
@@ -17,11 +17,11 @@ let debug = loggers.auth.extend('static')
 
 let authTokenFetchCh = tracingChannel('tracing:ydb:auth.token.fetch')
 
-// Timeouts sized to typical token-service SLAs and JWT expiry windows
-let ACQUIRE_TOKEN_TIMEOUT_MS = 5_000
-let HARD_EXPIRY_BUFFER_SECONDS = 30
-let SOFT_EXPIRY_BUFFER_SECONDS = 120
-let BACKGROUND_REFRESH_TIMEOUT_MS = 30_000
+// Token refresh strategy configuration
+let ACQUIRE_TOKEN_TIMEOUT_MS = 5_000 // 5 seconds timeout for token acquisition
+let HARD_EXPIRY_BUFFER_SECONDS = 30 // Hard limit - must refresh
+let SOFT_EXPIRY_BUFFER_SECONDS = 120 // Soft limit - start background refresh
+let BACKGROUND_REFRESH_TIMEOUT_MS = 30_000 // 30 seconds timeout for background refresh
 
 export type StaticCredentialsToken = {
 	value: string

--- a/packages/core/src/diagnostics.test.ts
+++ b/packages/core/src/diagnostics.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from 'vitest'
+import { channel as dcChannel } from 'node:diagnostics_channel'
+import { credentials } from '@grpc/grpc-js'
+
+import { ConnectionPool, POOL_GET_ACTIVE_FOR_TESTING } from './pool.js'
+
+function makeProtoEndpoint(nodeId: number, port = 2136) {
+	return {
+		nodeId,
+		address: `node-${nodeId}`,
+		port,
+		location: 'dc1',
+		sslTargetNameOverride: '',
+	} as any
+}
+
+function makePool() {
+	return new ConnectionPool({
+		channelCredentials: credentials.createInsecure(),
+		idleTimeout: 0,
+		idleInterval: 0,
+		pessimizationTimeout: 60_000,
+	})
+}
+
+/** Subscribe to a plain channel and collect published payloads. */
+function collect(name: string) {
+	let payloads: unknown[] = []
+	let fn = (msg: unknown) => payloads.push(structuredClone(msg))
+	dcChannel(name).subscribe(fn)
+	return { payloads, stop: () => dcChannel(name).unsubscribe(fn) }
+}
+
+test('ydb:pool.connection.added — fires with nodeId, address, location when endpoint is synced in', () => {
+	let pool = makePool()
+	let { payloads, stop } = collect('ydb:pool.connection.added')
+	try {
+		pool.sync([makeProtoEndpoint(1)])
+
+		expect(payloads).toHaveLength(1)
+		expect(payloads[0]).toMatchObject({
+			nodeId: 1n,
+			address: 'node-1:2136',
+			location: 'dc1',
+		})
+	} finally {
+		stop()
+		pool.close()
+	}
+})
+
+test('ydb:pool.connection.removed — fires when a previously active endpoint disappears from discovery', () => {
+	let pool = makePool()
+	pool.sync([makeProtoEndpoint(1)])
+
+	let { payloads, stop } = collect('ydb:pool.connection.removed')
+	try {
+		pool.sync([]) // node 1 is no longer in discovery
+
+		expect(payloads).toHaveLength(1)
+		expect(payloads[0]).toMatchObject({
+			nodeId: 1n,
+			reason: 'discovery.stale_active',
+		})
+	} finally {
+		stop()
+		pool.close()
+	}
+})
+
+test('ydb:pool.pessimize — fires with nodeId and address when a connection is pessimized', () => {
+	let pool = makePool()
+	pool.sync([makeProtoEndpoint(2)])
+	let [conn] = pool[POOL_GET_ACTIVE_FOR_TESTING]()
+
+	let { payloads, stop } = collect('ydb:pool.pessimize')
+	try {
+		pool.pessimize(conn!)
+
+		expect(payloads).toHaveLength(1)
+		expect(payloads[0]).toMatchObject({
+			nodeId: 2n,
+			address: 'node-2:2136',
+		})
+	} finally {
+		stop()
+		pool.close()
+	}
+})
+
+test('ydb:pool.connection.removed — fires for a pessimized endpoint removed by discovery', () => {
+	let pool = makePool()
+	pool.sync([makeProtoEndpoint(3)])
+	let [conn] = pool[POOL_GET_ACTIVE_FOR_TESTING]()
+	pool.pessimize(conn!) // move node 3 to pessimized map
+
+	let { payloads, stop } = collect('ydb:pool.connection.removed')
+	try {
+		pool.sync([]) // node 3 is pessimized and now stale
+
+		expect(payloads).toHaveLength(1)
+		expect(payloads[0]).toMatchObject({
+			nodeId: 3n,
+			reason: 'discovery.stale_pessimized',
+		})
+	} finally {
+		stop()
+		pool.close()
+	}
+})

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -1,6 +1,6 @@
 import * as tls from 'node:tls'
 import * as assert from 'node:assert/strict'
-import { channel as dcChannel } from 'node:diagnostics_channel'
+import { channel as dcChannel, tracingChannel } from 'node:diagnostics_channel'
 
 import { create } from '@bufbuild/protobuf'
 import { anyUnpack } from '@bufbuild/protobuf/wkt'
@@ -43,6 +43,10 @@ import type { DriverHooks, EndpointInfo } from './hooks.js'
 import { debug } from './middleware.js'
 import { ConnectionPool } from './pool.js'
 import { detectRuntime } from './runtime.js'
+
+const discoveryCh = tracingChannel('tracing:ydb:discovery')
+const retryRunCh = tracingChannel('tracing:ydb:retry.run')
+const retryAttemptCh = tracingChannel('tracing:ydb:retry.attempt')
 
 export type { DriverHooks, EndpointInfo }
 
@@ -218,6 +222,7 @@ export class Driver implements Disposable {
 		if (this.options['ydb.sdk.enable_discovery'] === false) {
 			dbg.log('discovery disabled, using single endpoint')
 			this.#ready.resolve()
+			dcChannel('ydb:driver.ready').publish({ database: this.database })
 		}
 
 		if (this.options['ydb.sdk.enable_discovery'] === true) {
@@ -227,7 +232,8 @@ export class Driver implements Disposable {
 			this.#discovery(AbortSignal.timeout(discoveryTimeout))
 				.then(() => {
 					dbg.log('initial discovery completed successfully')
-					return this.#ready.resolve()
+					this.#ready.resolve()
+					dcChannel('ydb:driver.ready').publish({ database: this.database })
 				})
 				.catch((error) => {
 					dbg.log('initial discovery failed: %O', error)
@@ -292,29 +298,9 @@ export class Driver implements Disposable {
 		dbg.log('starting discovery for database: %s', this.database)
 
 		let discoveryStart = performance.now()
-		let retryConfig: RetryConfig = {
-			...defaultRetryConfig,
-			signal: outerSignal,
-			onRetry: (ctx) => {
-				dbg.log('retrying discovery, attempt %d, error: %O', ctx.attempt, ctx.error)
+		let attempt = 0
 
-				// Fire onDiscoveryError hook for each failed attempt
-				this.#safeHook('onDiscoveryError', () =>
-					this.options.hooks?.onDiscoveryError?.({
-						error: ctx.error,
-						attempt: ctx.attempt,
-						duration: performance.now() - discoveryStart,
-					})
-				)
-				dcChannel('ydb:discovery.error').publish({
-					error: ctx.error,
-					attempt: ctx.attempt,
-					database: this.database,
-				})
-			},
-		}
-
-		let result = await retry(retryConfig, async (signal) => {
+		const fetchEndpoints = async (signal: AbortSignal) => {
 			let client = (this.#discoveryClient ??= createClientFactory()
 				.use(this.#middleware)
 				.create(DiscoveryServiceDefinition, this.#connection.channel))
@@ -330,35 +316,61 @@ export class Driver implements Disposable {
 			assert.ok(res, new DriverResponseError('Missing result in operation data.'))
 
 			return res
-		})
+		}
 
-		dbg.log('discovered %d endpoints: %O', result.endpoints.length, result.endpoints)
+		// ── entry point ─────────────────────────────────────────────────────
+		await discoveryCh.tracePromise(
+			async () => {
+				let retryConfig: RetryConfig = {
+					...defaultRetryConfig,
+					signal: outerSignal,
+					onRetry: (ctx) => {
+						dbg.log('retrying discovery, attempt %d, error: %O', ctx.attempt, ctx.error)
+						this.#safeHook('onDiscoveryError', () =>
+							this.options.hooks?.onDiscoveryError?.({
+								error: ctx.error,
+								attempt: ctx.attempt,
+								duration: performance.now() - discoveryStart,
+							})
+						)
+					},
+				}
 
-		let { added, removed } = this.#pool.sync(result.endpoints)
+				let result = await retryRunCh.tracePromise(
+					() =>
+						retry(retryConfig, (signal) => {
+							attempt++
+							return retryAttemptCh.tracePromise(() => fetchEndpoints(signal), {
+								attempt,
+								database: this.database,
+							})
+						}),
+					{ database: this.database }
+				)
 
-		let endpoints: EndpointInfo[] = result.endpoints.map((ep) =>
-			Object.freeze<EndpointInfo>({
-				nodeId: BigInt(ep.nodeId),
-				address: `${ep.address}:${ep.port}`,
-				location: ep.location,
-			})
+				dbg.log('discovered %d endpoints: %O', result.endpoints.length, result.endpoints)
+
+				let { added, removed } = this.#pool.sync(result.endpoints)
+
+				let endpoints: EndpointInfo[] = result.endpoints.map((ep) =>
+					Object.freeze<EndpointInfo>({
+						nodeId: BigInt(ep.nodeId),
+						address: `${ep.address}:${ep.port}`,
+						location: ep.location,
+					})
+				)
+
+				this.#safeHook('onDiscovery', () =>
+					this.options.hooks?.onDiscovery?.({
+						added,
+						removed,
+						duration: performance.now() - discoveryStart,
+						endpoints,
+					})
+				)
+			},
+			{ database: this.database }
 		)
-
-		this.#safeHook('onDiscovery', () =>
-			this.options.hooks?.onDiscovery?.({
-				added,
-				removed,
-				duration: performance.now() - discoveryStart,
-				endpoints,
-			})
-		)
-		dcChannel('ydb:discovery').publish({
-			endpoints,
-			added,
-			removed,
-			duration: performance.now() - discoveryStart,
-			database: this.database,
-		})
 	}
 
 	async ready(signal?: AbortSignal): Promise<void> {
@@ -388,6 +400,7 @@ export class Driver implements Disposable {
 		dbg.log('closing primary connection')
 		this.#connection.close()
 		dbg.log('driver closed')
+		dcChannel('ydb:driver.closed').publish({ database: this.database })
 	}
 
 	/**

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -44,9 +44,9 @@ import { debug } from './middleware.js'
 import { ConnectionPool } from './pool.js'
 import { detectRuntime } from './runtime.js'
 
-const discoveryCh = tracingChannel('tracing:ydb:discovery')
-const retryRunCh = tracingChannel('tracing:ydb:retry.run')
-const retryAttemptCh = tracingChannel('tracing:ydb:retry.attempt')
+let discoveryCh = tracingChannel('tracing:ydb:discovery')
+let retryRunCh = tracingChannel('tracing:ydb:retry.run')
+let retryAttemptCh = tracingChannel('tracing:ydb:retry.attempt')
 
 export type { DriverHooks, EndpointInfo }
 
@@ -95,7 +95,7 @@ export type DriverOptions = {
 
 let dbg = loggers.driver
 
-const defaultOptions: DriverOptions = {
+let defaultOptions: DriverOptions = {
 	'ydb.sdk.ready_timeout_ms': 30_000,
 	'ydb.sdk.token_timeout_ms': 10_000,
 	'ydb.sdk.enable_discovery': true,
@@ -106,7 +106,7 @@ const defaultOptions: DriverOptions = {
 	'ydb.sdk.connection_pessimization_timeout_ms': 60_000,
 } as const satisfies DriverOptions
 
-const defaultChannelOptions: ChannelOptions = {
+let defaultChannelOptions: ChannelOptions = {
 	'grpc.primary_user_agent': `ydb-js-sdk/${pkg.version}`,
 	'grpc.secondary_user_agent': detectRuntime(),
 
@@ -129,7 +129,7 @@ if (!Promise.withResolvers) {
 	} {
 		let resolve: (value: T | PromiseLike<T>) => void
 		let reject: (reason?: any) => void
-		const promise = new Promise<T>((res, rej) => {
+		let promise = new Promise<T>((res, rej) => {
 			resolve = res
 			reject = rej
 		})
@@ -300,7 +300,7 @@ export class Driver implements Disposable {
 		let discoveryStart = performance.now()
 		let attempt = 0
 
-		const fetchEndpoints = async (signal: AbortSignal) => {
+		let fetchEndpoints = async (signal: AbortSignal) => {
 			let client = (this.#discoveryClient ??= createClientFactory()
 				.use(this.#middleware)
 				.create(DiscoveryServiceDefinition, this.#connection.channel))
@@ -318,7 +318,7 @@ export class Driver implements Disposable {
 			return res
 		}
 
-		const traceRetryAttempt = (signal: AbortSignal) => {
+		let traceRetryAttempt = (signal: AbortSignal) => {
 			attempt++
 			return retryAttemptCh.tracePromise(() => fetchEndpoints(signal), {
 				attempt,
@@ -326,7 +326,7 @@ export class Driver implements Disposable {
 			})
 		}
 
-		const retryConfig: RetryConfig = {
+		let retryConfig: RetryConfig = {
 			...defaultRetryConfig,
 			signal: outerSignal,
 			onRetry: (ctx) => {

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -1,5 +1,6 @@
 import * as tls from 'node:tls'
 import * as assert from 'node:assert/strict'
+import { channel as dcChannel } from 'node:diagnostics_channel'
 
 import { create } from '@bufbuild/protobuf'
 import { anyUnpack } from '@bufbuild/protobuf/wkt'
@@ -305,6 +306,11 @@ export class Driver implements Disposable {
 						duration: performance.now() - discoveryStart,
 					})
 				)
+				dcChannel('ydb:discovery.error').publish({
+					error: ctx.error,
+					attempt: ctx.attempt,
+					database: this.database,
+				})
 			},
 		}
 
@@ -346,6 +352,13 @@ export class Driver implements Disposable {
 				endpoints,
 			})
 		)
+		dcChannel('ydb:discovery').publish({
+			endpoints,
+			added,
+			removed,
+			duration: performance.now() - discoveryStart,
+			database: this.database,
+		})
 	}
 
 	async ready(signal?: AbortSignal): Promise<void> {

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -318,33 +318,33 @@ export class Driver implements Disposable {
 			return res
 		}
 
-		// ── entry point ─────────────────────────────────────────────────────
+		const traceRetryAttempt = (signal: AbortSignal) => {
+			attempt++
+			return retryAttemptCh.tracePromise(() => fetchEndpoints(signal), {
+				attempt,
+				database: this.database,
+			})
+		}
+
+		const retryConfig: RetryConfig = {
+			...defaultRetryConfig,
+			signal: outerSignal,
+			onRetry: (ctx) => {
+				dbg.log('retrying discovery, attempt %d, error: %O', ctx.attempt, ctx.error)
+				this.#safeHook('onDiscoveryError', () =>
+					this.options.hooks?.onDiscoveryError?.({
+						error: ctx.error,
+						attempt: ctx.attempt,
+						duration: performance.now() - discoveryStart,
+					})
+				)
+			},
+		}
+
 		await discoveryCh.tracePromise(
 			async () => {
-				let retryConfig: RetryConfig = {
-					...defaultRetryConfig,
-					signal: outerSignal,
-					onRetry: (ctx) => {
-						dbg.log('retrying discovery, attempt %d, error: %O', ctx.attempt, ctx.error)
-						this.#safeHook('onDiscoveryError', () =>
-							this.options.hooks?.onDiscoveryError?.({
-								error: ctx.error,
-								attempt: ctx.attempt,
-								duration: performance.now() - discoveryStart,
-							})
-						)
-					},
-				}
-
 				let result = await retryRunCh.tracePromise(
-					() =>
-						retry(retryConfig, (signal) => {
-							attempt++
-							return retryAttemptCh.tracePromise(() => fetchEndpoints(signal), {
-								attempt,
-								database: this.database,
-							})
-						}),
+					() => retry(retryConfig, traceRetryAttempt),
 					{ database: this.database }
 				)
 

--- a/packages/core/src/pool.ts
+++ b/packages/core/src/pool.ts
@@ -1,5 +1,6 @@
 import type { EndpointInfo as ProtoEndpointInfo } from '@ydbjs/api/discovery'
 import { connectivityState } from '@grpc/grpc-js'
+import { channel as dcChannel } from 'node:diagnostics_channel'
 
 import { loggers } from '@ydbjs/debug'
 import type { ChannelCredentials, ChannelOptions } from 'nice-grpc'
@@ -121,6 +122,10 @@ export class ConnectionPool implements Disposable {
 		this.#pessimized.set(conn, Date.now() + this.options.pessimizationTimeout)
 
 		dbg.log('pessimized node %d address %s', conn.endpoint.nodeId, conn.endpoint.address)
+		dcChannel('ydb:pessimize').publish({
+			nodeId: conn.endpoint.nodeId,
+			address: conn.endpoint.address,
+		})
 
 		this.#safeHook('onPessimize', () => {
 			this.options.hooks?.onPessimize?.({ endpoint: conn.endpoint })
@@ -185,6 +190,11 @@ export class ConnectionPool implements Disposable {
 			conn.endpoint.address,
 			this.#connections.length
 		)
+		dcChannel('ydb:pool.connection.add').publish({
+			nodeId: conn.endpoint.nodeId,
+			address: conn.endpoint.address,
+			location: conn.endpoint.location,
+		})
 	}
 
 	/**
@@ -218,6 +228,12 @@ export class ConnectionPool implements Disposable {
 			this.#acquired.delete(conn)
 			this.#retired.add(conn)
 			removed.push(conn.endpoint)
+			dcChannel('ydb:pool.connection.remove').publish({
+				nodeId: conn.endpoint.nodeId,
+				address: conn.endpoint.address,
+				location: conn.endpoint.location,
+				reason: 'discovery.stale_active',
+			})
 			dbg.log('removed stale active node %d from routing', conn.endpoint.nodeId)
 		}
 
@@ -232,6 +248,12 @@ export class ConnectionPool implements Disposable {
 			this.#acquired.delete(conn)
 			this.#retired.add(conn)
 			removed.push(conn.endpoint)
+			dcChannel('ydb:pool.connection.remove').publish({
+				nodeId: conn.endpoint.nodeId,
+				address: conn.endpoint.address,
+				location: conn.endpoint.location,
+				reason: 'discovery.stale_pessimized',
+			})
 			dbg.log('removed stale pessimized node %d from routing', conn.endpoint.nodeId)
 		}
 
@@ -367,6 +389,10 @@ export class ConnectionPool implements Disposable {
 					conn.endpoint.nodeId,
 					conn.endpoint.address
 				)
+				dcChannel('ydb:unpessimize').publish({
+					nodeId: conn.endpoint.nodeId,
+					address: conn.endpoint.address,
+				})
 
 				this.#safeHook('onUnpessimize', () => {
 					this.options.hooks?.onUnpessimize?.({ endpoint: conn.endpoint })

--- a/packages/core/src/pool.ts
+++ b/packages/core/src/pool.ts
@@ -1,7 +1,7 @@
-import type { EndpointInfo as ProtoEndpointInfo } from '@ydbjs/api/discovery'
-import { connectivityState } from '@grpc/grpc-js'
 import { channel as dcChannel } from 'node:diagnostics_channel'
 
+import { connectivityState } from '@grpc/grpc-js'
+import type { EndpointInfo as ProtoEndpointInfo } from '@ydbjs/api/discovery'
 import { loggers } from '@ydbjs/debug'
 import type { ChannelCredentials, ChannelOptions } from 'nice-grpc'
 

--- a/packages/core/src/pool.ts
+++ b/packages/core/src/pool.ts
@@ -122,7 +122,7 @@ export class ConnectionPool implements Disposable {
 		this.#pessimized.set(conn, Date.now() + this.options.pessimizationTimeout)
 
 		dbg.log('pessimized node %d address %s', conn.endpoint.nodeId, conn.endpoint.address)
-		dcChannel('ydb:pessimize').publish({
+		dcChannel('ydb:pool.pessimize').publish({
 			nodeId: conn.endpoint.nodeId,
 			address: conn.endpoint.address,
 		})
@@ -389,7 +389,7 @@ export class ConnectionPool implements Disposable {
 					conn.endpoint.nodeId,
 					conn.endpoint.address
 				)
-				dcChannel('ydb:unpessimize').publish({
+				dcChannel('ydb:pool.unpessimize').publish({
 					nodeId: conn.endpoint.nodeId,
 					address: conn.endpoint.address,
 				})

--- a/packages/core/src/pool.ts
+++ b/packages/core/src/pool.ts
@@ -190,7 +190,7 @@ export class ConnectionPool implements Disposable {
 			conn.endpoint.address,
 			this.#connections.length
 		)
-		dcChannel('ydb:pool.connection.add').publish({
+		dcChannel('ydb:pool.connection.added').publish({
 			nodeId: conn.endpoint.nodeId,
 			address: conn.endpoint.address,
 			location: conn.endpoint.location,
@@ -228,7 +228,7 @@ export class ConnectionPool implements Disposable {
 			this.#acquired.delete(conn)
 			this.#retired.add(conn)
 			removed.push(conn.endpoint)
-			dcChannel('ydb:pool.connection.remove').publish({
+			dcChannel('ydb:pool.connection.removed').publish({
 				nodeId: conn.endpoint.nodeId,
 				address: conn.endpoint.address,
 				location: conn.endpoint.location,
@@ -248,7 +248,7 @@ export class ConnectionPool implements Disposable {
 			this.#acquired.delete(conn)
 			this.#retired.add(conn)
 			removed.push(conn.endpoint)
-			dcChannel('ydb:pool.connection.remove').publish({
+			dcChannel('ydb:pool.connection.removed').publish({
 				nodeId: conn.endpoint.nodeId,
 				address: conn.endpoint.address,
 				location: conn.endpoint.location,

--- a/packages/query/src/diagnostics.test.ts
+++ b/packages/query/src/diagnostics.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, expect, test } from 'vitest'
+import { channel as dcChannel, tracingChannel } from 'node:diagnostics_channel'
+import { createServer } from 'nice-grpc'
+import { create } from '@bufbuild/protobuf'
+
+import { StatusIds_StatusCode } from '@ydbjs/api/operation'
+import {
+	CreateSessionResponseSchema,
+	DeleteSessionResponseSchema,
+	QueryServiceDefinition,
+	SessionStateSchema,
+} from '@ydbjs/api/query'
+import { Driver } from '@ydbjs/core'
+
+import { SessionPool } from './session-pool.ts'
+
+// ── Minimal query server harness ──────────────────────────────────────────────
+
+async function startServer() {
+	let nextId = 0
+	let attachCtrls = new Map<string, AbortController>()
+
+	let server = createServer()
+	server.add(
+		{
+			createSession: QueryServiceDefinition.createSession,
+			deleteSession: QueryServiceDefinition.deleteSession,
+			attachSession: QueryServiceDefinition.attachSession,
+		},
+		{
+			async createSession() {
+				let sessionId = `ses-${++nextId}`
+				attachCtrls.set(sessionId, new AbortController())
+				return create(CreateSessionResponseSchema, {
+					status: StatusIds_StatusCode.SUCCESS,
+					sessionId,
+					nodeId: 1n,
+				})
+			},
+			async deleteSession(req) {
+				attachCtrls.get(req.sessionId)?.abort()
+				return create(DeleteSessionResponseSchema, {
+					status: StatusIds_StatusCode.SUCCESS,
+				})
+			},
+			async *attachSession(req, ctx) {
+				let serverCtrl = attachCtrls.get(req.sessionId) ?? new AbortController()
+				yield create(SessionStateSchema, { status: StatusIds_StatusCode.SUCCESS })
+				await new Promise<void>((resolve) => {
+					ctx.signal.addEventListener('abort', () => resolve(), { once: true })
+					serverCtrl.signal.addEventListener('abort', () => resolve(), { once: true })
+				})
+			},
+		}
+	)
+
+	let port = await server.listen('127.0.0.1:0')
+	let driver = new Driver(`grpc://127.0.0.1:${port}/local`, {
+		'ydb.sdk.enable_discovery': false,
+	})
+
+	return {
+		driver,
+		breakSession(id: string) {
+			attachCtrls.get(id)?.abort()
+		},
+		async close() {
+			driver.close()
+			await server.shutdown()
+		},
+	}
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Subscribe to a plain channel, collect published payloads. */
+function collect(name: string) {
+	let payloads: unknown[] = []
+	let fn = (msg: unknown) => payloads.push(structuredClone(msg))
+	dcChannel(name).subscribe(fn)
+	return { payloads, stop: () => dcChannel(name).unsubscribe(fn) }
+}
+
+/** Subscribe to start events of a tracing channel, collect context snapshots. */
+function collectStart(name: string) {
+	let contexts: Record<string, unknown>[] = []
+	let handlers = {
+		start(ctx: Record<string, unknown>) {
+			contexts.push({ ...ctx })
+		},
+	}
+	tracingChannel(name).subscribe(handlers)
+	return { contexts, stop: () => tracingChannel(name).unsubscribe(handlers) }
+}
+
+type Server = Awaited<ReturnType<typeof startServer>>
+let srv: Server | undefined
+let pool: SessionPool | undefined
+
+afterEach(async () => {
+	await pool?.close().catch(() => {})
+	pool = undefined
+	await srv?.close()
+	srv = undefined
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test('ydb:session.created — fires with sessionId and nodeId after pool.acquire()', async () => {
+	srv = await startServer()
+	pool = new SessionPool(srv.driver, { maxSize: 1 })
+
+	let { payloads, stop } = collect('ydb:session.created')
+	try {
+		let lease = await pool.acquire()
+		lease[Symbol.dispose]()
+
+		expect(payloads).toHaveLength(1)
+		expect(payloads[0]).toMatchObject({
+			sessionId: expect.stringContaining('ses-'),
+			nodeId: 1n,
+		})
+	} finally {
+		stop()
+	}
+})
+
+test('ydb:session.evicted — fires when the server kills the session attach stream', async () => {
+	srv = await startServer()
+	pool = new SessionPool(srv.driver, { maxSize: 1 })
+
+	let lease = await pool.acquire()
+	let sessionId = lease.id
+	lease[Symbol.dispose]()
+
+	let { payloads, stop } = collect('ydb:session.evicted')
+	try {
+		srv.breakSession(sessionId)
+		// Give the attach-stream abort time to propagate.
+		await new Promise((r) => setTimeout(r, 60))
+
+		expect(payloads).toHaveLength(1)
+		expect(payloads[0]).toMatchObject({ sessionId })
+	} finally {
+		stop()
+	}
+})
+
+test('ydb:session.destroyed — fires for every open session on pool.close()', async () => {
+	srv = await startServer()
+	pool = new SessionPool(srv.driver, { maxSize: 2 })
+
+	// Two sessions in the pool (idle after release).
+	let a = await pool.acquire()
+	let b = await pool.acquire()
+	a[Symbol.dispose]()
+	b[Symbol.dispose]()
+
+	let { payloads, stop } = collect('ydb:session.destroyed')
+	try {
+		await pool.close()
+		pool = undefined
+
+		expect(payloads).toHaveLength(2)
+		for (let p of payloads) {
+			expect(p).toMatchObject({
+				sessionId: expect.stringContaining('ses-'),
+				nodeId: 1n,
+			})
+		}
+	} finally {
+		stop()
+	}
+})
+
+test('tracing:ydb:session.create — start fires when pool grows a new session', async () => {
+	srv = await startServer()
+	pool = new SessionPool(srv.driver, { maxSize: 1 })
+
+	let { contexts, stop } = collectStart('tracing:ydb:session.create')
+	try {
+		let lease = await pool.acquire()
+		lease[Symbol.dispose]()
+
+		// start fires before the session is available — at least one context captured.
+		expect(contexts.length).toBeGreaterThanOrEqual(1)
+	} finally {
+		stop()
+	}
+})

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -12,17 +12,15 @@ import { loggers } from '@ydbjs/debug'
 import { Query } from './query.js'
 import { ctx } from './ctx.js'
 import { UnsafeString, identifier, unsafe, yql } from './yql.js'
-import { SessionPool, type SessionPoolOptions } from './session-pool.js'
+import { SessionPool, type SessionPoolOptions, sessionAcquireCh } from './session-pool.js'
 
-const transactionCh = tracingChannel('tracing:@ydbjs:query.transaction')
-const sessionAcquireCh = tracingChannel('tracing:@ydbjs:session.acquire')
+const transactionCh = tracingChannel('tracing:ydb:query.transaction')
+const retryRunCh = tracingChannel('tracing:ydb:retry.run')
+const retryAttemptCh = tracingChannel('tracing:ydb:retry.attempt')
 
 let dbg = loggers.query
 
 export type QueryOptions = {
-	/**
-	 * Session pool configuration
-	 */
 	poolOptions?: SessionPoolOptions
 }
 
@@ -188,186 +186,187 @@ export function query(driver: Driver, options?: QueryOptions): QueryClient {
 		let idempotent = options.idempotent ?? false
 
 		let sessionDiedLastAttempt = false
+		let attempt = 0
+
+		const acquireSession = (signal: AbortSignal) =>
+			sessionAcquireCh.tracePromise(() => sessionPool.acquire(signal), {
+				kind: 'transaction',
+			})
+
+		const runAttempt = async (retrySignal: AbortSignal) => {
+			dbg.log('acquiring session from pool for transaction')
+			using sessionLease = await acquireSession(retrySignal)
+			dbg.log('session %s acquired for transaction', sessionLease.id)
+
+			// linkSignals is disposed on scope exit — no listener buildup
+			// on the long-lived session signal across tx retries.
+			using linked = linkSignals(retrySignal, sessionLease.signal)
+			let signal = linked.signal
+
+			let attemptStore: typeof parentStore = {
+				...parentStore,
+				signal,
+				nodeId: sessionLease.nodeId,
+				sessionId: sessionLease.id,
+			}
+
+			let client = driver.createClient(QueryServiceDefinition, sessionLease.nodeId)
+
+			let beginTransactionResult = await client.beginTransaction(
+				{
+					sessionId: attemptStore.sessionId!,
+					txSettings: {
+						txMode: { case: options.isolation!, value: {} },
+					},
+				},
+				{ signal }
+			)
+			if (beginTransactionResult.status !== StatusIds_StatusCode.SUCCESS) {
+				dbg.log('failed to begin transaction, status: %d', beginTransactionResult.status)
+				throw new YDBError(beginTransactionResult.status, beginTransactionResult.issues)
+			}
+
+			attemptStore.transactionId = beginTransactionResult.txMeta!.id
+
+			let commitHooks: Array<(signal?: AbortSignal) => Promise<void> | void> = []
+			let rollbackHooks: Array<
+				(error: unknown, signal?: AbortSignal) => Promise<void> | void
+			> = []
+			let closeHooks: Array<
+				(committed: boolean, signal?: AbortSignal) => Promise<void> | void
+			> = []
+
+			let committed = false
+			try {
+				let tx = Object.assign(yqlQuery, {
+					nodeId: attemptStore.nodeId,
+					sessionId: attemptStore.sessionId,
+					transactionId: attemptStore.transactionId,
+					onRollback: (fn: () => Promise<void> | void) => {
+						rollbackHooks.push(fn)
+					},
+					onCommit: (fn: () => Promise<void> | void) => {
+						commitHooks.push(fn)
+					},
+					onClose: (fn: () => Promise<void> | void) => {
+						closeHooks.push(fn)
+					},
+				}) as TX
+
+				dbg.log('executing transaction body')
+				let result = await ctx.run(attemptStore, () => caller!(tx, signal))
+
+				dbg.log('executing %d commit hooks', commitHooks.length)
+				await Promise.all(
+					commitHooks.map(async (hook, i) => {
+						dbg.log('executing commit hook #%d', i + 1)
+						await hook(signal)
+						dbg.log('commit hook #%d completed', i + 1)
+					})
+				)
+
+				dbg.log('committing transaction')
+				let commitResult = await client.commitTransaction(
+					{
+						sessionId: attemptStore.sessionId!,
+						txId: attemptStore.transactionId,
+					},
+					{ signal }
+				)
+				if (commitResult.status !== StatusIds_StatusCode.SUCCESS) {
+					dbg.log('failed to commit transaction, status: %d', commitResult.status)
+					throw new CommitError(
+						'Transaction commit failed.',
+						new YDBError(commitResult.status, commitResult.issues)
+					)
+				}
+
+				committed = true
+				dbg.log('transaction committed successfully')
+				return result
+			} catch (error) {
+				dbg.log('transaction error: %O', error)
+
+				// Signal up to the retry callback that this attempt tore down
+				// because the session died — lets it retry with a fresh one
+				// if the caller opted into idempotent retries.
+				if (sessionLease.signal.aborted) {
+					sessionDiedLastAttempt = true
+				}
+
+				dbg.log('executing %d rollback hooks', rollbackHooks.length)
+				await Promise.all(
+					rollbackHooks.map(async (hook, i) => {
+						dbg.log('executing rollback hook #%d', i + 1)
+						await hook(error, signal)
+						dbg.log('rollback hook #%d completed', i + 1)
+					})
+				)
+
+				client
+					.rollbackTransaction({
+						sessionId: attemptStore.sessionId!,
+						txId: attemptStore.transactionId,
+					})
+					.catch(() => {})
+
+				if (!isRetryableError(error, idempotent)) {
+					dbg.log('transaction not retryable, aborting')
+					throw new Error('Transaction failed.', { cause: error })
+				}
+
+				throw error
+			} finally {
+				dbg.log('executing %d close hooks', closeHooks.length)
+				await Promise.all(
+					closeHooks.map(async (hook, i) => {
+						dbg.log('executing close hook #%d', i + 1)
+						await hook(committed, signal)
+						dbg.log('close hook #%d completed', i + 1)
+					})
+				)
+			}
+		}
+
+		const retryConfig = {
+			...defaultRetryConfig,
+			signal: options.signal,
+			// Caller's flag flows through the retry layer unchanged and
+			// lands back in the callback as the second arg — single source
+			// of truth for whether the body is safe to replay.
+			idempotent,
+			retry: (error: unknown, idempotent: boolean) => {
+				let sessionDied = sessionDiedLastAttempt
+				sessionDiedLastAttempt = false
+				// A session abort mid-tx means we don't know whether the
+				// server applied any side effects — only re-open if the
+				// caller opted into idempotent retries.
+				return isRetryableError(error, idempotent) || (sessionDied && idempotent)
+			},
+			onRetry: (retryCtx: { attempt: number; error: unknown }) => {
+				dbg.log(
+					'retrying transaction, attempt %d, error: %O',
+					retryCtx.attempt,
+					retryCtx.error
+				)
+			},
+		}
 
 		return transactionCh.tracePromise(
 			() =>
-				retry(
-					{
-						...defaultRetryConfig,
-						signal: options.signal,
-						// Caller's flag flows through the retry layer unchanged and
-						// lands back in the callback as the second arg — single source
-						// of truth for whether the body is safe to replay.
-						idempotent,
-						retry: (error, idempotent) => {
-							let sessionDied = sessionDiedLastAttempt
-							sessionDiedLastAttempt = false
-							// A session abort mid-tx means we don't know whether the
-							// server applied any side effects — only re-open if the
-							// caller opted into idempotent retries.
-							return (
-								isRetryableError(error, idempotent) || (sessionDied && idempotent)
-							)
-						},
-						onRetry: (ctx) => {
-							dbg.log(
-								'retrying transaction, attempt %d, error: %O',
-								ctx.attempt,
-								ctx.error
-							)
-						},
-					},
-					async (retrySignal) => {
-						dbg.log('acquiring session from pool for transaction')
-						using sessionLease = await sessionAcquireCh.tracePromise(
-							() => sessionPool.acquire(retrySignal),
-							{}
-						)
-						dbg.log('session %s acquired for transaction', sessionLease.id)
-
-						// linkSignals is disposed on scope exit — no listener buildup
-						// on the long-lived session signal across tx retries.
-						using linked = linkSignals(retrySignal, sessionLease.signal)
-						let signal = linked.signal
-
-						let attemptStore: typeof parentStore = {
-							...parentStore,
-							signal,
-							nodeId: sessionLease.nodeId,
-							sessionId: sessionLease.id,
-						}
-
-						let client = driver.createClient(
-							QueryServiceDefinition,
-							sessionLease.nodeId
-						)
-
-						let beginTransactionResult = await client.beginTransaction(
-							{
-								sessionId: attemptStore.sessionId!,
-								txSettings: {
-									txMode: { case: options.isolation!, value: {} },
-								},
-							},
-							{ signal }
-						)
-						if (beginTransactionResult.status !== StatusIds_StatusCode.SUCCESS) {
-							dbg.log(
-								'failed to begin transaction, status: %d',
-								beginTransactionResult.status
-							)
-							throw new YDBError(
-								beginTransactionResult.status,
-								beginTransactionResult.issues
-							)
-						}
-
-						attemptStore.transactionId = beginTransactionResult.txMeta!.id
-
-						let commitHooks: Array<(signal?: AbortSignal) => Promise<void> | void> = []
-						let rollbackHooks: Array<
-							(error: unknown, signal?: AbortSignal) => Promise<void> | void
-						> = []
-						let closeHooks: Array<
-							(committed: boolean, signal?: AbortSignal) => Promise<void> | void
-						> = []
-
-						let committed = false
-						try {
-							let tx = Object.assign(yqlQuery, {
-								nodeId: attemptStore.nodeId,
-								sessionId: attemptStore.sessionId,
-								transactionId: attemptStore.transactionId,
-								onRollback: (fn: () => Promise<void> | void) => {
-									rollbackHooks.push(fn)
-								},
-								onCommit: (fn: () => Promise<void> | void) => {
-									commitHooks.push(fn)
-								},
-								onClose: (fn: () => Promise<void> | void) => {
-									closeHooks.push(fn)
-								},
-							}) as TX
-
-							dbg.log('executing transaction body')
-							let result = await ctx.run(attemptStore, () => caller!(tx, signal))
-
-							dbg.log('executing %d commit hooks', commitHooks.length)
-							await Promise.all(
-								commitHooks.map(async (hook, i) => {
-									dbg.log('executing commit hook #%d', i + 1)
-									await hook(signal)
-									dbg.log('commit hook #%d completed', i + 1)
-								})
-							)
-
-							dbg.log('committing transaction')
-							let commitResult = await client.commitTransaction(
-								{
-									sessionId: attemptStore.sessionId!,
-									txId: attemptStore.transactionId,
-								},
-								{ signal }
-							)
-							if (commitResult.status !== StatusIds_StatusCode.SUCCESS) {
-								dbg.log(
-									'failed to commit transaction, status: %d',
-									commitResult.status
-								)
-								throw new CommitError(
-									'Transaction commit failed.',
-									new YDBError(commitResult.status, commitResult.issues)
-								)
-							}
-
-							committed = true
-							dbg.log('transaction committed successfully')
-							return result
-						} catch (error) {
-							dbg.log('transaction error: %O', error)
-
-							// Signal up to the retry callback that this attempt tore down
-							// because the session died — lets it retry with a fresh one
-							// if the caller opted into idempotent retries.
-							if (sessionLease.signal.aborted) {
-								sessionDiedLastAttempt = true
-							}
-
-							dbg.log('executing %d rollback hooks', rollbackHooks.length)
-							await Promise.all(
-								rollbackHooks.map(async (hook, i) => {
-									dbg.log('executing rollback hook #%d', i + 1)
-									await hook(error, signal)
-									dbg.log('rollback hook #%d completed', i + 1)
-								})
-							)
-
-							client
-								.rollbackTransaction({
-									sessionId: attemptStore.sessionId!,
-									txId: attemptStore.transactionId,
-								})
-								.catch(() => {})
-
-							if (!isRetryableError(error, idempotent)) {
-								dbg.log('transaction not retryable, aborting')
-								throw new Error('Transaction failed.', { cause: error })
-							}
-
-							throw error
-						} finally {
-							dbg.log('executing %d close hooks', closeHooks.length)
-							await Promise.all(
-								closeHooks.map(async (hook, i) => {
-									dbg.log('executing close hook #%d', i + 1)
-									await hook(committed, signal)
-									dbg.log('close hook #%d completed', i + 1)
-								})
-							)
-						}
-					}
+				retryRunCh.tracePromise(
+					() =>
+						retry(retryConfig, (retrySignal) => {
+							attempt++
+							return retryAttemptCh.tracePromise(() => runAttempt(retrySignal), {
+								attempt,
+								isolation: options.isolation!,
+								idempotent,
+							})
+						}),
+					{ isolation: options.isolation!, idempotent }
 				),
-			{ isolation: options.isolation ?? 'serializableReadWrite', idempotent }
+			{ isolation: options.isolation!, idempotent }
 		)
 	}
 

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -14,9 +14,9 @@ import { ctx } from './ctx.js'
 import { UnsafeString, identifier, unsafe, yql } from './yql.js'
 import { SessionPool, type SessionPoolOptions, sessionAcquireCh } from './session-pool.js'
 
-const transactionCh = tracingChannel('tracing:ydb:query.transaction')
-const retryRunCh = tracingChannel('tracing:ydb:retry.run')
-const retryAttemptCh = tracingChannel('tracing:ydb:retry.attempt')
+let transactionCh = tracingChannel('tracing:ydb:query.transaction')
+let retryRunCh = tracingChannel('tracing:ydb:retry.run')
+let retryAttemptCh = tracingChannel('tracing:ydb:retry.attempt')
 
 let dbg = loggers.query
 
@@ -98,7 +98,7 @@ export interface QueryClient extends SQL, AsyncDisposable {
 	unsafe(value: string | { toString(): string }): UnsafeString
 }
 
-const doImpl = function <T = unknown>(): Promise<T> {
+let doImpl = function <T = unknown>(): Promise<T> {
 	throw new Error('Not implemented')
 }
 
@@ -188,12 +188,12 @@ export function query(driver: Driver, options?: QueryOptions): QueryClient {
 		let sessionDiedLastAttempt = false
 		let attempt = 0
 
-		const acquireSession = (signal: AbortSignal) =>
+		let acquireSession = (signal: AbortSignal) =>
 			sessionAcquireCh.tracePromise(() => sessionPool.acquire(signal), {
 				kind: 'transaction',
 			})
 
-		const runAttempt = async (retrySignal: AbortSignal) => {
+		let runAttempt = async (retrySignal: AbortSignal) => {
 			dbg.log('acquiring session from pool for transaction')
 			using sessionLease = await acquireSession(retrySignal)
 			dbg.log('session %s acquired for transaction', sessionLease.id)
@@ -328,7 +328,7 @@ export function query(driver: Driver, options?: QueryOptions): QueryClient {
 			}
 		}
 
-		const retryConfig = {
+		let retryConfig = {
 			...defaultRetryConfig,
 			signal: options.signal,
 			// Caller's flag flows through the retry layer unchanged and
@@ -352,7 +352,7 @@ export function query(driver: Driver, options?: QueryOptions): QueryClient {
 			},
 		}
 
-		const traceRetryAttempt = (retrySignal: AbortSignal) => {
+		let traceRetryAttempt = (retrySignal: AbortSignal) => {
 			attempt++
 			return retryAttemptCh.tracePromise(() => runAttempt(retrySignal), {
 				attempt,

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -352,20 +352,21 @@ export function query(driver: Driver, options?: QueryOptions): QueryClient {
 			},
 		}
 
+		const traceRetryAttempt = (retrySignal: AbortSignal) => {
+			attempt++
+			return retryAttemptCh.tracePromise(() => runAttempt(retrySignal), {
+				attempt,
+				isolation: options.isolation!,
+				idempotent,
+			})
+		}
+
 		return transactionCh.tracePromise(
 			() =>
-				retryRunCh.tracePromise(
-					() =>
-						retry(retryConfig, (retrySignal) => {
-							attempt++
-							return retryAttemptCh.tracePromise(() => runAttempt(retrySignal), {
-								attempt,
-								isolation: options.isolation!,
-								idempotent,
-							})
-						}),
-					{ isolation: options.isolation!, idempotent }
-				),
+				retryRunCh.tracePromise(() => retry(retryConfig, traceRetryAttempt), {
+					isolation: options.isolation!,
+					idempotent,
+				}),
 			{ isolation: options.isolation!, idempotent }
 		)
 	}

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1,4 +1,5 @@
 import type { Abortable } from 'node:events'
+import { tracingChannel } from 'node:diagnostics_channel'
 
 import { linkSignals } from '@ydbjs/abortable'
 import { StatusIds_StatusCode } from '@ydbjs/api/operation'
@@ -12,6 +13,9 @@ import { Query } from './query.js'
 import { ctx } from './ctx.js'
 import { UnsafeString, identifier, unsafe, yql } from './yql.js'
 import { SessionPool, type SessionPoolOptions } from './session-pool.js'
+
+const transactionCh = tracingChannel('tracing:@ydbjs:query.transaction')
+const sessionAcquireCh = tracingChannel('tracing:@ydbjs:session.acquire')
 
 let dbg = loggers.query
 
@@ -185,163 +189,185 @@ export function query(driver: Driver, options?: QueryOptions): QueryClient {
 
 		let sessionDiedLastAttempt = false
 
-		return retry(
-			{
-				...defaultRetryConfig,
-				signal: options.signal,
-				// Caller's flag flows through the retry layer unchanged and
-				// lands back in the callback as the second arg — single source
-				// of truth for whether the body is safe to replay.
-				idempotent,
-				retry: (error, idempotent) => {
-					let sessionDied = sessionDiedLastAttempt
-					sessionDiedLastAttempt = false
-					// A session abort mid-tx means we don't know whether the
-					// server applied any side effects — only re-open if the
-					// caller opted into idempotent retries.
-					return isRetryableError(error, idempotent) || (sessionDied && idempotent)
-				},
-				onRetry: (ctx) => {
-					dbg.log('retrying transaction, attempt %d, error: %O', ctx.attempt, ctx.error)
-				},
-			},
-			async (retrySignal) => {
-				dbg.log('acquiring session from pool for transaction')
-				using sessionLease = await sessionPool.acquire(retrySignal)
-				dbg.log('session %s acquired for transaction', sessionLease.id)
-
-				// linkSignals is disposed on scope exit — no listener buildup
-				// on the long-lived session signal across tx retries.
-				using linked = linkSignals(retrySignal, sessionLease.signal)
-				let signal = linked.signal
-
-				let attemptStore: typeof parentStore = {
-					...parentStore,
-					signal,
-					nodeId: sessionLease.nodeId,
-					sessionId: sessionLease.id,
-				}
-
-				let client = driver.createClient(QueryServiceDefinition, sessionLease.nodeId)
-
-				let beginTransactionResult = await client.beginTransaction(
+		return transactionCh.tracePromise(
+			() =>
+				retry(
 					{
-						sessionId: attemptStore.sessionId!,
-						txSettings: {
-							txMode: { case: options.isolation!, value: {} },
+						...defaultRetryConfig,
+						signal: options.signal,
+						// Caller's flag flows through the retry layer unchanged and
+						// lands back in the callback as the second arg — single source
+						// of truth for whether the body is safe to replay.
+						idempotent,
+						retry: (error, idempotent) => {
+							let sessionDied = sessionDiedLastAttempt
+							sessionDiedLastAttempt = false
+							// A session abort mid-tx means we don't know whether the
+							// server applied any side effects — only re-open if the
+							// caller opted into idempotent retries.
+							return (
+								isRetryableError(error, idempotent) || (sessionDied && idempotent)
+							)
+						},
+						onRetry: (ctx) => {
+							dbg.log(
+								'retrying transaction, attempt %d, error: %O',
+								ctx.attempt,
+								ctx.error
+							)
 						},
 					},
-					{ signal }
-				)
-				if (beginTransactionResult.status !== StatusIds_StatusCode.SUCCESS) {
-					dbg.log(
-						'failed to begin transaction, status: %d',
-						beginTransactionResult.status
-					)
-					throw new YDBError(beginTransactionResult.status, beginTransactionResult.issues)
-				}
-
-				attemptStore.transactionId = beginTransactionResult.txMeta!.id
-
-				let commitHooks: Array<(signal?: AbortSignal) => Promise<void> | void> = []
-				let rollbackHooks: Array<
-					(error: unknown, signal?: AbortSignal) => Promise<void> | void
-				> = []
-				let closeHooks: Array<
-					(committed: boolean, signal?: AbortSignal) => Promise<void> | void
-				> = []
-
-				let committed = false
-				try {
-					let tx = Object.assign(yqlQuery, {
-						nodeId: attemptStore.nodeId,
-						sessionId: attemptStore.sessionId,
-						transactionId: attemptStore.transactionId,
-						onRollback: (fn: () => Promise<void> | void) => {
-							rollbackHooks.push(fn)
-						},
-						onCommit: (fn: () => Promise<void> | void) => {
-							commitHooks.push(fn)
-						},
-						onClose: (fn: () => Promise<void> | void) => {
-							closeHooks.push(fn)
-						},
-					}) as TX
-
-					dbg.log('executing transaction body')
-					let result = await ctx.run(attemptStore, () => caller!(tx, signal))
-
-					dbg.log('executing %d commit hooks', commitHooks.length)
-					await Promise.all(
-						commitHooks.map(async (hook, i) => {
-							dbg.log('executing commit hook #%d', i + 1)
-							await hook(signal)
-							dbg.log('commit hook #%d completed', i + 1)
-						})
-					)
-
-					dbg.log('committing transaction')
-					let commitResult = await client.commitTransaction(
-						{
-							sessionId: attemptStore.sessionId!,
-							txId: attemptStore.transactionId,
-						},
-						{ signal }
-					)
-					if (commitResult.status !== StatusIds_StatusCode.SUCCESS) {
-						dbg.log('failed to commit transaction, status: %d', commitResult.status)
-						throw new CommitError(
-							'Transaction commit failed.',
-							new YDBError(commitResult.status, commitResult.issues)
+					async (retrySignal) => {
+						dbg.log('acquiring session from pool for transaction')
+						using sessionLease = await sessionAcquireCh.tracePromise(
+							() => sessionPool.acquire(retrySignal),
+							{}
 						)
+						dbg.log('session %s acquired for transaction', sessionLease.id)
+
+						// linkSignals is disposed on scope exit — no listener buildup
+						// on the long-lived session signal across tx retries.
+						using linked = linkSignals(retrySignal, sessionLease.signal)
+						let signal = linked.signal
+
+						let attemptStore: typeof parentStore = {
+							...parentStore,
+							signal,
+							nodeId: sessionLease.nodeId,
+							sessionId: sessionLease.id,
+						}
+
+						let client = driver.createClient(
+							QueryServiceDefinition,
+							sessionLease.nodeId
+						)
+
+						let beginTransactionResult = await client.beginTransaction(
+							{
+								sessionId: attemptStore.sessionId!,
+								txSettings: {
+									txMode: { case: options.isolation!, value: {} },
+								},
+							},
+							{ signal }
+						)
+						if (beginTransactionResult.status !== StatusIds_StatusCode.SUCCESS) {
+							dbg.log(
+								'failed to begin transaction, status: %d',
+								beginTransactionResult.status
+							)
+							throw new YDBError(
+								beginTransactionResult.status,
+								beginTransactionResult.issues
+							)
+						}
+
+						attemptStore.transactionId = beginTransactionResult.txMeta!.id
+
+						let commitHooks: Array<(signal?: AbortSignal) => Promise<void> | void> = []
+						let rollbackHooks: Array<
+							(error: unknown, signal?: AbortSignal) => Promise<void> | void
+						> = []
+						let closeHooks: Array<
+							(committed: boolean, signal?: AbortSignal) => Promise<void> | void
+						> = []
+
+						let committed = false
+						try {
+							let tx = Object.assign(yqlQuery, {
+								nodeId: attemptStore.nodeId,
+								sessionId: attemptStore.sessionId,
+								transactionId: attemptStore.transactionId,
+								onRollback: (fn: () => Promise<void> | void) => {
+									rollbackHooks.push(fn)
+								},
+								onCommit: (fn: () => Promise<void> | void) => {
+									commitHooks.push(fn)
+								},
+								onClose: (fn: () => Promise<void> | void) => {
+									closeHooks.push(fn)
+								},
+							}) as TX
+
+							dbg.log('executing transaction body')
+							let result = await ctx.run(attemptStore, () => caller!(tx, signal))
+
+							dbg.log('executing %d commit hooks', commitHooks.length)
+							await Promise.all(
+								commitHooks.map(async (hook, i) => {
+									dbg.log('executing commit hook #%d', i + 1)
+									await hook(signal)
+									dbg.log('commit hook #%d completed', i + 1)
+								})
+							)
+
+							dbg.log('committing transaction')
+							let commitResult = await client.commitTransaction(
+								{
+									sessionId: attemptStore.sessionId!,
+									txId: attemptStore.transactionId,
+								},
+								{ signal }
+							)
+							if (commitResult.status !== StatusIds_StatusCode.SUCCESS) {
+								dbg.log(
+									'failed to commit transaction, status: %d',
+									commitResult.status
+								)
+								throw new CommitError(
+									'Transaction commit failed.',
+									new YDBError(commitResult.status, commitResult.issues)
+								)
+							}
+
+							committed = true
+							dbg.log('transaction committed successfully')
+							return result
+						} catch (error) {
+							dbg.log('transaction error: %O', error)
+
+							// Signal up to the retry callback that this attempt tore down
+							// because the session died — lets it retry with a fresh one
+							// if the caller opted into idempotent retries.
+							if (sessionLease.signal.aborted) {
+								sessionDiedLastAttempt = true
+							}
+
+							dbg.log('executing %d rollback hooks', rollbackHooks.length)
+							await Promise.all(
+								rollbackHooks.map(async (hook, i) => {
+									dbg.log('executing rollback hook #%d', i + 1)
+									await hook(error, signal)
+									dbg.log('rollback hook #%d completed', i + 1)
+								})
+							)
+
+							client
+								.rollbackTransaction({
+									sessionId: attemptStore.sessionId!,
+									txId: attemptStore.transactionId,
+								})
+								.catch(() => {})
+
+							if (!isRetryableError(error, idempotent)) {
+								dbg.log('transaction not retryable, aborting')
+								throw new Error('Transaction failed.', { cause: error })
+							}
+
+							throw error
+						} finally {
+							dbg.log('executing %d close hooks', closeHooks.length)
+							await Promise.all(
+								closeHooks.map(async (hook, i) => {
+									dbg.log('executing close hook #%d', i + 1)
+									await hook(committed, signal)
+									dbg.log('close hook #%d completed', i + 1)
+								})
+							)
+						}
 					}
-
-					committed = true
-					dbg.log('transaction committed successfully')
-					return result
-				} catch (error) {
-					dbg.log('transaction error: %O', error)
-
-					// Signal up to the retry callback that this attempt tore down
-					// because the session died — lets it retry with a fresh one
-					// if the caller opted into idempotent retries.
-					if (sessionLease.signal.aborted) {
-						sessionDiedLastAttempt = true
-					}
-
-					dbg.log('executing %d rollback hooks', rollbackHooks.length)
-					await Promise.all(
-						rollbackHooks.map(async (hook, i) => {
-							dbg.log('executing rollback hook #%d', i + 1)
-							await hook(error, signal)
-							dbg.log('rollback hook #%d completed', i + 1)
-						})
-					)
-
-					client
-						.rollbackTransaction({
-							sessionId: attemptStore.sessionId!,
-							txId: attemptStore.transactionId,
-						})
-						.catch(() => {})
-
-					if (!isRetryableError(error, idempotent)) {
-						dbg.log('transaction not retryable, aborting')
-						throw new Error('Transaction failed.', { cause: error })
-					}
-
-					throw error
-				} finally {
-					dbg.log('executing %d close hooks', closeHooks.length)
-					await Promise.all(
-						closeHooks.map(async (hook, i) => {
-							dbg.log('executing close hook #%d', i + 1)
-							await hook(committed, signal)
-							dbg.log('close hook #%d completed', i + 1)
-						})
-					)
-				}
-			}
+				),
+			{ isolation: options.isolation ?? 'serializableReadWrite', idempotent }
 		)
 	}
 

--- a/packages/query/src/query.ts
+++ b/packages/query/src/query.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events'
+import { tracingChannel } from 'node:diagnostics_channel'
 
 import { create } from '@bufbuild/protobuf'
 import { StatusIds_StatusCode } from '@ydbjs/api/operation'
@@ -25,7 +26,6 @@ import {
 import { type Value, fromYdb, toJs } from '@ydbjs/value'
 import { typeToString } from '@ydbjs/value/print'
 import type { Metadata } from 'nice-grpc'
-import { tracingChannel } from 'node:diagnostics_channel'
 
 import { ctx } from './ctx.js'
 import { linkSignals } from '@ydbjs/abortable'
@@ -301,19 +301,20 @@ export class Query<T extends any[] = unknown[]>
 			}
 		}
 
+		const traceRetryAttempt = (retrySignal: AbortSignal) => {
+			attempt++
+			return retryAttemptCh.tracePromise(() => tracedAttempt(retrySignal), {
+				attempt,
+				text: this.text,
+				idempotent: this.#idempotent,
+			})
+		}
+
 		this.#promise = retryRunCh
-			.tracePromise(
-				() =>
-					retry(retryConfig, (retrySignal) => {
-						attempt++
-						return retryAttemptCh.tracePromise(() => tracedAttempt(retrySignal), {
-							attempt,
-							text: this.text,
-							idempotent: this.#idempotent,
-						})
-					}),
-				{ text: this.text, idempotent: this.#idempotent }
-			)
+			.tracePromise(() => retry(retryConfig, traceRetryAttempt), {
+				text: this.text,
+				idempotent: this.#idempotent,
+			})
 			.then((results) => {
 				if (this.#stats) {
 					this.emit('stats', this.#stats)

--- a/packages/query/src/query.ts
+++ b/packages/query/src/query.ts
@@ -29,11 +29,11 @@ import { tracingChannel } from 'node:diagnostics_channel'
 
 import { ctx } from './ctx.js'
 import { linkSignals } from '@ydbjs/abortable'
-import type { SessionPool } from './session-pool.js'
+import { type SessionPool, sessionAcquireCh } from './session-pool.js'
 
-const retryCh = tracingChannel('tracing:@ydbjs:retry')
-const executeQueryCh = tracingChannel('tracing:@ydbjs:query.execute')
-const sessionAcquireCh = tracingChannel('tracing:@ydbjs:session.acquire')
+const retryRunCh = tracingChannel('tracing:ydb:retry.run')
+const retryAttemptCh = tracingChannel('tracing:ydb:retry.attempt')
+const executeQueryCh = tracingChannel('tracing:ydb:query.execute')
 
 let dbg = loggers.query
 
@@ -115,12 +115,6 @@ export class Query<T extends any[] = unknown[]>
 
 	async #execute(): Promise<ArrayifyTuple<T>> {
 		let store = ctx.getStore() || {}
-		// `txSessionId` / `txNodeId` are set only when we run inside a
-		// transaction — the transaction body owns the session. Outside a
-		// transaction they stay undefined and every retry attempt grabs a
-		// fresh lease from the pool. Treating these as closure-local (vs
-		// mutating them per attempt) prevents a released session from being
-		// reused across retries by a different caller.
 		let txSessionId = store.sessionId
 		let txNodeId = store.nodeId
 		let transactionId = store.transactionId
@@ -174,162 +168,149 @@ export class Query<T extends any[] = unknown[]>
 
 		await this.#driver.ready(linkedSignal.signal)
 
-		this.#promise = retryCh
+		let attempt = 0
+
+		const acquireSession = (signal: AbortSignal) =>
+			sessionAcquireCh.tracePromise(() => this.#sessionPool.acquire(signal), {
+				kind: 'query',
+			})
+
+		const tracedAttempt = (retrySignal: AbortSignal) =>
+			executeQueryCh.tracePromise(() => runAttempt(retrySignal), {
+				text: this.text,
+				idempotent: this.#idempotent,
+			})
+
+		const runAttempt = async (retrySignal: AbortSignal) => {
+			// Transaction-owned session stays pinned; out-of-transaction
+			// attempts always get a fresh lease — no cross-attempt reuse.
+			using sessionLease = txSessionId ? undefined : await acquireSession(retrySignal)
+			let attemptSessionId = txSessionId ?? sessionLease!.id
+			let attemptNodeId = txNodeId ?? sessionLease!.nodeId
+
+			// linkSignals cleans up listeners on dispose — no accumulation
+			// on the long-lived session signal across many queries.
+			using linked = linkSignals(retrySignal, sessionLease?.signal)
+			let signal = linked.signal
+
+			if (sessionLease) {
+				dbg.log('acquired session %s from pool', sessionLease.id)
+			}
+
+			dbg.log('creating query client for nodeId: %s', attemptNodeId)
+			let client = this.#driver.createClient(QueryServiceDefinition, attemptNodeId)
+
+			let parameters: Record<string, TypedValue> = {}
+			for (let key in this.#parameters) {
+				parameters[key] = create(TypedValueSchema, {
+					type: this.#parameters[key]!.type.encode(),
+					value: this.#parameters[key]!.encode(),
+				})
+			}
+
+			let txControl: TransactionControl | undefined
+			if (transactionId) {
+				txControl = create(TransactionControlSchema, {
+					txSelector: { case: 'txId', value: transactionId },
+				})
+			} else if (this.#isolation !== 'implicit') {
+				txControl = create(TransactionControlSchema, {
+					commitTx: true,
+					txSelector: {
+						case: 'beginTx',
+						value: {
+							txMode: {
+								case: this.#isolation,
+								value: this.#isolationSettings as {},
+							},
+						},
+					},
+				})
+			}
+
+			try {
+				let stream = client.executeQuery(
+					{
+						sessionId: attemptSessionId,
+						execMode: ExecMode.EXECUTE,
+						query: {
+							case: 'queryContent',
+							value: { syntax: this.#syntax, text: this.text },
+						},
+						parameters,
+						statsMode: this.#statsMode,
+						...(this.#poolId && { poolId: this.#poolId }),
+						...(txControl && { txControl }),
+					},
+					{
+						signal,
+						onTrailer: (trailer) => {
+							this.emit('metadata', trailer)
+						},
+					}
+				)
+
+				let results = [] as ArrayifyTuple<T>
+				for await (let part of stream) {
+					signal.throwIfAborted()
+
+					if (part.status !== StatusIds_StatusCode.SUCCESS) {
+						dbg.log('query part failed, status: %d', part.status)
+						throw new YDBError(part.status, part.issues)
+					}
+
+					if (part.execStats) {
+						dbg.log('received query stats')
+						this.#stats = part.execStats
+					}
+
+					if (!part.resultSet) continue
+
+					while (part.resultSetIndex >= results.length) {
+						results.push([])
+					}
+
+					for (let i = 0; i < part.resultSet.rows.length; i++) {
+						let result: any = this.#values ? [] : {}
+
+						for (let j = 0; j < part.resultSet.columns.length; j++) {
+							let column = part.resultSet.columns[j]!
+							let value = part.resultSet.rows[i]!.items[j]!
+
+							if (this.#values) {
+								result.push(this.#raw ? value : toJs(fromYdb(value, column.type!)))
+								continue
+							}
+
+							result[column.name] = this.#raw
+								? value
+								: toJs(fromYdb(value, column.type!))
+						}
+
+						results[Number(part.resultSetIndex)]!.push(result)
+					}
+				}
+
+				dbg.log('query executed successfully')
+				return results
+			} catch (err) {
+				if (sessionLease?.signal.aborted) {
+					sessionDiedLastAttempt = true
+				}
+				throw err
+			}
+		}
+
+		this.#promise = retryRunCh
 			.tracePromise(
 				() =>
-					retry(retryConfig, async (retrySignal) => {
-						// Transaction-owned session stays pinned; out-of-transaction
-						// attempts always get a fresh lease — no cross-attempt reuse.
-						using sessionLease = txSessionId
-							? undefined
-							: await sessionAcquireCh.tracePromise(
-									() => this.#sessionPool.acquire(retrySignal),
-									{}
-								)
-						let attemptSessionId = txSessionId ?? sessionLease!.id
-						let attemptNodeId = txNodeId ?? sessionLease!.nodeId
-
-						// linkSignals cleans up listeners on dispose — no accumulation
-						// on the long-lived session signal across many queries.
-						using linked = linkSignals(retrySignal, sessionLease?.signal)
-						let signal = linked.signal
-
-						if (sessionLease) {
-							dbg.log('acquired session %s from pool', sessionLease.id)
-						}
-
-						dbg.log('creating query client for nodeId: %s', attemptNodeId)
-						let client = this.#driver.createClient(
-							QueryServiceDefinition,
-							attemptNodeId
-						)
-
-						let parameters: Record<string, TypedValue> = {}
-						for (let key in this.#parameters) {
-							parameters[key] = create(TypedValueSchema, {
-								type: this.#parameters[key]!.type.encode(),
-								value: this.#parameters[key]!.encode(),
-							})
-						}
-
-						// If we have a transactionId, we should use it
-						// If we have an isolation level, we should use it
-						let txControl: TransactionControl | undefined
-						if (transactionId) {
-							txControl = create(TransactionControlSchema, {
-								txSelector: {
-									case: 'txId',
-									value: transactionId,
-								},
-							})
-						} else if (this.#isolation !== 'implicit') {
-							txControl = create(TransactionControlSchema, {
-								commitTx: true,
-								txSelector: {
-									case: 'beginTx',
-									value: {
-										txMode: {
-											case: this.#isolation,
-											value: this.#isolationSettings as {},
-										},
-									},
-								},
-							})
-						}
-
-						try {
-							return await executeQueryCh.tracePromise(
-								async () => {
-									let stream = client.executeQuery(
-										{
-											sessionId: attemptSessionId,
-											execMode: ExecMode.EXECUTE,
-											query: {
-												case: 'queryContent',
-												value: {
-													syntax: this.#syntax,
-													text: this.text,
-												},
-											},
-											parameters,
-											statsMode: this.#statsMode,
-											...(this.#poolId && { poolId: this.#poolId }),
-											...(txControl && { txControl }),
-										},
-										{
-											signal,
-											onTrailer: (trailer) => {
-												this.emit('metadata', trailer)
-											},
-										}
-									)
-
-									let results = [] as ArrayifyTuple<T>
-									for await (let part of stream) {
-										signal.throwIfAborted()
-
-										if (part.status !== StatusIds_StatusCode.SUCCESS) {
-											dbg.log('query part failed, status: %d', part.status)
-											throw new YDBError(part.status, part.issues)
-										}
-
-										if (part.execStats) {
-											dbg.log('received query stats')
-											this.#stats = part.execStats
-										}
-
-										if (!part.resultSet) {
-											continue
-										}
-
-										while (part.resultSetIndex >= results.length) {
-											results.push([])
-										}
-
-										for (let i = 0; i < part.resultSet.rows.length; i++) {
-											let result: any = this.#values ? [] : {}
-
-											for (
-												let j = 0;
-												j < part.resultSet.columns.length;
-												j++
-											) {
-												let column = part.resultSet.columns[j]!
-												let value = part.resultSet.rows[i]!.items[j]!
-
-												if (this.#values) {
-													result.push(
-														this.#raw
-															? value
-															: toJs(fromYdb(value, column.type!))
-													)
-													continue
-												}
-
-												result[column.name] = this.#raw
-													? value
-													: toJs(fromYdb(value, column.type!))
-											}
-
-											results[Number(part.resultSetIndex)]!.push(result)
-										}
-									}
-
-									dbg.log('query executed successfully')
-									return results
-								},
-								{
-									text: this.text,
-									sessionId: attemptSessionId,
-									idempotent: this.#idempotent,
-								}
-							)
-						} catch (err) {
-							if (sessionLease?.signal.aborted) {
-								sessionDiedLastAttempt = true
-							}
-							throw err
-						}
+					retry(retryConfig, (retrySignal) => {
+						attempt++
+						return retryAttemptCh.tracePromise(() => tracedAttempt(retrySignal), {
+							attempt,
+							text: this.text,
+							idempotent: this.#idempotent,
+						})
 					}),
 				{ text: this.text, idempotent: this.#idempotent }
 			)

--- a/packages/query/src/query.ts
+++ b/packages/query/src/query.ts
@@ -25,10 +25,15 @@ import {
 import { type Value, fromYdb, toJs } from '@ydbjs/value'
 import { typeToString } from '@ydbjs/value/print'
 import type { Metadata } from 'nice-grpc'
+import { tracingChannel } from 'node:diagnostics_channel'
 
 import { ctx } from './ctx.js'
 import { linkSignals } from '@ydbjs/abortable'
 import type { SessionPool } from './session-pool.js'
+
+const retryCh = tracingChannel('tracing:@ydbjs:retry')
+const executeQueryCh = tracingChannel('tracing:@ydbjs:query.execute')
+const sessionAcquireCh = tracingChannel('tracing:@ydbjs:session.acquire')
 
 let dbg = loggers.query
 
@@ -169,141 +174,165 @@ export class Query<T extends any[] = unknown[]>
 
 		await this.#driver.ready(linkedSignal.signal)
 
-		this.#promise = retry(retryConfig, async (retrySignal) => {
-			// Transaction-owned session stays pinned; out-of-transaction
-			// attempts always get a fresh lease — no cross-attempt reuse.
-			using sessionLease = txSessionId
-				? undefined
-				: await this.#sessionPool.acquire(retrySignal)
-			let attemptSessionId = txSessionId ?? sessionLease!.id
-			let attemptNodeId = txNodeId ?? sessionLease!.nodeId
+		this.#promise = retryCh
+			.tracePromise(
+				() =>
+					retry(retryConfig, async (retrySignal) => {
+						// Transaction-owned session stays pinned; out-of-transaction
+						// attempts always get a fresh lease — no cross-attempt reuse.
+						using sessionLease = txSessionId
+							? undefined
+							: await sessionAcquireCh.tracePromise(
+									() => this.#sessionPool.acquire(retrySignal),
+									{}
+								)
+						let attemptSessionId = txSessionId ?? sessionLease!.id
+						let attemptNodeId = txNodeId ?? sessionLease!.nodeId
 
-			// linkSignals cleans up listeners on dispose — no accumulation
-			// on the long-lived session signal across many queries.
-			using linked = linkSignals(retrySignal, sessionLease?.signal)
-			let signal = linked.signal
+						// linkSignals cleans up listeners on dispose — no accumulation
+						// on the long-lived session signal across many queries.
+						using linked = linkSignals(retrySignal, sessionLease?.signal)
+						let signal = linked.signal
 
-			if (sessionLease) {
-				dbg.log('acquired session %s from pool', sessionLease.id)
-			}
-
-			dbg.log('creating query client for nodeId: %s', attemptNodeId)
-			let client = this.#driver.createClient(QueryServiceDefinition, attemptNodeId)
-
-			let parameters: Record<string, TypedValue> = {}
-			for (let key in this.#parameters) {
-				parameters[key] = create(TypedValueSchema, {
-					type: this.#parameters[key]!.type.encode(),
-					value: this.#parameters[key]!.encode(),
-				})
-			}
-
-			// If we have a transactionId, we should use it
-			// If we have an isolation level, we should use it
-			let txControl: TransactionControl | undefined
-			if (transactionId) {
-				txControl = create(TransactionControlSchema, {
-					txSelector: {
-						case: 'txId',
-						value: transactionId,
-					},
-				})
-			} else if (this.#isolation !== 'implicit') {
-				txControl = create(TransactionControlSchema, {
-					commitTx: true,
-					txSelector: {
-						case: 'beginTx',
-						value: {
-							txMode: {
-								case: this.#isolation,
-								value: this.#isolationSettings as {},
-							},
-						},
-					},
-				})
-			}
-
-			let stream = client.executeQuery(
-				{
-					sessionId: attemptSessionId,
-					execMode: ExecMode.EXECUTE,
-					query: {
-						case: 'queryContent',
-						value: {
-							syntax: this.#syntax,
-							text: this.text,
-						},
-					},
-					parameters,
-					statsMode: this.#statsMode,
-					...(this.#poolId && { poolId: this.#poolId }),
-					...(txControl && { txControl }),
-				},
-				{
-					signal,
-					onTrailer: (trailer) => {
-						this.emit('metadata', trailer)
-					},
-				}
-			)
-
-			let results = [] as ArrayifyTuple<T>
-
-			try {
-				for await (let part of stream) {
-					signal.throwIfAborted()
-
-					if (part.status !== StatusIds_StatusCode.SUCCESS) {
-						dbg.log('query part failed, status: %d', part.status)
-						throw new YDBError(part.status, part.issues)
-					}
-
-					if (part.execStats) {
-						dbg.log('received query stats')
-						this.#stats = part.execStats
-					}
-
-					if (!part.resultSet) {
-						continue
-					}
-
-					while (part.resultSetIndex >= results.length) {
-						results.push([])
-					}
-
-					for (let i = 0; i < part.resultSet.rows.length; i++) {
-						let result: any = this.#values ? [] : {}
-
-						for (let j = 0; j < part.resultSet.columns.length; j++) {
-							let column = part.resultSet.columns[j]!
-							let value = part.resultSet.rows[i]!.items[j]!
-
-							if (this.#values) {
-								result.push(this.#raw ? value : toJs(fromYdb(value, column.type!)))
-								continue
-							}
-
-							result[column.name] = this.#raw
-								? value
-								: toJs(fromYdb(value, column.type!))
+						if (sessionLease) {
+							dbg.log('acquired session %s from pool', sessionLease.id)
 						}
 
-						results[Number(part.resultSetIndex)]!.push(result)
-					}
-				}
-			} catch (err) {
-				// Record whether this attempt failed because the session died.
-				// The retry callback uses this to decide — together with the
-				// idempotent flag — whether to retry against a fresh session.
-				if (sessionLease?.signal.aborted) {
-					sessionDiedLastAttempt = true
-				}
-				throw err
-			}
+						dbg.log('creating query client for nodeId: %s', attemptNodeId)
+						let client = this.#driver.createClient(
+							QueryServiceDefinition,
+							attemptNodeId
+						)
 
-			dbg.log('query executed successfully')
-			return results
-		})
+						let parameters: Record<string, TypedValue> = {}
+						for (let key in this.#parameters) {
+							parameters[key] = create(TypedValueSchema, {
+								type: this.#parameters[key]!.type.encode(),
+								value: this.#parameters[key]!.encode(),
+							})
+						}
+
+						// If we have a transactionId, we should use it
+						// If we have an isolation level, we should use it
+						let txControl: TransactionControl | undefined
+						if (transactionId) {
+							txControl = create(TransactionControlSchema, {
+								txSelector: {
+									case: 'txId',
+									value: transactionId,
+								},
+							})
+						} else if (this.#isolation !== 'implicit') {
+							txControl = create(TransactionControlSchema, {
+								commitTx: true,
+								txSelector: {
+									case: 'beginTx',
+									value: {
+										txMode: {
+											case: this.#isolation,
+											value: this.#isolationSettings as {},
+										},
+									},
+								},
+							})
+						}
+
+						try {
+							return await executeQueryCh.tracePromise(
+								async () => {
+									let stream = client.executeQuery(
+										{
+											sessionId: attemptSessionId,
+											execMode: ExecMode.EXECUTE,
+											query: {
+												case: 'queryContent',
+												value: {
+													syntax: this.#syntax,
+													text: this.text,
+												},
+											},
+											parameters,
+											statsMode: this.#statsMode,
+											...(this.#poolId && { poolId: this.#poolId }),
+											...(txControl && { txControl }),
+										},
+										{
+											signal,
+											onTrailer: (trailer) => {
+												this.emit('metadata', trailer)
+											},
+										}
+									)
+
+									let results = [] as ArrayifyTuple<T>
+									for await (let part of stream) {
+										signal.throwIfAborted()
+
+										if (part.status !== StatusIds_StatusCode.SUCCESS) {
+											dbg.log('query part failed, status: %d', part.status)
+											throw new YDBError(part.status, part.issues)
+										}
+
+										if (part.execStats) {
+											dbg.log('received query stats')
+											this.#stats = part.execStats
+										}
+
+										if (!part.resultSet) {
+											continue
+										}
+
+										while (part.resultSetIndex >= results.length) {
+											results.push([])
+										}
+
+										for (let i = 0; i < part.resultSet.rows.length; i++) {
+											let result: any = this.#values ? [] : {}
+
+											for (
+												let j = 0;
+												j < part.resultSet.columns.length;
+												j++
+											) {
+												let column = part.resultSet.columns[j]!
+												let value = part.resultSet.rows[i]!.items[j]!
+
+												if (this.#values) {
+													result.push(
+														this.#raw
+															? value
+															: toJs(fromYdb(value, column.type!))
+													)
+													continue
+												}
+
+												result[column.name] = this.#raw
+													? value
+													: toJs(fromYdb(value, column.type!))
+											}
+
+											results[Number(part.resultSetIndex)]!.push(result)
+										}
+									}
+
+									dbg.log('query executed successfully')
+									return results
+								},
+								{
+									text: this.text,
+									sessionId: attemptSessionId,
+									idempotent: this.#idempotent,
+								}
+							)
+						} catch (err) {
+							if (sessionLease?.signal.aborted) {
+								sessionDiedLastAttempt = true
+							}
+							throw err
+						}
+					}),
+				{ text: this.text, idempotent: this.#idempotent }
+			)
 			.then((results) => {
 				if (this.#stats) {
 					this.emit('stats', this.#stats)

--- a/packages/query/src/query.ts
+++ b/packages/query/src/query.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events'
 import { tracingChannel } from 'node:diagnostics_channel'
 
 import { create } from '@bufbuild/protobuf'
+import { linkSignals } from '@ydbjs/abortable'
 import { StatusIds_StatusCode } from '@ydbjs/api/operation'
 import {
 	ExecMode,
@@ -28,12 +29,11 @@ import { typeToString } from '@ydbjs/value/print'
 import type { Metadata } from 'nice-grpc'
 
 import { ctx } from './ctx.js'
-import { linkSignals } from '@ydbjs/abortable'
 import { type SessionPool, sessionAcquireCh } from './session-pool.js'
 
-const retryRunCh = tracingChannel('tracing:ydb:retry.run')
-const retryAttemptCh = tracingChannel('tracing:ydb:retry.attempt')
-const executeQueryCh = tracingChannel('tracing:ydb:query.execute')
+let retryRunCh = tracingChannel('tracing:ydb:retry.run')
+let retryAttemptCh = tracingChannel('tracing:ydb:retry.attempt')
+let executeQueryCh = tracingChannel('tracing:ydb:query.execute')
 
 let dbg = loggers.query
 
@@ -170,18 +170,18 @@ export class Query<T extends any[] = unknown[]>
 
 		let attempt = 0
 
-		const acquireSession = (signal: AbortSignal) =>
+		let acquireSession = (signal: AbortSignal) =>
 			sessionAcquireCh.tracePromise(() => this.#sessionPool.acquire(signal), {
 				kind: 'query',
 			})
 
-		const tracedAttempt = (retrySignal: AbortSignal) =>
+		let tracedAttempt = (retrySignal: AbortSignal) =>
 			executeQueryCh.tracePromise(() => runAttempt(retrySignal), {
 				text: this.text,
 				idempotent: this.#idempotent,
 			})
 
-		const runAttempt = async (retrySignal: AbortSignal) => {
+		let runAttempt = async (retrySignal: AbortSignal) => {
 			// Transaction-owned session stays pinned; out-of-transaction
 			// attempts always get a fresh lease — no cross-attempt reuse.
 			using sessionLease = txSessionId ? undefined : await acquireSession(retrySignal)
@@ -301,7 +301,7 @@ export class Query<T extends any[] = unknown[]>
 			}
 		}
 
-		const traceRetryAttempt = (retrySignal: AbortSignal) => {
+		let traceRetryAttempt = (retrySignal: AbortSignal) => {
 			attempt++
 			return retryAttemptCh.tracePromise(() => tracedAttempt(retrySignal), {
 				attempt,

--- a/packages/query/src/session-pool.ts
+++ b/packages/query/src/session-pool.ts
@@ -28,8 +28,8 @@ import type { Driver } from '@ydbjs/core'
 import { loggers } from '@ydbjs/debug'
 import { Session } from './session.js'
 
-export const sessionAcquireCh = tracingChannel('tracing:ydb:session.acquire')
-const sessionCreateCh = tracingChannel('tracing:ydb:session.create')
+export let sessionAcquireCh = tracingChannel('tracing:ydb:session.acquire')
+let sessionCreateCh = tracingChannel('tracing:ydb:session.create')
 
 let dbg = loggers.query.extend('pool2')
 
@@ -54,7 +54,7 @@ export type SessionPoolOptions = {
 	waitQueueFactor?: number
 }
 
-const DEFAULTS = {
+let DEFAULTS = {
 	maxSize: 50,
 	waitQueueFactor: 8,
 } satisfies Required<SessionPoolOptions>
@@ -239,7 +239,7 @@ export class SessionPool implements AsyncDisposable {
 		// many concurrent creates fan out.
 		using linked = linkSignals(signal, this.#close.signal)
 
-		const createCtx = {
+		let createCtx = {
 			poolSize: this.#all.size,
 			maxSize: this.#maxSize,
 		}

--- a/packages/query/src/session-pool.ts
+++ b/packages/query/src/session-pool.ts
@@ -21,10 +21,15 @@
  *     hot session serving N queries would accumulate N listeners.
  */
 
+import { channel as dcChannel, tracingChannel } from 'node:diagnostics_channel'
+
 import { linkSignals } from '@ydbjs/abortable'
 import type { Driver } from '@ydbjs/core'
 import { loggers } from '@ydbjs/debug'
 import { Session } from './session.js'
+
+export const sessionAcquireCh = tracingChannel('tracing:ydb:session.acquire')
+const sessionCreateCh = tracingChannel('tracing:ydb:session.create')
 
 let dbg = loggers.query.extend('pool2')
 
@@ -195,7 +200,10 @@ export class SessionPool implements AsyncDisposable {
 		this.#all.clear()
 		this.#available.length = 0
 		// close() is sync + fire-and-forget — no need to await each RPC.
-		for (let s of sessions) s.close()
+		for (let s of sessions) {
+			s.close()
+			dcChannel('ydb:session.destroyed').publish({ sessionId: s.id, nodeId: s.nodeId })
+		}
 		dbg.log('pool closed (%d sessions)', sessions.length)
 	}
 
@@ -230,7 +238,12 @@ export class SessionPool implements AsyncDisposable {
 		// close) when the block exits — no accumulation on #close.signal as
 		// many concurrent creates fan out.
 		using linked = linkSignals(signal, this.#close.signal)
-		let promise = Session.open(this.#driver, linked.signal)
+
+		const createCtx = {}
+		let promise = sessionCreateCh.tracePromise(
+			() => Session.open(this.#driver, linked.signal),
+			createCtx
+		)
 		this.#creates.add(promise)
 
 		try {
@@ -244,6 +257,10 @@ export class SessionPool implements AsyncDisposable {
 
 			this.#all.add(session)
 			this.#bindEviction(session)
+			dcChannel('ydb:session.created').publish({
+				sessionId: session.id,
+				nodeId: session.nodeId,
+			})
 			return session
 		} finally {
 			this.#creates.delete(promise)
@@ -258,6 +275,10 @@ export class SessionPool implements AsyncDisposable {
 				let idx = this.#available.indexOf(session)
 				if (idx !== -1) this.#available.splice(idx, 1)
 				dbg.log('evicted session %s', session.id)
+				dcChannel('ydb:session.evicted').publish({
+					sessionId: session.id,
+					nodeId: session.nodeId,
+				})
 				this.#pumpWaitersAfterEviction()
 			},
 			{ once: true }

--- a/packages/query/src/session-pool.ts
+++ b/packages/query/src/session-pool.ts
@@ -239,7 +239,10 @@ export class SessionPool implements AsyncDisposable {
 		// many concurrent creates fan out.
 		using linked = linkSignals(signal, this.#close.signal)
 
-		const createCtx = {}
+		const createCtx = {
+			poolSize: this.#all.size,
+			maxSize: this.#maxSize,
+		}
 		let promise = sessionCreateCh.tracePromise(
 			() => Session.open(this.#driver, linked.signal),
 			createCtx


### PR DESCRIPTION
Продублирую для удобства: 

### Идея

`@ydbjs/query` и `@ydbjs/core` публикуют доменные события через `node:diagnostics_channel` (стабилен с Node 19.9, работает в Bun и Deno через `node:` compat). `@ydbjs/telemetry` — отдельный подписчик, который превращает события в OTel-спаны. Ключевой механизм — `TracingChannel`: брекетит функцию событиями `start`/`asyncEnd`/`error` и даёт общий `context`-объект между ними.

**Издатель** — внутри `@ydbjs/query`:

```ts
import dc from 'node:diagnostics_channel'
const execCh = dc.tracingChannel('tracing:@ydbjs:query.execute')

async #execute() {
  return execCh.tracePromise(
    async () => { /* существующий код #execute без изменений */ },
    { text: this.text, sessionId, idempotent: this.#idempotent }
  )
}
```

**Подписчик** — внутри `@ydbjs/telemetry`:

```ts
dc.tracingChannel('tracing:@ydbjs:query.execute').subscribe({
  start(ctx) {
    ctx.span = tracer.startSpan('ydb.ExecuteQuery', {
      attributes: { 'db.query.text': ctx.text, 'db.system.name': 'ydb' },
    })
  },
  asyncEnd(ctx) { ctx.span.end() },
  error(ctx) { ctx.span.recordException(ctx.error); ctx.span.setStatus({ code: 2 }) },
})
```

### Что это даёт

- **`core` и `retry` не трогаются.** Уходят `onBeforeCall`, `RetryHooks`, `retryHooks` в `DriverOptions` — регрессии из исходного ревью (в т.ч. пропавший `x-ydb-sdk-build-info`) автоматически не возникают.
- **Нулевая стоимость без подписчиков** — `TracingChannel.tracePromise` короткозамыкается на `hasSubscribers`.
- **ALS propagation из коробки** — OTel context распространяется через `tracePromise` автоматически, retry-иерархия (`ydb.RunWithRetry` → `ydb.Try` → `ydb.ExecuteQuery`) получается сама собой без `currentTrySpan` в замыкании.
- **Мульти-подписчики** — OTel, Datadog, Pino, custom logger параллельно на одних каналах.
- **Traceparent пробрасывается `nice-grpc` middleware**, которую телеметрия подкладывает при оборачивании клиента — без `onBeforeCall` в `hooks.ts`.
- **Zero-config режим** — `@ydbjs/telemetry/register` через `node --import` (паттерн OTel auto-instrumentations) оборачивает `query()` снаружи без строчки кода у пользователя.

### Публичный контракт каналов

```
tracing:@ydbjs:query.execute       — одна попытка ExecuteQuery
tracing:@ydbjs:query.transaction   — begin..commit
tracing:@ydbjs:session.acquire     — ожидание сессии
tracing:@ydbjs:retry               — обёртка retry() (родитель attempts)
ydb:discovery                      — обычный channel.publish
ydb:pessimize
```

Имена — часть public API, стабилизировать по SemVer.


### Матрица выбора

| Примитив | Когда | Примеры |
|---|---|---|
| `tracingChannel(name)` | Операция с длительностью и возможной ошибкой (`start` → `asyncEnd`/`error`) | `query.execute`, `session.acquire`, `tx.commit`, `retry.run`, `retry.attempt` |
| `channel(name).publish(payload)` | Точечное событие — факт или дельта состояния | `discovery.completed`, `pool.pessimize`, `pool.unpessimize`, `pool.connection.add/remove`, `session.create/destroy`, `token.refreshed` |

### Антипаттерны

- **`tracingChannel` на pessimize/unpessimize.** Это state change, не операция — брекетить нечего. → `channel.publish`.
- **`channel.publish` на `query.execute`.** Потеряется duration и `error`-подканал, OTel-подписчик не соберёт ни span, ни latency histogram. → `tracingChannel`.
- **Публичный getter состояния пула — преждевременно.** Метрики состояния (active, pessimized, idle sessions) реконструируются подписчиком через дельта-события (`pool.connection.add` → `+1 active`, `pool.pessimize` → `-1 active, +1 pessimized` и т.д.). Это не требует фиксировать `driver.stats()` в SemVer-стабильной поверхности и оставляет свободу менять внутренности пула. Если когда-то понадобится snapshot-аксессор — вернёмся отдельно.
- **Один канал на несколько операций.** `tracing:@ydbjs:query` куда идут и execute, и tx, и session → подписчик парсит `context.kind`. Заведите отдельные каналы с явными именами.
- **Внутренние типы в `context`.** `context` в `TracingChannel` — публичный контракт, такой же как имя канала. Только примитивы и стабильные поля: `sessionId: string`, `nodeId: bigint`, но не `sessionLease` и не `#connection`. Смена структуры = SemVer major.

### Именование

`tracing:<package>:<operation>` для TracingChannel, `<package>:<event>` для обычных каналов — конвенция из Node docs, OTel subscriber'ы ожидают префикс `tracing:`.
