### PR TITLE
Instrument SDK with node:diagnostics_channel

### DIFF
--- a/.changeset/auth-diagnostics-channel.md
+++ b/.changeset/auth-diagnostics-channel.md
@@ -1,0 +1,16 @@
+---
+'@ydbjs/auth': minor
+---
+
+Publish credentials-provider events on `node:diagnostics_channel`.
+
+New channels:
+
+- `tracing:ydb:auth.token.fetch` — span around the full token fetch, including retries. Context: `{ provider }`.
+- `ydb:auth.token.refreshed` — `{ provider, expiresAt }` (unix ms). Single, monotonic timestamp instead of per-provider `expiresIn` semantics.
+- `ydb:auth.token.expired` — `{ provider, stalenessMs }`. Fires once per expiration incident, not per call.
+- `ydb:auth.provider.failed` — `{ provider, error }`. Fires after all retries are exhausted.
+
+`provider` is an open string set. Built-in values: `'static'`, `'metadata'`, plus values contributed by external providers (e.g. `'yc-service-account'` from `@ydbjs/auth-yandex-cloud`). Custom `CredentialsProvider` implementations should mint a stable, namespaced provider id.
+
+Channel names and payload fields are part of the public API. See `packages/auth/README.md` for the full contract and a warning about safe subscribers.

--- a/.changeset/auth-yandex-cloud-diagnostics-channel.md
+++ b/.changeset/auth-yandex-cloud-diagnostics-channel.md
@@ -1,0 +1,14 @@
+---
+'@ydbjs/auth-yandex-cloud': minor
+---
+
+Participate in the `node:diagnostics_channel` surface defined by `@ydbjs/auth`.
+
+`ServiceAccountCredentialsProvider` now publishes:
+
+- `tracing:ydb:auth.token.fetch` — span around `getToken()` with `provider: 'yc-service-account'`.
+- `ydb:auth.token.refreshed` — `{ provider, expiresAt }` after a successful IAM token exchange.
+- `ydb:auth.token.expired` — `{ provider, stalenessMs }`, once per incident.
+- `ydb:auth.provider.failed` — `{ provider, error }` when all retries are exhausted.
+
+Retry attempts inside the IAM exchange are visible on `tracing:ydb:retry.*` from `@ydbjs/retry`. See `@ydbjs/auth` README for the full channel contract and the warning about safe subscribers.

--- a/.changeset/core-diagnostics-channel.md
+++ b/.changeset/core-diagnostics-channel.md
@@ -1,0 +1,14 @@
+---
+'@ydbjs/core': minor
+---
+
+Publish driver, discovery, and connection-pool events on `node:diagnostics_channel` so external subscribers can build traces, metrics, and logs.
+
+New channels:
+
+- `ydb:driver.ready`, `ydb:driver.failed`, `ydb:driver.closed` — driver lifecycle.
+- `tracing:ydb:discovery` — discovery round span.
+- `ydb:discovery.completed` — per-round delta.
+- `ydb:pool.connection.added`, `pessimized`, `unpessimized`, `retired`, `removed` — connection-pool state changes.
+
+Channel names and payload fields are part of the public API. See `packages/core/README.md` for the full table and a warning about safe subscribers (DC publishes synchronously — a throwing subscriber will disrupt the SDK).

--- a/.changeset/diagnostics-followup-fixes.md
+++ b/.changeset/diagnostics-followup-fixes.md
@@ -1,0 +1,27 @@
+---
+'@ydbjs/query': minor
+'@ydbjs/core': patch
+'@ydbjs/retry': patch
+'@ydbjs/auth': patch
+---
+
+Follow-ups to the `node:diagnostics_channel` instrumentation:
+
+`@ydbjs/query` — new tracing channels around transaction control RPCs:
+
+- `tracing:ydb:query.begin` — `BeginTransaction`. Context: `{ sessionId, nodeId, isolation }`.
+- `tracing:ydb:query.commit` — `CommitTransaction`. Context: `{ sessionId, nodeId, txId }`.
+- `tracing:ydb:query.rollback` — `RollbackTransaction`. Context: `{ sessionId, nodeId, txId }`. Fire-and-forget — `start` always fires, `asyncEnd` may land after the surrounding `query.transaction.error`.
+
+`tracing:ydb:query.execute` is reserved for `ExecuteQuery` RPCs only; subscribers building per-statement metrics should not expect `query.execute` events for begin/commit/rollback.
+
+Bug fixes:
+
+- `@ydbjs/query` — releasing a checked-out session after `pool.close()` no longer publishes `ydb:session.closed` twice. The eviction listener is detached before `session.close()` fires its abort.
+- `@ydbjs/core` — `Driver.close()` now cancels in-flight discovery and rejects pending `ready()` waiters. `ydb:driver.ready` / `ydb:driver.failed` no longer fire after `ydb:driver.closed`.
+- `@ydbjs/core` — `pool.pessimize()` only publishes `ydb:pool.connection.pessimized` (and calls the `onPessimize` hook) on the active→pessimized transition. Repeated pessimize calls that just refresh the timeout are now silent, so subscribers reconstructing pool state from delta events don't see phantom transitions.
+
+Documentation contract clarifications (no behavior change, but subscribers built from the previous wording were wrong):
+
+- `@ydbjs/retry` — `tracing:ydb:retry.attempt.error` fires for **every** failed attempt, including the final non-retried one. The README previously implied it fires only for attempts that will be retried.
+- `@ydbjs/auth` — the `provider` field is an open string set (custom `CredentialsProvider` implementations may contribute new values), not an enum. Subscribers should treat it as a label rather than write exhaustive switches.

--- a/.changeset/query-diagnostics-channel.md
+++ b/.changeset/query-diagnostics-channel.md
@@ -1,0 +1,18 @@
+---
+'@ydbjs/query': minor
+---
+
+Publish query, transaction, and session-pool events on `node:diagnostics_channel`.
+
+New channels:
+
+- `tracing:ydb:query.execute` — span around a single `ExecuteQuery` RPC. Context: `{ text, sessionId, nodeId, idempotent, isolation, stage }`. `stage` is `'standalone' | 'tx' | 'do'`.
+- `tracing:ydb:query.transaction` — span around `tx.begin` → `commit`/`rollback` including retries. Context: `{ isolation, idempotent }`.
+- `tracing:ydb:session.acquire` — span around `pool.acquire()`. Context: `{ kind: 'query' | 'transaction' }`.
+- `tracing:ydb:session.create` — span around `Session.open()` when the pool grows. Context: `{ liveSessions, maxSize, creating }`.
+- `ydb:session.created` — `{ sessionId, nodeId }`.
+- `ydb:session.closed` — `{ sessionId, nodeId, reason, uptime }` with `reason: 'evicted' | 'pool_close'`. Fires exactly once per session, replacing the previous pair of `evicted` + `destroyed` events (which could double-fire on `pool.close()`).
+
+Retry-loop spans (`tracing:ydb:retry.*`) come from `@ydbjs/retry` and nest under `query.transaction` / `query.execute` via `AsyncLocalStorage` propagation — no per-callsite retry channel imports needed.
+
+Channel names, payload fields, and the `stage` / `reason` / `kind` enums are part of the public API. See `packages/query/README.md` for the full contract and a warning about safe subscribers.

--- a/.changeset/retry-diagnostics-channel.md
+++ b/.changeset/retry-diagnostics-channel.md
@@ -1,0 +1,15 @@
+---
+'@ydbjs/retry': minor
+---
+
+Publish retry-loop and per-attempt events on `node:diagnostics_channel`.
+
+New channels:
+
+- `tracing:ydb:retry.run` — span around the whole retry loop. Context: `{ idempotent }`.
+- `tracing:ydb:retry.attempt` — span around each attempt (numbered from 1). Context: `{ attempt, idempotent }`.
+- `ydb:retry.exhausted` — publish event when the loop exits without success. Payload: `{ attempts, totalDuration, lastError }`.
+
+Every consumer of `retry()` (driver discovery, query execution, transactions, auth token refresh) now produces a unified retry-span hierarchy automatically — no per-callsite imports needed.
+
+Channel names and payload fields are part of the public API. See `packages/retry/README.md` for the full table and a warning about safe subscribers.

--- a/examples/diagnostics/README.md
+++ b/examples/diagnostics/README.md
@@ -1,0 +1,80 @@
+# YDB Diagnostics Channel Example
+
+Subscribes to every `node:diagnostics_channel` event published by the SDK
+packages (`@ydbjs/core`, `@ydbjs/retry`, `@ydbjs/auth`, `@ydbjs/query`),
+runs one `SELECT` and one transaction, and prints the full event stack to
+the console in the order the events fire.
+
+The goal is to show how a single subscriber can build traces, metrics, and
+logs on top of the SDK without pulling in OpenTelemetry or any other
+telemetry stack.
+
+## Run
+
+```sh
+npm install
+YDB_CONNECTION_STRING=grpc://localhost:2136/local npm start
+```
+
+Default connection string: `grpc://localhost:2136/local`.
+
+Discovery is **off by default** because containerised local-ydb advertises
+an internal hostname that's unreachable from the host. To see the full
+discovery / pool flow (`tracing:ydb:discovery`, `ydb:pool.connection.added`,
+…), run a `local-ydb` container with `--hostname localhost` and pass
+`ENABLE_DISCOVERY=1`:
+
+```sh
+docker run -d --rm --name ydb-diag-demo --hostname localhost \
+  -p 2136:2136 ydbplatform/local-ydb:latest
+
+ENABLE_DISCOVERY=1 \
+  YDB_CONNECTION_STRING=grpc://localhost:2136/local \
+  npm start
+```
+
+## Sample output (default run, discovery off)
+
+```
+# diagnostics example, connecting to grpc://localhost:2136/local
+# discovery=off
+
++    7.0ms ● ydb:driver.ready  database="/local" duration=4.3
+
+# 1. single-shot SELECT 1
+
++    8.0ms ┌─ tracing:ydb:retry.run  idempotent=false
++    8.2ms   ┌─ tracing:ydb:retry.attempt  attempt=1 idempotent=false
++    8.3ms     ┌─ tracing:ydb:session.acquire  kind="query"
++    8.4ms       ┌─ tracing:ydb:session.create  liveSessions=0 maxSize=50 creating=0
++   30.0ms       └─ tracing:ydb:session.create ✓
++   30.1ms       ● ydb:session.created  sessionId="ydb://session/3?…" nodeId=1n
++   30.2ms     └─ tracing:ydb:session.acquire ✓
++   30.3ms     ┌─ tracing:ydb:query.execute  text="SELECT 1 AS n" sessionId="…" nodeId=1n idempotent=false isolation="implicit" stage="standalone"
++   38.2ms     └─ tracing:ydb:query.execute ✓
++   38.3ms   └─ tracing:ydb:retry.attempt ✓
++   38.4ms └─ tracing:ydb:retry.run ✓
+
+  → result: {"n":1}
+```
+
+With `ENABLE_DISCOVERY=1` the run additionally emits `tracing:ydb:discovery`,
+`ydb:pool.connection.added`, and `ydb:discovery.completed` before the first
+query.
+
+## What you can learn from this
+
+- **Event ordering**. `tracing:` channels fire `start` before the work
+  begins and `asyncEnd` after it completes; nesting reflects the actual
+  call hierarchy via `AsyncLocalStorage`.
+- **Retry hierarchy**. `tracing:ydb:retry.*` come from `@ydbjs/retry` and
+  nest under whichever caller invoked `retry()` — discovery, query,
+  transaction, auth — without any per-callsite import.
+- **Public contract**. The channel names and payload fields you see here
+  are SemVer-stable. See each package's README for the full table.
+
+## Important
+
+`node:diagnostics_channel` invokes subscribers **synchronously**. A
+subscriber that throws will disrupt the SDK. Wrap your real subscriber
+logic in `try/catch`.

--- a/examples/diagnostics/index.js
+++ b/examples/diagnostics/index.js
@@ -1,0 +1,191 @@
+/**
+ * YDB Diagnostics Channel Example
+ *
+ * Подписывается на все события `node:diagnostics_channel`, которые публикуют
+ * пакеты SDK (`@ydbjs/core`, `@ydbjs/retry`, `@ydbjs/auth`, `@ydbjs/query`),
+ * выполняет один SELECT и одну транзакцию, и печатает весь стек событий в
+ * консоль в порядке их возникновения.
+ *
+ * Цель — показать, как один телеметрический подписчик может построить трейсы,
+ * метрики и логи поверх SDK, не подключая никакие OTel зависимости.
+ *
+ * Запуск:
+ *   YDB_CONNECTION_STRING=grpc://localhost:2136/local node index.js
+ */
+
+import { subscribe, tracingChannel } from 'node:diagnostics_channel'
+import { performance } from 'node:perf_hooks'
+
+import { Driver } from '@ydbjs/core'
+import { query } from '@ydbjs/query'
+
+// ── Channel registry ────────────────────────────────────────────────────────
+
+/**
+ * Public DC contract published by SDK packages. Keep this list in sync with
+ * the README tables in `@ydbjs/core`, `@ydbjs/retry`, `@ydbjs/auth`,
+ * `@ydbjs/query`. For real telemetry you would wire each into spans/metrics.
+ */
+let publishChannels = [
+	// @ydbjs/core — driver lifecycle
+	'ydb:driver.ready',
+	'ydb:driver.failed',
+	'ydb:driver.closed',
+	// @ydbjs/core — discovery
+	'ydb:discovery.completed',
+	// @ydbjs/core — connection pool
+	'ydb:pool.connection.added',
+	'ydb:pool.connection.pessimized',
+	'ydb:pool.connection.unpessimized',
+	'ydb:pool.connection.retired',
+	'ydb:pool.connection.removed',
+	// @ydbjs/retry
+	'ydb:retry.exhausted',
+	// @ydbjs/auth
+	'ydb:auth.token.refreshed',
+	'ydb:auth.token.expired',
+	'ydb:auth.provider.failed',
+	// @ydbjs/query — session pool
+	'ydb:session.created',
+	'ydb:session.closed',
+]
+
+let tracingChannels = [
+	// @ydbjs/core
+	'tracing:ydb:discovery',
+	// @ydbjs/retry
+	'tracing:ydb:retry.run',
+	'tracing:ydb:retry.attempt',
+	// @ydbjs/auth
+	'tracing:ydb:auth.token.fetch',
+	// @ydbjs/query
+	'tracing:ydb:query.execute',
+	'tracing:ydb:query.transaction',
+	'tracing:ydb:session.acquire',
+	'tracing:ydb:session.create',
+]
+
+// ── Pretty printer ──────────────────────────────────────────────────────────
+
+let started = performance.now()
+let depth = 0
+// `tracingChannel` invokes BOTH `error` and `asyncEnd` when the wrapped
+// promise rejects. We only want one log line per span, so remember which
+// span ctx already produced an `error` line and skip the trailing `asyncEnd`.
+let failed = new WeakSet()
+
+function ts() {
+	let ms = (performance.now() - started).toFixed(1).padStart(7)
+	return `+${ms}ms`
+}
+
+function indent() {
+	return '  '.repeat(depth)
+}
+
+function format(value) {
+	if (typeof value === 'bigint') return `${value}n`
+	if (value instanceof Error) return `${value.name}(${value.message})`
+	return JSON.stringify(value, (_, v) => (typeof v === 'bigint' ? `${v}n` : v))
+}
+
+function describe(payload) {
+	if (!payload || typeof payload !== 'object') return ''
+	let entries = Object.entries(payload)
+		.filter(([k]) => k !== 'span' && k !== 'error' && k !== 'asyncId')
+		.map(([k, v]) => `${k}=${format(v)}`)
+	let extras = []
+	if ('error' in payload) extras.push(`error=${format(payload.error)}`)
+	return [...entries, ...extras].join(' ')
+}
+
+// Try to keep query text in logs short.
+function tidy(payload) {
+	if (!payload || typeof payload !== 'object') return payload
+	if ('text' in payload && typeof payload.text === 'string' && payload.text.length > 60) {
+		return { ...payload, text: payload.text.slice(0, 60) + '…' }
+	}
+	return payload
+}
+
+// ── Subscriptions ───────────────────────────────────────────────────────────
+
+for (let name of publishChannels) {
+	subscribe(name, (msg) => {
+		let payload = describe(tidy(msg))
+		console.log(`${ts()} ${indent()}● ${name}${payload ? '  ' + payload : ''}`)
+	})
+}
+
+for (let name of tracingChannels) {
+	tracingChannel(name).subscribe({
+		start(ctx) {
+			let payload = describe(tidy(ctx))
+			console.log(`${ts()} ${indent()}┌─ ${name}${payload ? '  ' + payload : ''}`)
+			depth++
+		},
+		asyncEnd(ctx) {
+			if (failed.has(ctx)) return // `error` already printed for this span
+			depth = Math.max(0, depth - 1)
+			console.log(`${ts()} ${indent()}└─ ${name} ✓`)
+		},
+		error(ctx) {
+			failed.add(ctx)
+			depth = Math.max(0, depth - 1)
+			console.log(`${ts()} ${indent()}└─ ${name} ✗ ${format(ctx.error)}`)
+		},
+	})
+}
+
+// ── Workload ────────────────────────────────────────────────────────────────
+
+let connectionString = process.env.YDB_CONNECTION_STRING || 'grpc://localhost:2136/local'
+// `ENABLE_DISCOVERY=1` to see the full discovery / pool flow. Off by default
+// because containerised YDB usually advertises an internal hostname that's
+// unreachable from the host machine, hanging the demo on first RPC.
+let enableDiscovery = process.env.ENABLE_DISCOVERY === '1'
+
+console.log(`# diagnostics example, connecting to ${connectionString}`)
+console.log(`# discovery=${enableDiscovery ? 'on' : 'off'}\n`)
+
+// `using` for the driver and `await using` for the query client — dispose
+// runs in reverse order so the session pool drains (publishing
+// `session.closed{pool_close}`) BEFORE `driver.close()` fires `driver.closed`.
+using driver = new Driver(connectionString, {
+	'ydb.sdk.enable_discovery': enableDiscovery,
+})
+await driver.ready()
+
+await using sql = query(driver)
+
+// `Query` extends `EventEmitter`. Its `.finally` aborts an internal controller
+// which can synthesise a stray `'error'` event after the awaited result is
+// already resolved — unhandled by default. Demos run with the noisy event
+// silenced; production code should attach `.on('error', …)` per query or
+// install a process-level handler.
+process.on('uncaughtException', (err) => {
+	if (err instanceof Error && err.name === 'AbortError') return
+	throw err
+})
+
+console.log('\n# 1. single-shot SELECT 1\n')
+{
+	let [[row]] = await sql`SELECT 1 AS n`
+	console.log(`\n  → result: ${JSON.stringify(row)}\n`)
+}
+
+console.log('\n# 2. transaction with two SELECTs\n')
+{
+	let result = await sql.begin(async (tx) => {
+		let [[a]] = await tx`SELECT 1 AS a`
+		let [[b]] = await tx`SELECT ${a.a + 1} AS b`
+		return b.b
+	})
+	console.log(`\n  → result: ${result}\n`)
+}
+
+console.log('\n# done, shutting down\n')
+
+// `await using` above releases sql first (drains the session pool, fires
+// `session.closed{pool_close}`), then `using driver` closes the driver and
+// fires `driver.closed`. No manual close() calls needed.

--- a/examples/diagnostics/package.json
+++ b/examples/diagnostics/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "@ydbjs/examples-diagnostics",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"publishConfig": {
+		"access": "restricted"
+	},
+	"scripts": {
+		"start": "node index.js"
+	},
+	"dependencies": {
+		"@ydbjs/core": "^6.1.1",
+		"@ydbjs/query": "^6.1.0"
+	},
+	"engines": {
+		"node": ">=20.19.0",
+		"npm": ">=10"
+	},
+	"engineStrict": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,8 @@
 				"packages/*",
 				"third-parties/*"
 			],
-			"dependencies": {
-				"@types/node": "^25.5.0"
-			},
 			"devDependencies": {
+				"@types/node": "^25.6.0",
 				"@vitest/coverage-v8": "^4.1.5",
 				"@vitest/ui": "^4.1.5",
 				"oxfmt": "^0.46.0",
@@ -2260,10 +2258,12 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.5.0",
+			"version": "25.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.18.0"
+				"undici-types": "~7.19.0"
 			}
 		},
 		"node_modules/@types/unist": {
@@ -4284,7 +4284,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.18.2",
+			"version": "7.19.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
 			"license": "MIT"
 		},
 		"node_modules/unist-util-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,18 @@
 				"@ydbjs/core": "^6.1.1"
 			}
 		},
+		"examples/diagnostics": {
+			"name": "@ydbjs/examples-diagnostics",
+			"version": "0.1.0",
+			"dependencies": {
+				"@ydbjs/core": "^6.1.1",
+				"@ydbjs/query": "^6.1.0"
+			},
+			"engines": {
+				"node": ">=20.19.0",
+				"npm": ">=10"
+			}
+		},
 		"examples/environ": {
 			"name": "@ydbjs/examples-environ",
 			"version": "6.0.0",
@@ -2827,6 +2839,10 @@
 		},
 		"node_modules/@ydbjs/examples-coordination": {
 			"resolved": "examples/coordination",
+			"link": true
+		},
+		"node_modules/@ydbjs/examples-diagnostics": {
+			"resolved": "examples/diagnostics",
 			"link": true
 		},
 		"node_modules/@ydbjs/examples-environ": {

--- a/package.json
+++ b/package.json
@@ -26,10 +26,8 @@
 		"publish": "npx changeset publish",
 		"prepare": "git config core.hooksPath scripts/hooks"
 	},
-	"dependencies": {
-		"@types/node": "^25.5.0"
-	},
 	"devDependencies": {
+		"@types/node": "^25.6.0",
 		"@vitest/coverage-v8": "^4.1.5",
 		"@vitest/ui": "^4.1.5",
 		"oxfmt": "^0.46.0",

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -164,6 +164,72 @@ You do not need to manually set headers; the SDK handles this for you.
 
 ---
 
+## Observability via `node:diagnostics_channel`
+
+`@ydbjs/auth` publishes events to [`node:diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html) so external subscribers (`@ydbjs/telemetry`, OpenTelemetry, custom loggers) can build traces and metrics for token lifecycle without coupling the SDK to a specific telemetry stack.
+
+### Channels
+
+| Channel                        | Type    | Payload                                                                             |
+| ------------------------------ | ------- | ----------------------------------------------------------------------------------- |
+| `tracing:ydb:auth.token.fetch` | tracing | `{ provider: string }` — wraps the full token fetch (with retries)                  |
+| `ydb:auth.token.refreshed`     | publish | `{ provider: string, expiresAt: number }` — unix milliseconds                       |
+| `ydb:auth.token.expired`       | publish | `{ provider: string, stalenessMs: number }` — fires once per incident, not per call |
+| `ydb:auth.provider.failed`     | publish | `{ provider: string, error: unknown }` — fires after all retries are exhausted      |
+
+### `provider` values
+
+The `provider` field is an open, extensible string set. Built-in values published
+by SDK packages:
+
+- `'static'` — `StaticCredentialsProvider` (username/password → JWT via Auth API)
+- `'metadata'` — `MetadataCredentialsProvider` (cloud metadata service)
+- `'yc-service-account'` — `ServiceAccountCredentialsProvider` from `@ydbjs/auth-yandex-cloud`
+
+Third-party `CredentialsProvider` implementations are expected to mint their own
+stable, namespaced provider id and document it. Subscribers should not assume the
+set is exhaustive — prefer label-based metric attributes over hard-coded switches
+over provider names.
+
+### Per-incident `token.expired` semantics
+
+`ydb:auth.token.expired` fires **once** per expiration incident, even if many concurrent calls observe the same expired cached token. The flag is reset on every successful refresh, so the next expiration produces a new event. This makes the channel suitable as a counter for "token went stale" incidents rather than "calls hit a stale cache".
+
+### Subscribing
+
+```ts
+import { channel, tracingChannel } from 'node:diagnostics_channel'
+
+tracingChannel('tracing:ydb:auth.token.fetch').subscribe({
+  start(ctx) {
+    span.start({ name: 'auth.token.fetch', attributes: { 'auth.provider': ctx.provider } })
+  },
+  asyncEnd() {
+    span.end()
+  },
+  error(ctx) {
+    span.recordException(ctx.error)
+    span.end()
+  },
+})
+
+channel('ydb:auth.token.expired').subscribe((msg) => {
+  metrics.tokenExpired.add(1, { provider: msg.provider })
+})
+```
+
+Retry-loop spans are emitted from `@ydbjs/retry` automatically (`tracing:ydb:retry.run`, `tracing:ydb:retry.attempt`, `ydb:retry.exhausted`) and nest correctly under the `auth.token.fetch` span via `AsyncLocalStorage` propagation.
+
+### ⚠️ Subscribers must be safe
+
+**`node:diagnostics_channel` invokes subscribers synchronously.** Any exception thrown inside a subscriber propagates up the call stack and **will** disrupt the SDK — a buggy subscriber can break a `getToken()` call. `@ydbjs/auth` does **not** wrap your subscribers; wrap them yourself in `try/catch`.
+
+### Stability
+
+Channel names, payload field names, and the `provider` enum follow semantic versioning. Adding new optional fields or new enum values is a minor change; renaming or removing fields is a major change.
+
+---
+
 ## License
 
 This project is licensed under the [Apache 2.0 License](../../LICENSE).

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -226,7 +226,7 @@ Retry-loop spans are emitted from `@ydbjs/retry` automatically (`tracing:ydb:ret
 
 ### Stability
 
-Channel names, payload field names, and the `provider` enum follow semantic versioning. Adding new optional fields or new enum values is a minor change; renaming or removing fields is a major change.
+Channel names and payload field names follow semantic versioning. The `provider` field is an **open string set** (custom `CredentialsProvider` implementations may contribute new values), so subscribers should treat it as a label — adding new providers is a minor change. Renaming or removing channels or fields is a major change.
 
 ---
 

--- a/packages/auth/src/diagnostics.test.ts
+++ b/packages/auth/src/diagnostics.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import { channel as dc, tracingChannel } from 'node:diagnostics_channel'
+import { create } from '@bufbuild/protobuf'
+import { anyPack } from '@bufbuild/protobuf/wkt'
+import { ServerError, Status, createServer } from 'nice-grpc'
+
+import { AuthServiceDefinition, LoginResponseSchema, LoginResultSchema } from '@ydbjs/api/auth'
+import { StatusIds_StatusCode } from '@ydbjs/api/operation'
+
+import { MetadataCredentialsProvider } from './metadata.js'
+import { StaticCredentialsProvider } from './static.js'
+
+afterEach(() => {
+	vi.restoreAllMocks()
+})
+
+/** Subscribe to a plain channel; returned object is `Disposable`. */
+function collect(name: string): { payloads: unknown[] } & Disposable {
+	let payloads: unknown[] = []
+	let fn = (msg: unknown) => payloads.push(structuredClone(msg))
+	dc(name).subscribe(fn)
+	return {
+		payloads,
+		[Symbol.dispose]() {
+			dc(name).unsubscribe(fn)
+		},
+	}
+}
+
+/** Subscribe to a tracing channel; capture start / asyncEnd / error contexts. */
+function collectTrace(name: string): {
+	start: object[]
+	asyncEnd: object[]
+	error: (object & { error: unknown })[]
+} & Disposable {
+	let ch = tracingChannel(name)
+	let start: object[] = []
+	let asyncEnd: object[] = []
+	let error: (object & { error: unknown })[] = []
+	let handlers = {
+		start: (ctx: any) => start.push({ ...ctx }),
+		asyncEnd: (ctx: any) => asyncEnd.push({ ...ctx }),
+		error: (ctx: any) => error.push({ ...ctx }),
+	}
+	ch.subscribe(handlers as any)
+	return {
+		start,
+		asyncEnd,
+		error,
+		[Symbol.dispose]() {
+			ch.unsubscribe(handlers as any)
+		},
+	}
+}
+
+// ── metadata ────────────────────────────────────────────────────────────────
+
+test('traces metadata getToken via tracing:ydb:auth.token.fetch', async () => {
+	global.fetch = vi.fn(async () => {
+		let response = new Response(JSON.stringify({ access_token: 'tok', expires_in: 3600 }))
+		response.headers.set('Content-Type', 'application/json')
+		return response
+	})
+	using trace = collectTrace('tracing:ydb:auth.token.fetch')
+
+	let provider = new MetadataCredentialsProvider({})
+	await provider.getToken(true)
+
+	expect(trace.start.length).toBeGreaterThanOrEqual(1)
+	expect(trace.asyncEnd.length).toBeGreaterThanOrEqual(1)
+	expect(trace.error).toHaveLength(0)
+	expect(trace.start[0]).toMatchObject({ provider: 'metadata' })
+})
+
+test('publishes ydb:auth.token.refreshed with expiresAt for metadata provider', async () => {
+	let before = Date.now()
+	global.fetch = vi.fn(async () => {
+		let response = new Response(JSON.stringify({ access_token: 'tok', expires_in: 60 }))
+		response.headers.set('Content-Type', 'application/json')
+		return response
+	})
+	using refreshed = collect('ydb:auth.token.refreshed')
+
+	let provider = new MetadataCredentialsProvider({})
+	await provider.getToken(true)
+
+	expect(refreshed.payloads).toHaveLength(1)
+	let p = refreshed.payloads[0] as any
+	expect(p.provider).toBe('metadata')
+	expect(typeof p.expiresAt).toBe('number')
+	// expiresAt should be roughly now + 60s in unix ms
+	expect(p.expiresAt).toBeGreaterThanOrEqual(before + 60_000)
+})
+
+test('publishes ydb:auth.provider.failed when metadata fetch fails', async () => {
+	global.fetch = vi.fn(async () => new Response('boom', { status: 500 }))
+	using failed = collect('ydb:auth.provider.failed')
+
+	let provider = new MetadataCredentialsProvider({})
+
+	await expect(provider.getToken(true, AbortSignal.timeout(50))).rejects.toThrow(
+		/aborted|fetch token|abort/i
+	)
+
+	expect(failed.payloads).toHaveLength(1)
+	let p = failed.payloads[0] as any
+	expect(p.provider).toBe('metadata')
+	expect(p.error).toBeDefined()
+})
+
+test('publishes ydb:auth.token.expired once per incident across concurrent metadata calls', async () => {
+	// First call: server gives a token that expires immediately.
+	let nowSeconds = 0
+	global.fetch = vi.fn(async () => {
+		nowSeconds++
+		let response = new Response(
+			JSON.stringify({ access_token: `tok-${nowSeconds}`, expires_in: 0 })
+		)
+		response.headers.set('Content-Type', 'application/json')
+		return response
+	})
+
+	let provider = new MetadataCredentialsProvider({})
+	await provider.getToken(true)
+
+	using expired = collect('ydb:auth.token.expired')
+
+	// Three concurrent calls observe the same expired cached token.
+	await Promise.all([
+		provider.getToken(false).catch(() => {}),
+		provider.getToken(false).catch(() => {}),
+		provider.getToken(false).catch(() => {}),
+	])
+
+	// Single incident → single event (others piggyback the in-flight refresh).
+	expect(expired.payloads).toHaveLength(1)
+	let p = expired.payloads[0] as any
+	expect(p.provider).toBe('metadata')
+	expect(typeof p.stalenessMs).toBe('number')
+	expect(p.stalenessMs).toBeGreaterThanOrEqual(0)
+})
+
+// ── static ──────────────────────────────────────────────────────────────────
+
+async function startAuthServer(opts: { fail?: boolean } = {}) {
+	let server = createServer()
+
+	server.add(
+		{ login: AuthServiceDefinition.login },
+		{
+			async login() {
+				if (opts.fail) {
+					throw new ServerError(Status.UNAUTHENTICATED, 'login boom')
+				}
+				// Plain string — not a JWT — forces the StaticCredentialsProvider
+				// fallback branch (5-minute synthetic exp).
+				let result = create(LoginResultSchema, { token: 'opaque-token' })
+				return create(LoginResponseSchema, {
+					operation: {
+						status: StatusIds_StatusCode.SUCCESS,
+						ready: true,
+						result: anyPack(LoginResultSchema, result),
+					} as any,
+				})
+			},
+		}
+	)
+
+	let port = await server.listen('127.0.0.1:0')
+	return {
+		endpoint: `grpc://127.0.0.1:${port}`,
+		async [Symbol.asyncDispose]() {
+			await server.shutdown()
+		},
+	}
+}
+
+test('traces static getToken via tracing:ydb:auth.token.fetch', async () => {
+	await using server = await startAuthServer()
+	using trace = collectTrace('tracing:ydb:auth.token.fetch')
+
+	let provider = new StaticCredentialsProvider({ username: 'u', password: 'p' }, server.endpoint)
+	await provider.getToken(true)
+
+	expect(trace.start.length).toBeGreaterThanOrEqual(1)
+	expect(trace.asyncEnd.length).toBeGreaterThanOrEqual(1)
+	expect(trace.error).toHaveLength(0)
+	expect(trace.start[0]).toMatchObject({ provider: 'static' })
+})
+
+test('publishes ydb:auth.token.refreshed with expiresAt for static provider', async () => {
+	let before = Date.now()
+	await using server = await startAuthServer()
+	using refreshed = collect('ydb:auth.token.refreshed')
+
+	let provider = new StaticCredentialsProvider({ username: 'u', password: 'p' }, server.endpoint)
+	await provider.getToken(true)
+
+	expect(refreshed.payloads).toHaveLength(1)
+	let p = refreshed.payloads[0] as any
+	expect(p.provider).toBe('static')
+	// Token 'a.b.c' is not a valid JWT — fallback expiry is 5 minutes from now.
+	expect(p.expiresAt).toBeGreaterThanOrEqual(before + 4 * 60_000)
+})
+
+test('publishes ydb:auth.provider.failed when static login fails', async () => {
+	await using server = await startAuthServer({ fail: true })
+	using failed = collect('ydb:auth.provider.failed')
+
+	let provider = new StaticCredentialsProvider({ username: 'u', password: 'p' }, server.endpoint)
+
+	await expect(provider.getToken(true, AbortSignal.timeout(200))).rejects.toThrow(
+		/login boom|aborted/i
+	)
+
+	expect(failed.payloads.length).toBeGreaterThanOrEqual(1)
+	let p = failed.payloads[0] as any
+	expect(p.provider).toBe('static')
+	expect(p.error).toBeDefined()
+})

--- a/packages/auth/src/metadata.ts
+++ b/packages/auth/src/metadata.ts
@@ -1,7 +1,13 @@
+import { channel as dc, tracingChannel } from 'node:diagnostics_channel'
+
 import { loggers } from '@ydbjs/debug'
 import { type RetryConfig, retry } from '@ydbjs/retry'
 import { backoff } from '@ydbjs/retry/strategy'
 import { CredentialsProvider } from './index.js'
+
+let authTokenFetchCh = tracingChannel<{ provider: 'metadata' }, { provider: 'metadata' }>(
+	'tracing:ydb:auth.token.fetch'
+)
 
 let dbg = loggers.auth.extend('metadata')
 
@@ -31,6 +37,10 @@ export class MetadataCredentialsProvider extends CredentialsProvider {
 	#flavor: string = 'Google'
 	#endpoint: string =
 		'http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token'
+
+	// See StaticCredentialsProvider — fire `token.expired` at most once per
+	// incident; reset on every successful refresh.
+	#expiredReported = false
 
 	/**
 	 * Creates an instance of `MetadataCredentialsProvider`.
@@ -72,6 +82,12 @@ export class MetadataCredentialsProvider extends CredentialsProvider {
 			return this.#token.value
 		}
 
+		if (this.#token && this.#token.expired_at <= Date.now() && !this.#expiredReported) {
+			this.#expiredReported = true
+			let stalenessMs = Date.now() - this.#token.expired_at
+			dc('ydb:auth.token.expired').publish({ provider: 'metadata', stalenessMs })
+		}
+
 		if (this.#promise) {
 			dbg.log('token fetch already in progress, waiting for result')
 			return this.#promise
@@ -89,50 +105,62 @@ export class MetadataCredentialsProvider extends CredentialsProvider {
 			},
 		}
 
-		this.#promise = retry(retryConfig, async (signal) => {
-			dbg.log('attempting to fetch token from %s', this.#endpoint)
-			let response = await fetch(this.#endpoint, {
-				headers: {
-					'Metadata-Flavor': this.#flavor,
-				},
-				signal,
+		this.#promise = authTokenFetchCh
+			.tracePromise(
+				() => retry(retryConfig, (attemptSignal) => this.#fetchTokenAttempt(attemptSignal)),
+				{ provider: 'metadata' }
+			)
+			.catch((error) => {
+				dc('ydb:auth.provider.failed').publish({ provider: 'metadata', error })
+				throw error
+			})
+			.finally(() => {
+				this.#promise = null
 			})
 
-			dbg.log(
-				'%s %s %s',
-				this.#endpoint,
-				response.status,
-				response.headers.get('Content-Type')
-			)
+		return this.#promise
+	}
 
-			if (!response.ok) {
-				let error = new Error(
-					`Failed to fetch token: ${response.status} ${response.statusText}`
-				)
-				dbg.log('error fetching token: %O', error)
-				throw error
-			}
-
-			let token = JSON.parse(await response.text()) as {
-				access_token?: string
-				expires_in?: number
-			}
-			if (!token.access_token) {
-				dbg.log('missing access token in response, response: %O', token)
-				throw new Error('No access token exists in response')
-			}
-
-			this.#token = {
-				value: token.access_token,
-				expired_at: Date.now() + (token.expires_in ?? 3600) * 1000,
-			}
-
-			dbg.log('token fetched successfully, expires in %d seconds', token.expires_in ?? 3600)
-			return this.#token.value
-		}).finally(() => {
-			this.#promise = null
+	async #fetchTokenAttempt(signal: AbortSignal): Promise<string> {
+		dbg.log('attempting to fetch token from %s', this.#endpoint)
+		let response = await fetch(this.#endpoint, {
+			headers: { 'Metadata-Flavor': this.#flavor },
+			signal,
 		})
 
-		return this.#promise
+		dbg.log('%s %s %s', this.#endpoint, response.status, response.headers.get('Content-Type'))
+
+		if (!response.ok) {
+			let error = new Error(
+				`Failed to fetch token: ${response.status} ${response.statusText}`
+			)
+			dbg.log('error fetching token: %O', error)
+			throw error
+		}
+
+		let token = JSON.parse(await response.text()) as {
+			access_token?: string
+			expires_in?: number
+		}
+		if (!token.access_token) {
+			dbg.log('missing access token in response, response: %O', token)
+			throw new Error('No access token exists in response')
+		}
+
+		this.#token = {
+			value: token.access_token,
+			expired_at: Date.now() + (token.expires_in ?? 3600) * 1000,
+		}
+
+		dbg.log('token fetched successfully, expires in %d seconds', token.expires_in ?? 3600)
+
+		// Allow the next expiration incident to be reported.
+		this.#expiredReported = false
+
+		dc('ydb:auth.token.refreshed').publish({
+			provider: 'metadata',
+			expiresAt: this.#token.expired_at,
+		})
+		return this.#token.value
 	}
 }

--- a/packages/auth/src/static.ts
+++ b/packages/auth/src/static.ts
@@ -1,4 +1,5 @@
 import * as tls from 'node:tls'
+import { channel as dc, tracingChannel } from 'node:diagnostics_channel'
 
 import { anyUnpack } from '@bufbuild/protobuf/wkt'
 import { type ChannelOptions, credentials } from '@grpc/grpc-js'
@@ -6,13 +7,17 @@ import { AuthServiceDefinition, LoginResultSchema } from '@ydbjs/api/auth'
 import { StatusIds_StatusCode } from '@ydbjs/api/operation'
 import { loggers } from '@ydbjs/debug'
 import { YDBError } from '@ydbjs/error'
-import { defaultRetryConfig, retry } from '@ydbjs/retry'
+import { type RetryContext, defaultRetryConfig, retry } from '@ydbjs/retry'
+import { linkSignals } from '@ydbjs/abortable'
 import { type Client, ClientError, Status, createChannel, createClient } from 'nice-grpc'
 
 import { CredentialsProvider } from './index.js'
-import { linkSignals } from '@ydbjs/abortable'
 
 let debug = loggers.auth.extend('static')
+
+let authTokenFetchCh = tracingChannel<{ provider: 'static' }, { provider: 'static' }>(
+	'tracing:ydb:auth.token.fetch'
+)
 
 // Token refresh strategy configuration
 const ACQUIRE_TOKEN_TIMEOUT_MS = 5_000 // 5 seconds timeout for token acquisition
@@ -47,6 +52,11 @@ export class StaticCredentialsProvider extends CredentialsProvider {
 	#token: StaticCredentialsToken | undefined = undefined
 	#promise: Promise<string> | undefined = undefined
 	#backgroundRefreshPromise: Promise<void> | undefined = undefined
+
+	// Tracks whether the current token has already triggered a `token.expired`
+	// event so concurrent getToken() calls don't fan out into N events for the
+	// same incident. Reset on every successful refresh.
+	#expiredReported = false
 
 	constructor(
 		{ username, password }: StaticCredentials,
@@ -131,6 +141,25 @@ export class StaticCredentialsProvider extends CredentialsProvider {
 			return this.#promise
 		}
 
+		// Fire `token.expired` at most once per incident: only the first caller
+		// who observes the cached token past its hard buffer publishes; the next
+		// successful refresh resets the flag for the new token.
+		if (
+			this.#token &&
+			this.#token.exp <= currentTimeSeconds + HARD_EXPIRY_BUFFER_SECONDS &&
+			!this.#expiredReported
+		) {
+			this.#expiredReported = true
+			// `stalenessMs` measures how long we've been past the hard buffer
+			// (== exp + buffer). Negative values mean we're still inside the
+			// buffer but planning a forced refresh — normalize to 0.
+			let stalenessMs = Math.max(
+				0,
+				Date.now() - (this.#token.exp - HARD_EXPIRY_BUFFER_SECONDS) * 1000
+			)
+			dc('ydb:auth.token.expired').publish({ provider: 'static', stalenessMs })
+		}
+
 		debug.log(
 			'fetching new token (force=%s, expired=%s)',
 			force,
@@ -161,81 +190,94 @@ export class StaticCredentialsProvider extends CredentialsProvider {
 	 * @returns the new token value
 	 */
 	async #refreshToken(signal: AbortSignal): Promise<string> {
-		this.#promise = retry(
-			{
-				...defaultRetryConfig,
-				signal,
-				idempotent: true,
-				onRetry: (ctx) => {
-					debug.log('retry attempt #%d after error: %s', ctx.attempt, ctx.error)
-				},
+		let retryConfig = {
+			...defaultRetryConfig,
+			signal,
+			idempotent: true,
+			onRetry: (ctx: RetryContext) => {
+				debug.log('retry attempt #%d after error: %s', ctx.attempt, ctx.error)
 			},
-			async (signal) => {
-				debug.log('attempting login with user: %s', this.#username)
+		}
 
-				let response = await this.#client.login(
-					{ user: this.#username, password: this.#password },
-					{ signal }
-				)
-				if (!response.operation) {
-					throw new ClientError(
-						AuthServiceDefinition.login.path,
-						Status.UNKNOWN,
-						'No operation in response'
-					)
-				}
-
-				if (response.operation.status !== StatusIds_StatusCode.SUCCESS) {
-					throw new YDBError(response.operation.status, response.operation.issues)
-				}
-
-				let result = anyUnpack(response.operation.result!, LoginResultSchema)
-				if (!result) {
-					throw new ClientError(
-						AuthServiceDefinition.login.path,
-						Status.UNKNOWN,
-						'No result in operation'
-					)
-				}
-
-				debug.log('login successful, parsing JWT token')
-
-				// The result.token is a JWT in the format header.payload.signature.
-				// We attempt to decode the payload to extract token metadata (aud, exp, iat, sub).
-				// If the token is not in the expected format, we fallback to default values.
-				let [header, payload, signature] = result.token.split('.')
-				if (header && payload && signature) {
-					let decodedPayload = JSON.parse(Buffer.from(payload, 'base64').toString())
-
-					this.#token = {
-						value: result.token,
-						...decodedPayload,
-					}
-					debug.log(
-						'token parsed successfully, expires at %s',
-						new Date(decodedPayload.exp * 1000).toISOString()
-					)
-				} else {
-					debug.log('token not in JWT format, using fallback metadata')
-					this.#token = {
-						value: result.token,
-						aud: [],
-						exp: Math.floor(Date.now() / 1000) + 5 * 60, // fallback: 5 minutes from now
-						iat: Math.floor(Date.now() / 1000),
-						sub: '',
-					}
-					debug.log(
-						'token created with fallback expiry: %s',
-						new Date(this.#token.exp * 1000).toISOString()
-					)
-				}
-
-				return this.#token!.value!
-			}
-		).finally(() => {
-			this.#promise = undefined
-		})
+		this.#promise = authTokenFetchCh
+			.tracePromise(
+				() => retry(retryConfig, (attemptSignal) => this.#loginAttempt(attemptSignal)),
+				{ provider: 'static' }
+			)
+			.catch((error) => {
+				dc('ydb:auth.provider.failed').publish({ provider: 'static', error })
+				throw error
+			})
+			.finally(() => {
+				this.#promise = undefined
+			})
 
 		return this.#promise
+	}
+
+	async #loginAttempt(signal: AbortSignal): Promise<string> {
+		debug.log('attempting login with user: %s', this.#username)
+
+		let response = await this.#client.login(
+			{ user: this.#username, password: this.#password },
+			{ signal }
+		)
+		if (!response.operation) {
+			throw new ClientError(
+				AuthServiceDefinition.login.path,
+				Status.UNKNOWN,
+				'No operation in response'
+			)
+		}
+
+		if (response.operation.status !== StatusIds_StatusCode.SUCCESS) {
+			throw new YDBError(response.operation.status, response.operation.issues)
+		}
+
+		let result = anyUnpack(response.operation.result!, LoginResultSchema)
+		if (!result) {
+			throw new ClientError(
+				AuthServiceDefinition.login.path,
+				Status.UNKNOWN,
+				'No result in operation'
+			)
+		}
+
+		debug.log('login successful, parsing JWT token')
+
+		// The result.token is a JWT in the format header.payload.signature.
+		// We attempt to decode the payload to extract token metadata (aud, exp, iat, sub).
+		// If the token is not in the expected format, we fallback to default values.
+		let [header, payload, signature] = result.token.split('.')
+		if (header && payload && signature) {
+			let decodedPayload = JSON.parse(Buffer.from(payload, 'base64').toString())
+			this.#token = { value: result.token, ...decodedPayload }
+			debug.log(
+				'token parsed successfully, expires at %s',
+				new Date(decodedPayload.exp * 1000).toISOString()
+			)
+		} else {
+			debug.log('token not in JWT format, using fallback metadata')
+			this.#token = {
+				value: result.token,
+				aud: [],
+				exp: Math.floor(Date.now() / 1000) + 5 * 60, // fallback: 5 minutes from now
+				iat: Math.floor(Date.now() / 1000),
+				sub: '',
+			}
+			debug.log(
+				'token created with fallback expiry: %s',
+				new Date(this.#token.exp * 1000).toISOString()
+			)
+		}
+
+		// Allow the next expiration incident to be reported.
+		this.#expiredReported = false
+
+		dc('ydb:auth.token.refreshed').publish({
+			provider: 'static',
+			expiresAt: this.#token!.exp * 1000,
+		})
+		return this.#token!.value!
 	}
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -69,6 +69,94 @@ Always close the driver when done to release resources:
 driver.close()
 ```
 
+## Observability via `node:diagnostics_channel`
+
+`@ydbjs/core` publishes domain events over [`node:diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html) so external subscribers (`@ydbjs/telemetry`, OpenTelemetry, custom loggers) can build traces, metrics, and logs without the driver knowing anything about them.
+
+Two primitives are used:
+
+- **`channel.publish`** — point-in-time state changes (gauges, counters, structured logs).
+- **`tracingChannel.tracePromise`** — bracketed operations with duration and possible error (spans, latency histograms).
+
+### Channels
+
+#### Driver lifecycle
+
+| Channel             | Type    | Payload                                                  |
+| ------------------- | ------- | -------------------------------------------------------- |
+| `ydb:driver.ready`  | publish | `{ database: string, duration: number }`                 |
+| `ydb:driver.failed` | publish | `{ database: string, duration: number, error: unknown }` |
+| `ydb:driver.closed` | publish | `{ database: string, uptime: number }`                   |
+
+#### Discovery
+
+| Channel                   | Type    | Payload                                                                                                |
+| ------------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| `tracing:ydb:discovery`   | tracing | `{ database: string }`                                                                                 |
+| `ydb:discovery.completed` | publish | `{ database: string, addedCount: number, removedCount: number, totalCount: number, duration: number }` |
+
+#### Connection pool
+
+| Channel                            | Type    | Payload                                                                                               |
+| ---------------------------------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| `ydb:pool.connection.added`        | publish | `{ nodeId: bigint, address: string, location: string }`                                               |
+| `ydb:pool.connection.pessimized`   | publish | `{ nodeId: bigint, address: string, location: string, until: number }`                                |
+| `ydb:pool.connection.unpessimized` | publish | `{ nodeId: bigint, address: string, location: string, pessimizedDuration: number }`                   |
+| `ydb:pool.connection.retired`      | publish | `{ nodeId: bigint, address: string, location: string, reason: 'stale_active' \| 'stale_pessimized' }` |
+| `ydb:pool.connection.removed`      | publish | `{ nodeId: bigint, address: string, location: string, reason: 'replaced' \| 'idle' \| 'pool_close' }` |
+
+The pool exposes two distinct lifecycle events for connections:
+
+- `retired` — the connection was removed from active routing (e.g. its endpoint disappeared from discovery), but its gRPC channel is left open so in-flight streams can drain.
+- `removed` — the gRPC channel was physically closed. The `reason` field distinguishes whether it was a replacement, an idle teardown, or a pool shutdown.
+
+A gauge of "alive channels" can be reconstructed from the delta between `pool.connection.added` and `pool.connection.removed`. A gauge of "routable connections" should also subtract `retired`.
+
+### Subscribing
+
+```ts
+import { channel, tracingChannel } from 'node:diagnostics_channel'
+
+channel('ydb:driver.ready').subscribe((msg) => {
+  console.log('driver ready', msg)
+})
+
+tracingChannel('tracing:ydb:discovery').subscribe({
+  start(ctx) {
+    // ctx.database === '/local'
+  },
+  asyncEnd(ctx) {
+    // discovery round succeeded
+  },
+  error(ctx) {
+    // ctx.error is the failure
+  },
+})
+```
+
+### ⚠️ Subscribers must be safe
+
+**`node:diagnostics_channel` invokes subscribers synchronously, on the publishing thread.** Any exception thrown inside a subscriber propagates up the call stack and **will** disrupt the SDK — a buggy subscriber can break a `Driver.ready()`, abort a discovery round, or leak a gRPC channel.
+
+`@ydbjs/core` does **not** wrap your subscribers. It is your responsibility to keep them safe:
+
+```ts
+channel('ydb:driver.ready').subscribe((msg) => {
+  try {
+    metrics.driverReady.add(1, { database: msg.database })
+  } catch (err) {
+    // Never let a metrics failure escape — log it locally and move on.
+    console.error('telemetry subscriber failed', err)
+  }
+})
+```
+
+The same applies to `tracingChannel` handlers (`start`, `asyncEnd`, `error`, etc.) — each must be self-contained and never throw.
+
+### Stability
+
+Channel names and payload field names follow semantic versioning. Adding new optional fields is a minor change; renaming or removing fields is a major change. Treat the channel names and payload shapes as a public API surface.
+
 ## Development
 
 ### Building the Package

--- a/packages/core/src/diagnostics.test.ts
+++ b/packages/core/src/diagnostics.test.ts
@@ -124,6 +124,20 @@ test('publishes ydb:pool.connection.pessimized with deadline when pessimize() is
 	expect(p.until).toBeGreaterThanOrEqual(before + 60_000)
 })
 
+test('does not re-publish ydb:pool.connection.pessimized when pessimize() refreshes an already-pessimized conn', () => {
+	using pool = makePool({ pessimizationTimeout: 60_000 })
+	pool.sync([makeProtoEndpoint(20)])
+	let [conn] = pool[POOL_GET_ACTIVE_FOR_TESTING]()
+
+	using pessimized = collect('ydb:pool.connection.pessimized')
+
+	pool.pessimize(conn!) // active → pessimized: fires
+	pool.pessimize(conn!) // already pessimized: timeout refresh, must not fire
+	pool.pessimize(conn!)
+
+	expect(pessimized.payloads).toHaveLength(1)
+})
+
 test('publishes ydb:pool.connection.unpessimized after the pessimization timeout elapses', async () => {
 	// 1ms timeout + a small wait so `until < Date.now()` holds inside
 	// #refreshPessimized when acquire() runs.
@@ -360,6 +374,70 @@ test('traces tracing:ydb:discovery start and asyncEnd around a successful round'
 	expect(trace.asyncEnd.length).toBeGreaterThanOrEqual(1)
 	expect(trace.error).toHaveLength(0)
 	expect(trace.start[0]?.ctx).toMatchObject({ database: '/local' })
+})
+
+test('close() during in-flight initial discovery suppresses ydb:driver.ready / .failed', async () => {
+	// Discovery server that hangs forever — the only way out is the per-round
+	// timeout (driver close should kick in first).
+	let release: () => void = () => {}
+	let server = createServer()
+	let port = 0
+	server.add(
+		{
+			listEndpoints: DiscoveryServiceDefinition.listEndpoints,
+			whoAmI: DiscoveryServiceDefinition.whoAmI,
+		},
+		{
+			async listEndpoints() {
+				await new Promise<void>((r) => (release = r))
+				let result = create(ListEndpointsResultSchema, {
+					endpoints: [
+						create(EndpointInfoSchema, {
+							nodeId: 1,
+							address: '127.0.0.1',
+							port,
+							location: 'dc1',
+						}),
+					],
+				})
+				return {
+					operation: {
+						status: StatusIds_StatusCode.SUCCESS,
+						ready: true,
+						result: anyPack(ListEndpointsResultSchema, result),
+					},
+				} as any
+			},
+			async whoAmI() {
+				return {} as any
+			},
+		}
+	)
+	port = await server.listen('127.0.0.1:0')
+
+	using ready = collect('ydb:driver.ready')
+	using failed = collect('ydb:driver.failed')
+	using closed = collect('ydb:driver.closed')
+
+	let driver = new Driver(`grpc://127.0.0.1:${port}/local`, {
+		'ydb.sdk.discovery_timeout_ms': 5_000,
+		'ydb.sdk.ready_timeout_ms': 5_000,
+	})
+
+	// Give the RPC time to land on the server.
+	await new Promise((r) => setTimeout(r, 50))
+	driver.close()
+
+	// Let the listEndpoints handler resolve so the (now-cancelled) discovery
+	// callbacks have a chance to run #markReady on a closed driver.
+	release()
+	await new Promise((r) => setTimeout(r, 50))
+
+	expect(closed.payloads).toHaveLength(1)
+	expect(ready.payloads).toHaveLength(0)
+	expect(failed.payloads).toHaveLength(0)
+
+	await server.shutdown()
 })
 
 test('traces tracing:ydb:discovery error when listEndpoints fails', async () => {

--- a/packages/core/src/diagnostics.test.ts
+++ b/packages/core/src/diagnostics.test.ts
@@ -1,0 +1,381 @@
+import { expect, test } from 'vitest'
+import { channel as dc, tracingChannel } from 'node:diagnostics_channel'
+import { credentials } from '@grpc/grpc-js'
+import { create } from '@bufbuild/protobuf'
+import { anyPack } from '@bufbuild/protobuf/wkt'
+import { ServerError, Status, createServer } from 'nice-grpc'
+import {
+	DiscoveryServiceDefinition,
+	EndpointInfoSchema,
+	ListEndpointsResultSchema,
+} from '@ydbjs/api/discovery'
+import { StatusIds_StatusCode } from '@ydbjs/api/operation'
+
+import { Driver } from './driver.js'
+import { ConnectionPool, POOL_GET_ACTIVE_FOR_TESTING } from './pool.js'
+
+function makeProtoEndpoint(nodeId: number, port = 2136) {
+	return {
+		nodeId,
+		address: `node-${nodeId}`,
+		port,
+		location: 'dc1',
+		sslTargetNameOverride: '',
+	} as any
+}
+
+function makePool(opts: { pessimizationTimeout?: number } = {}) {
+	return new ConnectionPool({
+		channelCredentials: credentials.createInsecure(),
+		idleTimeout: 0,
+		idleInterval: 0,
+		pessimizationTimeout: opts.pessimizationTimeout ?? 60_000,
+	})
+}
+
+/**
+ * Subscribe to a DC channel and collect deep-cloned payloads.
+ * Returned object is `Disposable` — `using` auto-unsubscribes on scope exit.
+ */
+function collect(name: string): { payloads: unknown[] } & Disposable {
+	let payloads: unknown[] = []
+	let fn = (msg: unknown) => payloads.push(structuredClone(msg))
+	dc(name).subscribe(fn)
+	return {
+		payloads,
+		[Symbol.dispose]() {
+			dc(name).unsubscribe(fn)
+		},
+	}
+}
+
+// ── added / removed via discovery ────────────────────────────────────────────
+
+test('publishes ydb:pool.connection.added when sync introduces a new endpoint', () => {
+	using pool = makePool()
+	using added = collect('ydb:pool.connection.added')
+
+	pool.sync([makeProtoEndpoint(1)])
+
+	expect(added.payloads).toHaveLength(1)
+	expect(added.payloads[0]).toMatchObject({
+		nodeId: 1n,
+		address: 'node-1:2136',
+		location: 'dc1',
+	})
+})
+
+test('publishes ydb:pool.connection.retired when an active endpoint disappears from discovery', () => {
+	using pool = makePool()
+	pool.sync([makeProtoEndpoint(1)])
+
+	using retired = collect('ydb:pool.connection.retired')
+	using removed = collect('ydb:pool.connection.removed')
+
+	pool.sync([]) // node 1 is no longer in discovery
+
+	// channel stays open until idle sweep → no `removed` yet
+	expect(removed.payloads).toHaveLength(0)
+	expect(retired.payloads).toHaveLength(1)
+	expect(retired.payloads[0]).toMatchObject({
+		nodeId: 1n,
+		address: 'node-1:2136',
+		location: 'dc1',
+		reason: 'stale_active',
+	})
+})
+
+test('publishes ydb:pool.connection.retired when a pessimized endpoint disappears from discovery', () => {
+	using pool = makePool()
+	pool.sync([makeProtoEndpoint(3)])
+	let [conn] = pool[POOL_GET_ACTIVE_FOR_TESTING]()
+	pool.pessimize(conn!)
+
+	using retired = collect('ydb:pool.connection.retired')
+
+	pool.sync([])
+
+	expect(retired.payloads).toHaveLength(1)
+	expect(retired.payloads[0]).toMatchObject({
+		nodeId: 3n,
+		reason: 'stale_pessimized',
+	})
+})
+
+// ── pessimize / unpessimize ──────────────────────────────────────────────────
+
+test('publishes ydb:pool.connection.pessimized with deadline when pessimize() is called', () => {
+	let before = Date.now()
+	using pool = makePool({ pessimizationTimeout: 60_000 })
+	pool.sync([makeProtoEndpoint(2)])
+	let [conn] = pool[POOL_GET_ACTIVE_FOR_TESTING]()
+
+	using pessimized = collect('ydb:pool.connection.pessimized')
+
+	pool.pessimize(conn!)
+
+	expect(pessimized.payloads).toHaveLength(1)
+	let p = pessimized.payloads[0] as any
+	expect(p).toMatchObject({
+		nodeId: 2n,
+		address: 'node-2:2136',
+		location: 'dc1',
+	})
+	expect(p.until).toBeGreaterThanOrEqual(before + 60_000)
+})
+
+test('publishes ydb:pool.connection.unpessimized after the pessimization timeout elapses', async () => {
+	// 1ms timeout + a small wait so `until < Date.now()` holds inside
+	// #refreshPessimized when acquire() runs.
+	using pool = makePool({ pessimizationTimeout: 1 })
+	pool.sync([makeProtoEndpoint(4)])
+	let [conn] = pool[POOL_GET_ACTIVE_FOR_TESTING]()
+	pool.pessimize(conn!)
+
+	await new Promise((r) => setTimeout(r, 5))
+
+	using unpessimized = collect('ydb:pool.connection.unpessimized')
+
+	pool.acquire() // calls #refreshPessimized() — restores node 4
+
+	expect(unpessimized.payloads).toHaveLength(1)
+	expect(unpessimized.payloads[0]).toMatchObject({
+		nodeId: 4n,
+		address: 'node-4:2136',
+		location: 'dc1',
+	})
+})
+
+// ── removed (physical close) by reason ───────────────────────────────────────
+
+test('publishes ydb:pool.connection.removed with reason=replaced on add() of an existing nodeId', () => {
+	using pool = makePool()
+	pool.sync([makeProtoEndpoint(5)])
+
+	using removed = collect('ydb:pool.connection.removed')
+
+	pool.add(makeProtoEndpoint(5)) // re-add — old channel must be replaced
+
+	expect(removed.payloads).toHaveLength(1)
+	expect(removed.payloads[0]).toMatchObject({
+		nodeId: 5n,
+		reason: 'replaced',
+	})
+})
+
+test('publishes ydb:pool.connection.removed with reason=pool_close on close()', () => {
+	let pool = makePool()
+	pool.sync([makeProtoEndpoint(6), makeProtoEndpoint(7)])
+
+	using removed = collect('ydb:pool.connection.removed')
+
+	pool.close()
+
+	expect(removed.payloads).toHaveLength(2)
+	for (let p of removed.payloads) {
+		expect(p).toMatchObject({ reason: 'pool_close' })
+	}
+})
+
+// ── driver lifecycle ────────────────────────────────────────────────────────
+
+/**
+ * Stand up a fake DiscoveryService that returns a single endpoint pointing
+ * back at the test server. Returned object is `AsyncDisposable` so callers can
+ * use `await using`.
+ */
+async function startDiscoveryServer(opts: { fail?: boolean } = {}) {
+	let server = createServer()
+	let selfPort = 0
+
+	server.add(
+		{
+			listEndpoints: DiscoveryServiceDefinition.listEndpoints,
+			whoAmI: DiscoveryServiceDefinition.whoAmI,
+		},
+		{
+			async listEndpoints() {
+				if (opts.fail) {
+					throw new ServerError(Status.INTERNAL, 'discovery boom')
+				}
+				let result = create(ListEndpointsResultSchema, {
+					endpoints: [
+						create(EndpointInfoSchema, {
+							nodeId: 1,
+							address: '127.0.0.1',
+							port: selfPort,
+							location: 'dc1',
+						}),
+					],
+				})
+				return {
+					operation: {
+						status: StatusIds_StatusCode.SUCCESS,
+						ready: true,
+						result: anyPack(ListEndpointsResultSchema, result),
+					},
+				} as any
+			},
+			async whoAmI() {
+				return {} as any
+			},
+		}
+	)
+
+	selfPort = await server.listen('127.0.0.1:0')
+
+	return {
+		port: selfPort,
+		async [Symbol.asyncDispose]() {
+			await server.shutdown()
+		},
+	}
+}
+
+/**
+ * Subscribe to a tracing channel and capture start/asyncEnd/error events.
+ */
+function collectTrace(name: string): {
+	start: { ctx: object }[]
+	asyncEnd: { ctx: object }[]
+	error: { ctx: object & { error: unknown } }[]
+} & Disposable {
+	let ch = tracingChannel(name)
+	let start: { ctx: object }[] = []
+	let asyncEnd: { ctx: object }[] = []
+	let error: { ctx: object & { error: unknown } }[] = []
+	let handlers = {
+		start: (ctx: any) => start.push({ ctx: { ...ctx } }),
+		asyncEnd: (ctx: any) => asyncEnd.push({ ctx: { ...ctx } }),
+		error: (ctx: any) => error.push({ ctx: { ...ctx } }),
+	}
+	ch.subscribe(handlers as any)
+	return {
+		start,
+		asyncEnd,
+		error,
+		[Symbol.dispose]() {
+			ch.unsubscribe(handlers as any)
+		},
+	}
+}
+
+test('publishes ydb:driver.ready with duration after successful initial discovery', async () => {
+	await using server = await startDiscoveryServer()
+	using ready = collect('ydb:driver.ready')
+
+	using driver = new Driver(`grpc://127.0.0.1:${server.port}/local`, {
+		'ydb.sdk.discovery_timeout_ms': 5_000,
+	})
+	await driver.ready()
+
+	expect(ready.payloads).toHaveLength(1)
+	let p = ready.payloads[0] as any
+	expect(p.database).toBe('/local')
+	expect(typeof p.duration).toBe('number')
+	expect(p.duration).toBeGreaterThanOrEqual(0)
+})
+
+test('publishes ydb:driver.ready synchronously when discovery is disabled', () => {
+	using ready = collect('ydb:driver.ready')
+
+	using driver = new Driver('grpc://127.0.0.1:1/local', {
+		'ydb.sdk.enable_discovery': false,
+	})
+
+	expect(driver.database).toBe('/local')
+	expect(ready.payloads).toHaveLength(1)
+	expect(ready.payloads[0]).toMatchObject({ database: '/local' })
+})
+
+test('publishes ydb:driver.failed with error and duration when initial discovery fails', async () => {
+	await using server = await startDiscoveryServer({ fail: true })
+	using failed = collect('ydb:driver.failed')
+
+	let driver = new Driver(`grpc://127.0.0.1:${server.port}/local`, {
+		// shrink timings so the test does not hang on the default 30s ready timeout
+		'ydb.sdk.discovery_timeout_ms': 200,
+		'ydb.sdk.discovery_interval_ms': 1_000,
+		'ydb.sdk.ready_timeout_ms': 1_000,
+	})
+
+	await expect(driver.ready()).rejects.toThrow(/discovery boom|aborted|timed out/i)
+	driver.close()
+
+	expect(failed.payloads.length).toBeGreaterThanOrEqual(1)
+	let p = failed.payloads[0] as any
+	expect(p.database).toBe('/local')
+	expect(typeof p.duration).toBe('number')
+	expect(p.error).toBeDefined()
+})
+
+test('publishes ydb:driver.closed with uptime on close()', async () => {
+	await using server = await startDiscoveryServer()
+
+	let driver = new Driver(`grpc://127.0.0.1:${server.port}/local`, {
+		'ydb.sdk.discovery_timeout_ms': 5_000,
+	})
+	await driver.ready()
+
+	using closed = collect('ydb:driver.closed')
+	driver.close()
+
+	expect(closed.payloads).toHaveLength(1)
+	let p = closed.payloads[0] as any
+	expect(p.database).toBe('/local')
+	expect(typeof p.uptime).toBe('number')
+	expect(p.uptime).toBeGreaterThanOrEqual(0)
+})
+
+test('publishes ydb:discovery.completed with added/removed/total counts', async () => {
+	await using server = await startDiscoveryServer()
+	using completed = collect('ydb:discovery.completed')
+
+	using driver = new Driver(`grpc://127.0.0.1:${server.port}/local`, {
+		'ydb.sdk.discovery_timeout_ms': 5_000,
+	})
+	await driver.ready()
+
+	expect(completed.payloads.length).toBeGreaterThanOrEqual(1)
+	let p = completed.payloads[0] as any
+	expect(p).toMatchObject({
+		database: '/local',
+		addedCount: 1,
+		removedCount: 0,
+		totalCount: 1,
+	})
+	expect(typeof p.duration).toBe('number')
+})
+
+test('traces tracing:ydb:discovery start and asyncEnd around a successful round', async () => {
+	await using server = await startDiscoveryServer()
+	using trace = collectTrace('tracing:ydb:discovery')
+
+	using driver = new Driver(`grpc://127.0.0.1:${server.port}/local`, {
+		'ydb.sdk.discovery_timeout_ms': 5_000,
+	})
+	await driver.ready()
+
+	expect(trace.start.length).toBeGreaterThanOrEqual(1)
+	expect(trace.asyncEnd.length).toBeGreaterThanOrEqual(1)
+	expect(trace.error).toHaveLength(0)
+	expect(trace.start[0]?.ctx).toMatchObject({ database: '/local' })
+})
+
+test('traces tracing:ydb:discovery error when listEndpoints fails', async () => {
+	await using server = await startDiscoveryServer({ fail: true })
+	using trace = collectTrace('tracing:ydb:discovery')
+
+	let driver = new Driver(`grpc://127.0.0.1:${server.port}/local`, {
+		'ydb.sdk.discovery_timeout_ms': 200,
+		'ydb.sdk.discovery_interval_ms': 1_000,
+		'ydb.sdk.ready_timeout_ms': 1_000,
+	})
+
+	await expect(driver.ready()).rejects.toThrow(/discovery boom|aborted|timed out/i)
+	driver.close()
+
+	expect(trace.start.length).toBeGreaterThanOrEqual(1)
+	expect(trace.error.length).toBeGreaterThanOrEqual(1)
+	expect(trace.error[0]?.ctx.error).toBeDefined()
+})

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -161,6 +161,9 @@ export class Driver implements Disposable {
 
 	#discoveryClient!: Client<typeof DiscoveryServiceDefinition>
 	#rediscoverTimer?: NodeJS.Timeout
+	// Aborted by close(); links into discovery signals so in-flight rounds
+	// stop ASAP and don't publish ready/failed after driver.closed.
+	#shutdown = new AbortController()
 
 	#credentialsProvider: CredentialsProvider = new AnonymousCredentialsProvider()
 
@@ -173,6 +176,10 @@ export class Driver implements Disposable {
 		dbg.log('Driver(connectionString: %s, options: %o)', connectionString, userOptions)
 
 		this.#initAt = performance.now()
+
+		// close() rejects #ready to unblock awaiters; silence unhandled
+		// rejection when no one observes the promise.
+		this.#ready.promise.catch(() => {})
 
 		this.cs = this.#parseConnectionString(connectionString)
 		this.options = this.#mergeOptions(userOptions)
@@ -264,6 +271,13 @@ export class Driver implements Disposable {
 
 		let uptime = this.#readyAt ? performance.now() - this.#readyAt : 0
 		dbg.log('closing driver (uptime %d ms)', uptime)
+
+		// Cancel any in-flight discovery so its callbacks bail out instead of
+		// publishing `ydb:driver.ready` / `ydb:driver.failed` after this point.
+		this.#shutdown.abort(new Error('driver closed'))
+		// Unblock anyone waiting on ready() — markReady/markFailed are now
+		// guarded by #closed and won't settle the latch.
+		this.#ready.reject(new Error('driver closed'))
 
 		if (this.#rediscoverTimer) {
 			clearInterval(this.#rediscoverTimer)
@@ -381,20 +395,30 @@ export class Driver implements Disposable {
 
 		dbg.log('discovery enabled, initial timeout %d ms, interval %d ms', timeout, interval)
 
-		this.#discovery(AbortSignal.timeout(timeout)).then(
+		this.#discovery(this.#discoverySignal(timeout)).then(
 			() => this.#markReady(),
 			(error) => this.#markFailed(error)
 		)
 
 		this.#rediscoverTimer = setInterval(() => {
-			void this.#discovery(AbortSignal.timeout(timeout))
+			if (this.#closed) return
+			void this.#discovery(this.#discoverySignal(timeout))
 		}, interval)
 
 		// Don't keep the process alive solely for rediscovery.
 		this.#rediscoverTimer.unref()
 	}
 
+	#discoverySignal(timeoutMs: number): AbortSignal {
+		// AbortSignal.any: closes when either the per-round timeout fires or
+		// the driver shuts down — whichever comes first.
+		return AbortSignal.any([this.#shutdown.signal, AbortSignal.timeout(timeoutMs)])
+	}
+
 	#markReady(): void {
+		// Discovery resolved after close() — drop the event so subscribers don't
+		// see `ready` after `closed`. ready() already rejected via shutdown signal.
+		if (this.#closed) return
 		this.#readyAt = performance.now()
 		let duration = this.#readyAt - this.#initAt
 		dbg.log('driver ready in %d ms', duration)
@@ -403,6 +427,8 @@ export class Driver implements Disposable {
 	}
 
 	#markFailed(error: unknown): void {
+		// Same reason as #markReady — don't publish failure after `closed`.
+		if (this.#closed) return
 		let duration = performance.now() - this.#initAt
 		dbg.log('driver init failed after %d ms: %O', duration, error)
 		this.#ready.reject(error)

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -1,5 +1,6 @@
 import * as tls from 'node:tls'
 import * as assert from 'node:assert/strict'
+import { channel as dc, tracingChannel } from 'node:diagnostics_channel'
 
 import { create } from '@bufbuild/protobuf'
 import { anyUnpack } from '@bufbuild/protobuf/wkt'
@@ -42,6 +43,10 @@ import type { DriverHooks, EndpointInfo } from './hooks.js'
 import { debug } from './middleware.js'
 import { ConnectionPool } from './pool.js'
 import { detectRuntime } from './runtime.js'
+
+let discoveryCh = tracingChannel<{ database: string }, { database: string }>(
+	'tracing:ydb:discovery'
+)
 
 export type { DriverHooks, EndpointInfo }
 
@@ -90,7 +95,17 @@ export type DriverOptions = {
 
 let dbg = loggers.driver
 
-const defaultOptions: DriverOptions = {
+function databaseFromUrl(url: URL): string {
+	if (url.pathname && url.pathname !== '/') {
+		return url.pathname
+	}
+	if (url.searchParams.has('database')) {
+		return url.searchParams.get('database') || ''
+	}
+	return ''
+}
+
+let defaultOptions: DriverOptions = {
 	'ydb.sdk.ready_timeout_ms': 30_000,
 	'ydb.sdk.token_timeout_ms': 10_000,
 	'ydb.sdk.enable_discovery': true,
@@ -101,7 +116,7 @@ const defaultOptions: DriverOptions = {
 	'ydb.sdk.connection_pessimization_timeout_ms': 60_000,
 } as const satisfies DriverOptions
 
-const defaultChannelOptions: ChannelOptions = {
+let defaultChannelOptions: ChannelOptions = {
 	'grpc.primary_user_agent': `ydb-js-sdk/${pkg.version}`,
 	'grpc.secondary_user_agent': detectRuntime(),
 
@@ -124,7 +139,7 @@ if (!Promise.withResolvers) {
 	} {
 		let resolve: (value: T | PromiseLike<T>) => void
 		let reject: (reason?: any) => void
-		const promise = new Promise<T>((res, rej) => {
+		let promise = new Promise<T>((res, rej) => {
 			resolve = res
 			reject = rej
 		})
@@ -149,49 +164,28 @@ export class Driver implements Disposable {
 
 	#credentialsProvider: CredentialsProvider = new AnonymousCredentialsProvider()
 
+	// Construction time, used for `driver.ready.duration` and `driver.closed.uptime`.
+	#initAt: number
+	#readyAt: number | undefined
+	#closed = false
+
 	constructor(connectionString: string, userOptions: Readonly<DriverOptions> = defaultOptions) {
 		dbg.log('Driver(connectionString: %s, options: %o)', connectionString, userOptions)
 
-		if (!connectionString) {
-			throw new Error('Invalid connection string. Must be a non-empty string')
-		}
+		this.#initAt = performance.now()
 
-		this.cs = new URL(connectionString.replace(/^grpc/, 'http'))
-		assert.ok(this.database, new DriverCSDatabaseError())
-		assert.match(this.cs.protocol, /^(grpc|http)(s?):$/, new DriverCSProtocolError())
+		this.cs = this.#parseConnectionString(connectionString)
+		this.options = this.#mergeOptions(userOptions)
+		this.#assertDiscoveryTimings()
 
-		this.options = { ...defaultOptions, ...userOptions }
-		this.options.channelOptions = { ...defaultChannelOptions, ...this.options.channelOptions }
-
-		let discoveryTimeout = this.options['ydb.sdk.discovery_timeout_ms']!
-		let discoveryInterval = this.options['ydb.sdk.discovery_interval_ms']!
-
-		assert.ok(discoveryTimeout > 0, new DriverDiscoveryTimeoutError(discoveryTimeout))
-		assert.ok(discoveryInterval > 0, new DriverDiscoveryIntervalError(discoveryInterval))
-		assert.ok(discoveryTimeout < discoveryInterval, new DriverDiscoveryOptionsError())
-
-		let initialEndpoint = create(EndpointInfoSchema, {
-			address: this.cs.hostname,
-			nodeId: -1,
-			port: parseInt(this.cs.port || (this.isSecure ? '443' : '80'), 10),
-			ssl: this.isSecure,
-		})
-
-		let channelCredentials = this.isSecure
-			? credentials.createSsl()
-			: credentials.createInsecure()
-
-		if ((this.options.secureOptions ??= this.options.ssl)) {
-			let secureContext = tls.createSecureContext(this.options.secureOptions)
-			channelCredentials = credentials.createFromSecureContext(secureContext)
-		}
+		let channelCredentials = this.#createChannelCredentials()
 
 		// The initial connection is always to the endpoint from the connection
 		// string. It is used for discovery and as the sole connection when
 		// discovery is disabled. GrpcConnection creates the channel eagerly but
 		// grpc-js starts it in IDLE — no TCP/TLS until the first RPC.
 		this.#connection = new GrpcConnection(
-			initialEndpoint,
+			this.#initialEndpoint(),
 			channelCredentials,
 			this.options.channelOptions
 		)
@@ -200,48 +194,7 @@ export class Driver implements Disposable {
 			this.#credentialsProvider = this.options.credentialsProvider
 		}
 
-		this.#middleware = composeClientMiddleware(debug, (call, options) => {
-			let metadata = Metadata(options.metadata)
-				.set('x-ydb-sdk-build-info', `ydb-js-sdk/${pkg.version}`)
-				.set('x-ydb-database', this.database)
-				.set('x-ydb-application-name', this.application)
-
-			return call.next(call.request, Object.assign(options, { metadata }))
-		})
-
-		this.#middleware = composeClientMiddleware(
-			this.#middleware,
-			this.#credentialsProvider.middleware
-		)
-
-		if (this.options['ydb.sdk.enable_discovery'] === false) {
-			dbg.log('discovery disabled, using single endpoint')
-			this.#ready.resolve()
-		}
-
-		if (this.options['ydb.sdk.enable_discovery'] === true) {
-			dbg.log('discovery enabled, using connection pool')
-
-			dbg.log('starting initial discovery with timeout %d ms', discoveryTimeout)
-			this.#discovery(AbortSignal.timeout(discoveryTimeout))
-				.then(() => {
-					dbg.log('initial discovery completed successfully')
-					return this.#ready.resolve()
-				})
-				.catch((error) => {
-					dbg.log('initial discovery failed: %O', error)
-					this.#ready.reject(error)
-				})
-
-			dbg.log('setting up periodic discovery every %d ms', discoveryInterval)
-			this.#rediscoverTimer = setInterval(() => {
-				dbg.log('starting periodic discovery')
-				void this.#discovery(AbortSignal.timeout(discoveryTimeout))
-			}, discoveryInterval)
-
-			// Unref the timer so it doesn't keep the process running
-			this.#rediscoverTimer.unref()
-		}
+		this.#middleware = this.#buildMiddleware()
 
 		this.#pool = new ConnectionPool({
 			hooks: this.options.hooks,
@@ -251,6 +204,13 @@ export class Driver implements Disposable {
 			idleInterval: this.options['ydb.sdk.connection_idle_interval_ms']!,
 			pessimizationTimeout: this.options['ydb.sdk.connection_pessimization_timeout_ms']!,
 		})
+
+		if (this.options['ydb.sdk.enable_discovery'] === false) {
+			dbg.log('discovery disabled, using single endpoint')
+			this.#markReady()
+		} else {
+			this.#startDiscoveryLoop()
+		}
 	}
 
 	get token(): Promise<string> {
@@ -260,15 +220,7 @@ export class Driver implements Disposable {
 	}
 
 	get database(): string {
-		if (this.cs.pathname && this.cs.pathname !== '/') {
-			return this.cs.pathname
-		}
-
-		if (this.cs.searchParams.has('database')) {
-			return this.cs.searchParams.get('database') || ''
-		}
-
-		return ''
+		return databaseFromUrl(this.cs)
 	}
 
 	get isSecure(): boolean {
@@ -285,67 +237,6 @@ export class Driver implements Disposable {
 		}
 
 		return ''
-	}
-
-	async #discovery(outerSignal: AbortSignal): Promise<void> {
-		dbg.log('starting discovery for database: %s', this.database)
-
-		let discoveryStart = performance.now()
-		let retryConfig: RetryConfig = {
-			...defaultRetryConfig,
-			signal: outerSignal,
-			onRetry: (ctx) => {
-				dbg.log('retrying discovery, attempt %d, error: %O', ctx.attempt, ctx.error)
-
-				// Fire onDiscoveryError hook for each failed attempt
-				this.#safeHook('onDiscoveryError', () =>
-					this.options.hooks?.onDiscoveryError?.({
-						error: ctx.error,
-						attempt: ctx.attempt,
-						duration: performance.now() - discoveryStart,
-					})
-				)
-			},
-		}
-
-		let result = await retry(retryConfig, async (signal) => {
-			let client = (this.#discoveryClient ??= createClientFactory()
-				.use(this.#middleware)
-				.create(DiscoveryServiceDefinition, this.#connection.channel))
-
-			let response = await client.listEndpoints({ database: this.database }, { signal })
-			assert.ok(response.operation, new DriverResponseError('Missing operation data.'))
-
-			if (response.operation.status !== StatusIds_StatusCode.SUCCESS) {
-				throw new YDBError(response.operation.status, response.operation.issues)
-			}
-
-			let res = anyUnpack(response.operation.result!, ListEndpointsResultSchema)
-			assert.ok(res, new DriverResponseError('Missing result in operation data.'))
-
-			return res
-		})
-
-		dbg.log('discovered %d endpoints: %O', result.endpoints.length, result.endpoints)
-
-		let { added, removed } = this.#pool.sync(result.endpoints)
-
-		let endpoints: EndpointInfo[] = result.endpoints.map((ep) =>
-			Object.freeze<EndpointInfo>({
-				nodeId: BigInt(ep.nodeId),
-				address: `${ep.address}:${ep.port}`,
-				location: ep.location,
-			})
-		)
-
-		this.#safeHook('onDiscovery', () =>
-			this.options.hooks?.onDiscovery?.({
-				added,
-				removed,
-				duration: performance.now() - discoveryStart,
-				endpoints,
-			})
-		)
 	}
 
 	async ready(signal?: AbortSignal): Promise<void> {
@@ -365,16 +256,22 @@ export class Driver implements Disposable {
 	}
 
 	close(): void {
-		dbg.log('closing driver')
+		// Idempotent — mixing an explicit `driver.close()` with `using` /
+		// `Symbol.dispose` must not double-tear-down resources or double-fire
+		// lifecycle events.
+		if (this.#closed) return
+		this.#closed = true
+
+		let uptime = this.#readyAt ? performance.now() - this.#readyAt : 0
+		dbg.log('closing driver (uptime %d ms)', uptime)
+
 		if (this.#rediscoverTimer) {
-			dbg.log('clearing discovery timer')
 			clearInterval(this.#rediscoverTimer)
 		}
-		dbg.log('closing connection pool')
 		this.#pool.close()
-		dbg.log('closing primary connection')
 		this.#connection.close()
-		dbg.log('driver closed')
+
+		dc('ydb:driver.closed').publish({ database: this.database, uptime })
 	}
 
 	/**
@@ -416,6 +313,177 @@ export class Driver implements Disposable {
 
 	[Symbol.asyncDispose](): PromiseLike<void> {
 		return Promise.resolve(this.close())
+	}
+
+	#parseConnectionString(cs: string): URL {
+		if (!cs) {
+			throw new Error('Invalid connection string. Must be a non-empty string')
+		}
+
+		let url = new URL(cs.replace(/^grpc/, 'http'))
+		assert.match(url.protocol, /^(grpc|http)(s?):$/, new DriverCSProtocolError())
+		assert.ok(databaseFromUrl(url), new DriverCSDatabaseError())
+
+		return url
+	}
+
+	#mergeOptions(userOptions: Readonly<DriverOptions>): DriverOptions {
+		let merged: DriverOptions = { ...defaultOptions, ...userOptions }
+		merged.channelOptions = { ...defaultChannelOptions, ...merged.channelOptions }
+		return merged
+	}
+
+	#assertDiscoveryTimings(): void {
+		let timeout = this.options['ydb.sdk.discovery_timeout_ms']!
+		let interval = this.options['ydb.sdk.discovery_interval_ms']!
+
+		assert.ok(timeout > 0, new DriverDiscoveryTimeoutError(timeout))
+		assert.ok(interval > 0, new DriverDiscoveryIntervalError(interval))
+		assert.ok(timeout < interval, new DriverDiscoveryOptionsError())
+	}
+
+	#initialEndpoint() {
+		return create(EndpointInfoSchema, {
+			address: this.cs.hostname,
+			nodeId: -1,
+			port: parseInt(this.cs.port || (this.isSecure ? '443' : '80'), 10),
+			ssl: this.isSecure,
+		})
+	}
+
+	#createChannelCredentials() {
+		if ((this.options.secureOptions ??= this.options.ssl)) {
+			let secureContext = tls.createSecureContext(this.options.secureOptions)
+			return credentials.createFromSecureContext(secureContext)
+		}
+		return this.isSecure ? credentials.createSsl() : credentials.createInsecure()
+	}
+
+	#buildMiddleware(): ClientMiddleware {
+		let stamp: ClientMiddleware = (call, options) => {
+			let metadata = Metadata(options.metadata)
+				.set('x-ydb-sdk-build-info', `ydb-js-sdk/${pkg.version}`)
+				.set('x-ydb-database', this.database)
+				.set('x-ydb-application-name', this.application)
+
+			return call.next(call.request, Object.assign(options, { metadata }))
+		}
+
+		return composeClientMiddleware(
+			composeClientMiddleware(debug, stamp),
+			this.#credentialsProvider.middleware
+		)
+	}
+
+	#startDiscoveryLoop(): void {
+		let timeout = this.options['ydb.sdk.discovery_timeout_ms']!
+		let interval = this.options['ydb.sdk.discovery_interval_ms']!
+
+		dbg.log('discovery enabled, initial timeout %d ms, interval %d ms', timeout, interval)
+
+		this.#discovery(AbortSignal.timeout(timeout)).then(
+			() => this.#markReady(),
+			(error) => this.#markFailed(error)
+		)
+
+		this.#rediscoverTimer = setInterval(() => {
+			void this.#discovery(AbortSignal.timeout(timeout))
+		}, interval)
+
+		// Don't keep the process alive solely for rediscovery.
+		this.#rediscoverTimer.unref()
+	}
+
+	#markReady(): void {
+		this.#readyAt = performance.now()
+		let duration = this.#readyAt - this.#initAt
+		dbg.log('driver ready in %d ms', duration)
+		this.#ready.resolve()
+		dc('ydb:driver.ready').publish({ database: this.database, duration })
+	}
+
+	#markFailed(error: unknown): void {
+		let duration = performance.now() - this.#initAt
+		dbg.log('driver init failed after %d ms: %O', duration, error)
+		this.#ready.reject(error)
+		dc('ydb:driver.failed').publish({ database: this.database, duration, error })
+	}
+
+	async #discovery(signal: AbortSignal): Promise<void> {
+		await discoveryCh.tracePromise(() => this.#runDiscoveryRound(signal), {
+			database: this.database,
+		})
+	}
+
+	async #runDiscoveryRound(signal: AbortSignal): Promise<void> {
+		let started = performance.now()
+		let retryConfig: RetryConfig = {
+			...defaultRetryConfig,
+			signal,
+			onRetry: (ctx) => {
+				dbg.log('retrying discovery, attempt %d, error: %O', ctx.attempt, ctx.error)
+				this.#safeHook('onDiscoveryError', () =>
+					this.options.hooks?.onDiscoveryError?.({
+						error: ctx.error,
+						attempt: ctx.attempt,
+						duration: performance.now() - started,
+					})
+				)
+			},
+		}
+
+		let result = await retry(retryConfig, (s) => this.#fetchEndpoints(s))
+		let { added, removed } = this.#pool.sync(result.endpoints)
+		let duration = performance.now() - started
+
+		dbg.log(
+			'discovered %d endpoints (+%d / -%d) in %d ms',
+			result.endpoints.length,
+			added.length,
+			removed.length,
+			duration
+		)
+
+		dc('ydb:discovery.completed').publish({
+			database: this.database,
+			addedCount: added.length,
+			removedCount: removed.length,
+			totalCount: result.endpoints.length,
+			duration,
+		})
+
+		this.#safeHook('onDiscovery', () =>
+			this.options.hooks?.onDiscovery?.({
+				added,
+				removed,
+				duration,
+				endpoints: result.endpoints.map((ep) =>
+					Object.freeze<EndpointInfo>({
+						nodeId: BigInt(ep.nodeId),
+						address: `${ep.address}:${ep.port}`,
+						location: ep.location,
+					})
+				),
+			})
+		)
+	}
+
+	async #fetchEndpoints(signal: AbortSignal) {
+		let client = (this.#discoveryClient ??= createClientFactory()
+			.use(this.#middleware)
+			.create(DiscoveryServiceDefinition, this.#connection.channel))
+
+		let response = await client.listEndpoints({ database: this.database }, { signal })
+		assert.ok(response.operation, new DriverResponseError('Missing operation data.'))
+
+		if (response.operation.status !== StatusIds_StatusCode.SUCCESS) {
+			throw new YDBError(response.operation.status, response.operation.issues)
+		}
+
+		let res = anyUnpack(response.operation.result!, ListEndpointsResultSchema)
+		assert.ok(res, new DriverResponseError('Missing result in operation data.'))
+
+		return res
 	}
 
 	#safeHook(name: string, fn: () => void): void {

--- a/packages/core/src/pool.ts
+++ b/packages/core/src/pool.ts
@@ -1,11 +1,27 @@
-import type { EndpointInfo as ProtoEndpointInfo } from '@ydbjs/api/discovery'
-import { connectivityState } from '@grpc/grpc-js'
+import { channel as dc } from 'node:diagnostics_channel'
 
+import { connectivityState } from '@grpc/grpc-js'
+import type { EndpointInfo as ProtoEndpointInfo } from '@ydbjs/api/discovery'
 import { loggers } from '@ydbjs/debug'
 import type { ChannelCredentials, ChannelOptions } from 'nice-grpc'
 
 import { type Connection, GrpcConnection } from './conn.js'
 import type { DriverHooks, EndpointInfo } from './hooks.js'
+
+/**
+ * Reasons a connection was retired from active routing while its gRPC
+ * channel is left open to drain in-flight streams. See `#retireConnection`.
+ */
+type RetiredReason = 'stale_active' | 'stale_pessimized'
+
+/**
+ * Reasons a connection's gRPC channel was physically closed.
+ *   - 'replaced'   — discovery returned the same nodeId, channel was rebuilt.
+   - 'idle'       — idle sweep closed an unused or drained channel.
+ *   - 'pool_close' — pool itself is shutting down.
+ * See `#dropConnection`.
+ */
+type RemovedReason = 'replaced' | 'idle' | 'pool_close'
 
 export const POOL_INJECT_FOR_TESTING: unique symbol = Symbol('POOL_INJECT')
 export const POOL_GET_ACTIVE_FOR_TESTING: unique symbol = Symbol('POOL_ACTIVE')
@@ -118,9 +134,17 @@ export class ConnectionPool implements Disposable {
 		}
 
 		// Don't double-pessimize — refresh the timestamp if already pessimized
-		this.#pessimized.set(conn, Date.now() + this.options.pessimizationTimeout)
+		let until = Date.now() + this.options.pessimizationTimeout
+		this.#pessimized.set(conn, until)
 
 		dbg.log('pessimized node %d address %s', conn.endpoint.nodeId, conn.endpoint.address)
+
+		dc('ydb:pool.connection.pessimized').publish({
+			nodeId: conn.endpoint.nodeId,
+			address: conn.endpoint.address,
+			location: conn.endpoint.location,
+			until,
+		})
 
 		this.#safeHook('onPessimize', () => {
 			this.options.hooks?.onPessimize?.({ endpoint: conn.endpoint })
@@ -145,7 +169,8 @@ export class ConnectionPool implements Disposable {
 			}
 
 			let old = this.#connections.splice(i, 1)[0]!
-			old.close()
+			this.#acquired.delete(old)
+			this.#dropConnection(old, 'replaced')
 			dbg.log('replaced active connection to node %d', nodeId)
 		}
 
@@ -156,7 +181,8 @@ export class ConnectionPool implements Disposable {
 			}
 
 			this.#pessimized.delete(conn)
-			conn.close()
+			this.#acquired.delete(conn)
+			this.#dropConnection(conn, 'replaced')
 			dbg.log('replaced pessimized connection to node %d', nodeId)
 		}
 
@@ -167,7 +193,7 @@ export class ConnectionPool implements Disposable {
 			}
 
 			this.#retired.delete(conn)
-			conn.close()
+			this.#dropConnection(conn, 'replaced')
 			dbg.log('replaced retired connection to node %d', nodeId)
 		}
 
@@ -185,6 +211,12 @@ export class ConnectionPool implements Disposable {
 			conn.endpoint.address,
 			this.#connections.length
 		)
+
+		dc('ydb:pool.connection.added').publish({
+			nodeId: conn.endpoint.nodeId,
+			address: conn.endpoint.address,
+			location: conn.endpoint.location,
+		})
 	}
 
 	/**
@@ -216,9 +248,8 @@ export class ConnectionPool implements Disposable {
 
 			this.#connections.splice(i, 1)
 			this.#acquired.delete(conn)
-			this.#retired.add(conn)
+			this.#retireConnection(conn, 'stale_active')
 			removed.push(conn.endpoint)
-			dbg.log('removed stale active node %d from routing', conn.endpoint.nodeId)
 		}
 
 		// Remove stale endpoints from pessimized map.
@@ -230,9 +261,8 @@ export class ConnectionPool implements Disposable {
 
 			this.#pessimized.delete(conn)
 			this.#acquired.delete(conn)
-			this.#retired.add(conn)
+			this.#retireConnection(conn, 'stale_pessimized')
 			removed.push(conn.endpoint)
-			dbg.log('removed stale pessimized node %d from routing', conn.endpoint.nodeId)
 		}
 
 		// Determine which endpoints in the discovery response are genuinely new
@@ -312,15 +342,15 @@ export class ConnectionPool implements Disposable {
 		}
 
 		for (let conn of this.#connections) {
-			conn.close()
+			this.#dropConnection(conn, 'pool_close')
 		}
 
 		for (let conn of this.#pessimized.keys()) {
-			conn.close()
+			this.#dropConnection(conn, 'pool_close')
 		}
 
 		for (let conn of this.#retired) {
-			conn.close()
+			this.#dropConnection(conn, 'pool_close')
 		}
 
 		this.#connections.length = 0
@@ -367,6 +397,13 @@ export class ConnectionPool implements Disposable {
 					conn.endpoint.nodeId,
 					conn.endpoint.address
 				)
+
+				dc('ydb:pool.connection.unpessimized').publish({
+					nodeId: conn.endpoint.nodeId,
+					address: conn.endpoint.address,
+					location: conn.endpoint.location,
+					pessimizedDuration: this.options.pessimizationTimeout - (until - now),
+				})
 
 				this.#safeHook('onUnpessimize', () => {
 					this.options.hooks?.onUnpessimize?.({ endpoint: conn.endpoint })
@@ -425,9 +462,7 @@ export class ConnectionPool implements Disposable {
 
 			if (idleStates.includes(state)) {
 				this.#retired.delete(conn)
-				conn.close()
-
-				dbg.log('closed retired connection to node %d', conn.endpoint.nodeId)
+				this.#dropConnection(conn, 'idle')
 			}
 		}
 
@@ -441,8 +476,7 @@ export class ConnectionPool implements Disposable {
 				if (state !== connectivityState.READY) {
 					this.#connections.splice(i, 1)
 					this.#acquired.delete(conn)
-					conn.close()
-					dbg.log('closed idle active connection to node %d', conn.endpoint.nodeId)
+					this.#dropConnection(conn, 'idle')
 				}
 			}
 		}
@@ -460,6 +494,51 @@ export class ConnectionPool implements Disposable {
 		} catch (error) {
 			dbg.log('hook %s threw an error (swallowed): %O', name, error)
 		}
+	}
+
+	/**
+	 * Move a connection to the retired set. The gRPC channel stays open so
+	 * in-flight streams can drain; the idle sweep closes it later. Caller
+	 * removes the connection from `#connections` / `#pessimized` first.
+	 */
+	#retireConnection(conn: Connection, reason: RetiredReason): void {
+		this.#retired.add(conn)
+
+		dbg.log(
+			'retired node %d address %s (reason: %s)',
+			conn.endpoint.nodeId,
+			conn.endpoint.address,
+			reason
+		)
+
+		dc('ydb:pool.connection.retired').publish({
+			nodeId: conn.endpoint.nodeId,
+			address: conn.endpoint.address,
+			location: conn.endpoint.location,
+			reason,
+		})
+	}
+
+	/**
+	 * Close a connection's gRPC channel. Caller removes the connection from
+	 * any container (active list, pessimized map, retired set) first.
+	 */
+	#dropConnection(conn: Connection, reason: RemovedReason): void {
+		conn.close()
+
+		dbg.log(
+			'closed node %d address %s (reason: %s)',
+			conn.endpoint.nodeId,
+			conn.endpoint.address,
+			reason
+		)
+
+		dc('ydb:pool.connection.removed').publish({
+			nodeId: conn.endpoint.nodeId,
+			address: conn.endpoint.address,
+			location: conn.endpoint.location,
+			reason,
+		})
 	}
 
 	/**

--- a/packages/core/src/pool.ts
+++ b/packages/core/src/pool.ts
@@ -134,21 +134,28 @@ export class ConnectionPool implements Disposable {
 		}
 
 		// Don't double-pessimize — refresh the timestamp if already pessimized
+		let wasPessimized = this.#pessimized.has(conn)
 		let until = Date.now() + this.options.pessimizationTimeout
 		this.#pessimized.set(conn, until)
 
 		dbg.log('pessimized node %d address %s', conn.endpoint.nodeId, conn.endpoint.address)
 
-		dc('ydb:pool.connection.pessimized').publish({
-			nodeId: conn.endpoint.nodeId,
-			address: conn.endpoint.address,
-			location: conn.endpoint.location,
-			until,
-		})
+		// Only fire on the active→pessimized transition. Re-pessimize of an
+		// already-pessimized connection is a timeout refresh, not a state
+		// change — subscribers reconstructing pool state from delta events
+		// must not see it as a fresh transition.
+		if (!wasPessimized) {
+			dc('ydb:pool.connection.pessimized').publish({
+				nodeId: conn.endpoint.nodeId,
+				address: conn.endpoint.address,
+				location: conn.endpoint.location,
+				until,
+			})
 
-		this.#safeHook('onPessimize', () => {
-			this.options.hooks?.onPessimize?.({ endpoint: conn.endpoint })
-		})
+			this.#safeHook('onPessimize', () => {
+				this.options.hooks?.onPessimize?.({ endpoint: conn.endpoint })
+			})
+		}
 	}
 
 	/**

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -185,6 +185,9 @@ Security note: identifier() only quotes the name and escapes backticks. Do not p
 | ------------------------------- | ------- | ---------------------------------------------------------------------------------------------- |
 | `tracing:ydb:query.execute`     | tracing | `{ text, sessionId, nodeId, idempotent, isolation, stage }` — one `ExecuteQuery` RPC           |
 | `tracing:ydb:query.transaction` | tracing | `{ isolation, idempotent }` — from `tx.begin` to `commit`/`rollback`, including the retry loop |
+| `tracing:ydb:query.begin`       | tracing | `{ sessionId, nodeId, isolation }` — one `BeginTransaction` RPC                                |
+| `tracing:ydb:query.commit`      | tracing | `{ sessionId, nodeId, txId }` — one `CommitTransaction` RPC                                    |
+| `tracing:ydb:query.rollback`    | tracing | `{ sessionId, nodeId, txId }` — one `RollbackTransaction` RPC (fire-and-forget)                |
 
 `stage` is `'standalone'` for single-shot queries, `'tx'` for queries inside a transaction body, and `'do'` reserved for the future `sql.do(...)` runner.
 
@@ -208,12 +211,14 @@ ydb.query.transaction
 └─ ydb.retry.run
    ├─ ydb.retry.attempt #1
    │  ├─ ydb.session.acquire
-   │  ├─ ydb.query.execute  (BEGIN)
-   │  ├─ ydb.query.execute  (SELECT ...)
-   │  └─ ydb.query.execute  (COMMIT)
+   │  ├─ ydb.query.begin
+   │  ├─ ydb.query.execute   (SELECT ...)
+   │  └─ ydb.query.commit            ← or ydb.query.rollback on body throw
    └─ ydb.retry.attempt #2
       ...
 ```
+
+`query.begin` / `query.commit` / `query.rollback` each wrap exactly one server RPC. Use them for "begin/commit/rollback latency" and "rollback rate" metrics; `query.execute` is reserved for `ExecuteQuery` only. Rollback is fire-and-forget — its `start` always fires, but `asyncEnd` may land after the surrounding `query.transaction.error`.
 
 ### Subscribing
 

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -173,6 +173,89 @@ await sql`SELECT * FROM users ${unsafe('ORDER BY created_at DESC')}`
 
 Security note: identifier() only quotes the name and escapes backticks. Do not pass untrusted input without validation/allow‑listing.
 
+## Observability via `node:diagnostics_channel`
+
+`@ydbjs/query` publishes events on [`node:diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html) so external subscribers (`@ydbjs/telemetry`, OpenTelemetry, custom loggers) can build traces, metrics, and logs without coupling the SDK to a specific telemetry stack.
+
+### Channels
+
+#### Query execution
+
+| Channel                         | Type    | Payload                                                                                        |
+| ------------------------------- | ------- | ---------------------------------------------------------------------------------------------- |
+| `tracing:ydb:query.execute`     | tracing | `{ text, sessionId, nodeId, idempotent, isolation, stage }` — one `ExecuteQuery` RPC           |
+| `tracing:ydb:query.transaction` | tracing | `{ isolation, idempotent }` — from `tx.begin` to `commit`/`rollback`, including the retry loop |
+
+`stage` is `'standalone'` for single-shot queries, `'tx'` for queries inside a transaction body, and `'do'` reserved for the future `sql.do(...)` runner.
+
+#### Session pool
+
+| Channel                       | Type    | Payload                                                            |
+| ----------------------------- | ------- | ------------------------------------------------------------------ |
+| `tracing:ydb:session.acquire` | tracing | `{ kind: 'query' \| 'transaction' }`                               |
+| `tracing:ydb:session.create`  | tracing | `{ liveSessions, maxSize, creating }` — only when the pool grows   |
+| `ydb:session.created`         | publish | `{ sessionId, nodeId }`                                            |
+| `ydb:session.closed`          | publish | `{ sessionId, nodeId, reason: 'evicted' \| 'pool_close', uptime }` |
+
+`session.closed` fires **once** per session lifecycle. `reason` distinguishes server-side teardown (`evicted` — attach stream died, e.g. session expired or was dropped by the server) from explicit pool shutdown (`pool_close` — emitted for every session still tracked by the pool when `pool.close()` runs).
+
+### Retry hierarchy
+
+Retry-loop spans (`tracing:ydb:retry.run`, `tracing:ydb:retry.attempt`, `ydb:retry.exhausted`) come from `@ydbjs/retry` and nest correctly under `query.transaction` / `query.execute` via `AsyncLocalStorage` propagation in `tracePromise`. Subscribers see a tree like:
+
+```
+ydb.query.transaction
+└─ ydb.retry.run
+   ├─ ydb.retry.attempt #1
+   │  ├─ ydb.session.acquire
+   │  ├─ ydb.query.execute  (BEGIN)
+   │  ├─ ydb.query.execute  (SELECT ...)
+   │  └─ ydb.query.execute  (COMMIT)
+   └─ ydb.retry.attempt #2
+      ...
+```
+
+### Subscribing
+
+```ts
+import { channel, tracingChannel } from 'node:diagnostics_channel'
+
+tracingChannel('tracing:ydb:query.execute').subscribe({
+  start(ctx) {
+    span.start({
+      name: 'ydb.query.execute',
+      attributes: {
+        'db.system': 'ydb',
+        'db.statement': ctx.text,
+        'db.ydb.session_id': ctx.sessionId,
+        'db.ydb.node_id': String(ctx.nodeId),
+        'db.ydb.isolation': ctx.isolation,
+        'db.ydb.stage': ctx.stage,
+      },
+    })
+  },
+  asyncEnd() {
+    span.end()
+  },
+  error(ctx) {
+    span.recordException(ctx.error)
+    span.end()
+  },
+})
+
+channel('ydb:session.closed').subscribe((msg) => {
+  metrics.sessionLifetime.record(msg.uptime, { reason: msg.reason })
+})
+```
+
+### ⚠️ Subscribers must be safe
+
+**`node:diagnostics_channel` invokes subscribers synchronously.** Any exception thrown inside a subscriber propagates up the call stack and **will** disrupt the SDK — a buggy subscriber can break a query mid-flight or leak a session lease. `@ydbjs/query` does **not** wrap your subscribers; wrap them yourself in `try/catch`.
+
+### Stability
+
+Channel names, payload field names, and the `stage` / `reason` / `kind` enums follow semantic versioning. Adding new optional fields or new enum values is a minor change; renaming or removing fields is a major change.
+
 ## Development
 
 ### Building the Package

--- a/packages/query/src/ctx.ts
+++ b/packages/query/src/ctx.ts
@@ -1,9 +1,16 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import type { Abortable } from 'node:events'
 
+import type { Session } from './session.js'
+
+/**
+ * Async-local context carried across an `sql.begin()` body. The Session
+ * instance is the source of truth for `sessionId` / `nodeId`; we don't
+ * duplicate them here. `transactionId` is the only piece that's not
+ * derivable from Session — it's per-attempt of the tx body.
+ */
 type Context = Abortable & {
-	nodeId?: bigint
-	sessionId?: string
+	session?: Session
 	transactionId?: string
 }
 

--- a/packages/query/src/diagnostics.test.ts
+++ b/packages/query/src/diagnostics.test.ts
@@ -190,6 +190,28 @@ test('publishes ydb:session.closed with reason=pool_close once per session on po
 	}
 })
 
+test('release of a checked-out session after pool.close() fires ydb:session.closed exactly once', async () => {
+	srv = await startServer()
+	pool = new SessionPool(srv.driver, { maxSize: 1 })
+
+	// Hold the session — do not release it before close().
+	let lease = await pool.acquire()
+
+	using closed = collect('ydb:session.closed')
+
+	// Race: pool.close() flips this.closed and awaits in-flight creates.
+	// While that promise pends, drop the lease so release() takes the
+	// closed-pool branch, which calls session.close() and would re-fire
+	// `evicted` through the eviction listener if it were still attached.
+	let closing = pool.close()
+	lease[Symbol.dispose]()
+	await closing
+	pool = undefined
+
+	expect(closed.payloads).toHaveLength(1)
+	expect(closed.payloads[0]).toMatchObject({ reason: 'pool_close' })
+})
+
 test('traces tracing:ydb:session.create with liveSessions/maxSize/creating context', async () => {
 	srv = await startServer()
 	pool = new SessionPool(srv.driver, { maxSize: 1 })

--- a/packages/query/src/diagnostics.test.ts
+++ b/packages/query/src/diagnostics.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, expect, test } from 'vitest'
+import { channel as dc, tracingChannel } from 'node:diagnostics_channel'
+import { createServer } from 'nice-grpc'
+import { create } from '@bufbuild/protobuf'
+
+import { StatusIds_StatusCode } from '@ydbjs/api/operation'
+import {
+	CreateSessionResponseSchema,
+	DeleteSessionResponseSchema,
+	QueryServiceDefinition,
+	SessionStateSchema,
+} from '@ydbjs/api/query'
+import { Driver } from '@ydbjs/core'
+
+import { SessionPool } from './session-pool.ts'
+
+// ── Minimal query server harness ──────────────────────────────────────────────
+
+async function startServer() {
+	let nextId = 0
+	let attachCtrls = new Map<string, AbortController>()
+
+	let server = createServer()
+	server.add(
+		{
+			createSession: QueryServiceDefinition.createSession,
+			deleteSession: QueryServiceDefinition.deleteSession,
+			attachSession: QueryServiceDefinition.attachSession,
+		},
+		{
+			async createSession() {
+				let sessionId = `ses-${++nextId}`
+				attachCtrls.set(sessionId, new AbortController())
+				return create(CreateSessionResponseSchema, {
+					status: StatusIds_StatusCode.SUCCESS,
+					sessionId,
+					nodeId: 1n,
+				})
+			},
+			async deleteSession(req) {
+				attachCtrls.get(req.sessionId)?.abort()
+				return create(DeleteSessionResponseSchema, {
+					status: StatusIds_StatusCode.SUCCESS,
+				})
+			},
+			async *attachSession(req, ctx) {
+				let serverCtrl = attachCtrls.get(req.sessionId) ?? new AbortController()
+				yield create(SessionStateSchema, { status: StatusIds_StatusCode.SUCCESS })
+				await new Promise<void>((resolve) => {
+					ctx.signal.addEventListener('abort', () => resolve(), { once: true })
+					serverCtrl.signal.addEventListener('abort', () => resolve(), { once: true })
+				})
+			},
+		}
+	)
+
+	let port = await server.listen('127.0.0.1:0')
+	let driver = new Driver(`grpc://127.0.0.1:${port}/local`, {
+		'ydb.sdk.enable_discovery': false,
+	})
+
+	return {
+		driver,
+		breakSession(id: string) {
+			attachCtrls.get(id)?.abort()
+		},
+		async close() {
+			driver.close()
+			await server.shutdown()
+		},
+	}
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Subscribe to a plain channel; returned object is `Disposable`. */
+function collect(name: string): { payloads: unknown[] } & Disposable {
+	let payloads: unknown[] = []
+	let fn = (msg: unknown) => payloads.push(structuredClone(msg))
+	dc(name).subscribe(fn)
+	return {
+		payloads,
+		[Symbol.dispose]() {
+			dc(name).unsubscribe(fn)
+		},
+	}
+}
+
+/** Subscribe to a tracing channel; capture start / asyncEnd / error contexts. */
+function collectTrace(name: string): {
+	start: object[]
+	asyncEnd: object[]
+	error: (object & { error: unknown })[]
+} & Disposable {
+	let ch = tracingChannel(name)
+	let start: object[] = []
+	let asyncEnd: object[] = []
+	let error: (object & { error: unknown })[] = []
+	let handlers = {
+		start: (ctx: any) => start.push({ ...ctx }),
+		asyncEnd: (ctx: any) => asyncEnd.push({ ...ctx }),
+		error: (ctx: any) => error.push({ ...ctx }),
+	}
+	ch.subscribe(handlers as any)
+	return {
+		start,
+		asyncEnd,
+		error,
+		[Symbol.dispose]() {
+			ch.unsubscribe(handlers as any)
+		},
+	}
+}
+
+type Server = Awaited<ReturnType<typeof startServer>>
+let srv: Server | undefined
+let pool: SessionPool | undefined
+
+afterEach(async () => {
+	await pool?.close().catch(() => {})
+	pool = undefined
+	await srv?.close()
+	srv = undefined
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test('publishes ydb:session.created with sessionId and nodeId after pool.acquire()', async () => {
+	srv = await startServer()
+	pool = new SessionPool(srv.driver, { maxSize: 1 })
+
+	using created = collect('ydb:session.created')
+
+	let lease = await pool.acquire()
+	lease[Symbol.dispose]()
+
+	expect(created.payloads).toHaveLength(1)
+	expect(created.payloads[0]).toMatchObject({
+		sessionId: expect.stringContaining('ses-'),
+		nodeId: 1n,
+	})
+})
+
+test('publishes ydb:session.closed with reason=evicted when the server kills the attach stream', async () => {
+	srv = await startServer()
+	pool = new SessionPool(srv.driver, { maxSize: 1 })
+
+	let lease = await pool.acquire()
+	let sessionId = lease.id
+	lease[Symbol.dispose]()
+
+	using closed = collect('ydb:session.closed')
+
+	srv.breakSession(sessionId)
+	// Give the attach-stream abort time to propagate.
+	await new Promise((r) => setTimeout(r, 60))
+
+	expect(closed.payloads).toHaveLength(1)
+	expect(closed.payloads[0]).toMatchObject({
+		sessionId,
+		reason: 'evicted',
+	})
+})
+
+test('publishes ydb:session.closed with reason=pool_close once per session on pool.close()', async () => {
+	srv = await startServer()
+	pool = new SessionPool(srv.driver, { maxSize: 2 })
+
+	// Two sessions in the pool (idle after release).
+	let a = await pool.acquire()
+	let b = await pool.acquire()
+	a[Symbol.dispose]()
+	b[Symbol.dispose]()
+
+	using closed = collect('ydb:session.closed')
+
+	await pool.close()
+	pool = undefined
+
+	// Exactly two events — one per session — and never doubled by the
+	// eviction listener (the pool detaches it before tearing down).
+	expect(closed.payloads).toHaveLength(2)
+	for (let p of closed.payloads) {
+		expect(p).toMatchObject({
+			sessionId: expect.stringContaining('ses-'),
+			nodeId: 1n,
+			reason: 'pool_close',
+		})
+		expect(typeof (p as any).uptime).toBe('number')
+	}
+})
+
+test('traces tracing:ydb:session.create with liveSessions/maxSize/creating context', async () => {
+	srv = await startServer()
+	pool = new SessionPool(srv.driver, { maxSize: 1 })
+
+	using trace = collectTrace('tracing:ydb:session.create')
+
+	let lease = await pool.acquire()
+	lease[Symbol.dispose]()
+
+	expect(trace.start.length).toBeGreaterThanOrEqual(1)
+	expect(trace.asyncEnd.length).toBeGreaterThanOrEqual(1)
+	expect(trace.start[0]).toMatchObject({
+		liveSessions: 0,
+		maxSize: 1,
+		creating: 0,
+	})
+})
+
+test('traces tracing:ydb:session.acquire with kind=query', async () => {
+	srv = await startServer()
+	pool = new SessionPool(srv.driver, { maxSize: 1 })
+
+	// Pre-warm so acquire goes through fast path; tracePromise still wraps.
+	let warm = await pool.acquire()
+	warm[Symbol.dispose]()
+
+	using trace = collectTrace('tracing:ydb:session.acquire')
+
+	// Drive the channel through the public sessionAcquireCh export by
+	// importing it via the same pool surface.
+	let { sessionAcquireCh } = await import('./session-pool.ts')
+	let lease = await sessionAcquireCh.tracePromise(() => pool!.acquire(), {
+		kind: 'query',
+	})
+	lease[Symbol.dispose]()
+
+	expect(trace.start.length).toBeGreaterThanOrEqual(1)
+	expect(trace.asyncEnd.length).toBeGreaterThanOrEqual(1)
+	expect(trace.start[0]).toMatchObject({ kind: 'query' })
+})

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1,24 +1,37 @@
 import type { Abortable } from 'node:events'
+import { tracingChannel } from 'node:diagnostics_channel'
 
 import { linkSignals } from '@ydbjs/abortable'
 import { StatusIds_StatusCode } from '@ydbjs/api/operation'
 import { QueryServiceDefinition } from '@ydbjs/api/query'
 import type { Driver } from '@ydbjs/core'
 import { CommitError, YDBError } from '@ydbjs/error'
-import { defaultRetryConfig, isRetryableError, retry } from '@ydbjs/retry'
+import {
+	type RetryConfig,
+	type RetryContext,
+	defaultRetryConfig,
+	isRetryableError,
+	retry,
+} from '@ydbjs/retry'
 import { loggers } from '@ydbjs/debug'
 
 import { Query } from './query.js'
 import { ctx } from './ctx.js'
 import { UnsafeString, identifier, unsafe, yql } from './yql.js'
-import { SessionPool, type SessionPoolOptions } from './session-pool.js'
+import { SessionPool, type SessionPoolOptions, sessionAcquireCh } from './session-pool.js'
+
+type TransactionContext = {
+	isolation: string
+	idempotent: boolean
+}
+
+let transactionCh = tracingChannel<TransactionContext, TransactionContext>(
+	'tracing:ydb:query.transaction'
+)
 
 let dbg = loggers.query
 
 export type QueryOptions = {
-	/**
-	 * Session pool configuration
-	 */
 	poolOptions?: SessionPoolOptions
 }
 
@@ -96,7 +109,7 @@ export interface QueryClient extends SQL, AsyncDisposable {
 	unsafe(value: string | { toString(): string }): UnsafeString
 }
 
-const doImpl = function <T = unknown>(): Promise<T> {
+let doImpl = function <T = unknown>(): Promise<T> {
 	throw new Error('Not implemented')
 }
 
@@ -185,164 +198,178 @@ export function query(driver: Driver, options?: QueryOptions): QueryClient {
 
 		let sessionDiedLastAttempt = false
 
-		return retry(
-			{
-				...defaultRetryConfig,
-				signal: options.signal,
-				// Caller's flag flows through the retry layer unchanged and
-				// lands back in the callback as the second arg — single source
-				// of truth for whether the body is safe to replay.
-				idempotent,
-				retry: (error, idempotent) => {
-					let sessionDied = sessionDiedLastAttempt
-					sessionDiedLastAttempt = false
-					// A session abort mid-tx means we don't know whether the
-					// server applied any side effects — only re-open if the
-					// caller opted into idempotent retries.
-					return isRetryableError(error, idempotent) || (sessionDied && idempotent)
+		let acquireSession = (signal: AbortSignal) =>
+			sessionAcquireCh.tracePromise(() => sessionPool.acquire(signal), {
+				kind: 'transaction',
+			})
+
+		let runAttempt = async (retrySignal: AbortSignal) => {
+			dbg.log('acquiring session from pool for transaction')
+			using sessionLease = await acquireSession(retrySignal)
+			// `sessionLease` exists only for lifecycle (auto-release on scope
+			// exit). All RPC-level work — begin/commit/rollback, ctx wiring,
+			// nested queries inside the body — talks to the underlying Session
+			// directly. One source of truth, no parallel id/nodeId fields.
+			let session = sessionLease.session
+			dbg.log('session %s acquired for transaction', session.id)
+
+			// linkSignals is disposed on scope exit — no listener buildup
+			// on the long-lived session signal across tx retries.
+			using linked = linkSignals(retrySignal, sessionLease.signal)
+			let signal = linked.signal
+
+			let attemptStore: typeof parentStore = {
+				...parentStore,
+				signal,
+				session,
+			}
+
+			let client = driver.createClient(QueryServiceDefinition, session.nodeId)
+
+			let beginTransactionResult = await client.beginTransaction(
+				{
+					sessionId: session.id,
+					txSettings: {
+						txMode: { case: options.isolation!, value: {} },
+					},
 				},
-				onRetry: (ctx) => {
-					dbg.log('retrying transaction, attempt %d, error: %O', ctx.attempt, ctx.error)
-				},
-			},
-			async (retrySignal) => {
-				dbg.log('acquiring session from pool for transaction')
-				using sessionLease = await sessionPool.acquire(retrySignal)
-				dbg.log('session %s acquired for transaction', sessionLease.id)
+				{ signal }
+			)
+			if (beginTransactionResult.status !== StatusIds_StatusCode.SUCCESS) {
+				dbg.log('failed to begin transaction, status: %d', beginTransactionResult.status)
+				throw new YDBError(beginTransactionResult.status, beginTransactionResult.issues)
+			}
 
-				// linkSignals is disposed on scope exit — no listener buildup
-				// on the long-lived session signal across tx retries.
-				using linked = linkSignals(retrySignal, sessionLease.signal)
-				let signal = linked.signal
+			attemptStore.transactionId = beginTransactionResult.txMeta!.id
 
-				let attemptStore: typeof parentStore = {
-					...parentStore,
-					signal,
-					nodeId: sessionLease.nodeId,
-					sessionId: sessionLease.id,
-				}
+			let commitHooks: Array<(signal?: AbortSignal) => Promise<void> | void> = []
+			let rollbackHooks: Array<
+				(error: unknown, signal?: AbortSignal) => Promise<void> | void
+			> = []
+			let closeHooks: Array<
+				(committed: boolean, signal?: AbortSignal) => Promise<void> | void
+			> = []
 
-				let client = driver.createClient(QueryServiceDefinition, sessionLease.nodeId)
+			let committed = false
+			try {
+				let tx = Object.assign(yqlQuery, {
+					nodeId: session.nodeId,
+					sessionId: session.id,
+					transactionId: attemptStore.transactionId,
+					onRollback: (fn: () => Promise<void> | void) => {
+						rollbackHooks.push(fn)
+					},
+					onCommit: (fn: () => Promise<void> | void) => {
+						commitHooks.push(fn)
+					},
+					onClose: (fn: () => Promise<void> | void) => {
+						closeHooks.push(fn)
+					},
+				}) as TX
 
-				let beginTransactionResult = await client.beginTransaction(
+				dbg.log('executing transaction body')
+				let result = await ctx.run(attemptStore, () => caller!(tx, signal))
+
+				dbg.log('executing %d commit hooks', commitHooks.length)
+				await Promise.all(
+					commitHooks.map(async (hook, i) => {
+						dbg.log('executing commit hook #%d', i + 1)
+						await hook(signal)
+						dbg.log('commit hook #%d completed', i + 1)
+					})
+				)
+
+				dbg.log('committing transaction')
+				let commitResult = await client.commitTransaction(
 					{
-						sessionId: attemptStore.sessionId!,
-						txSettings: {
-							txMode: { case: options.isolation!, value: {} },
-						},
+						sessionId: session.id,
+						txId: attemptStore.transactionId,
 					},
 					{ signal }
 				)
-				if (beginTransactionResult.status !== StatusIds_StatusCode.SUCCESS) {
-					dbg.log(
-						'failed to begin transaction, status: %d',
-						beginTransactionResult.status
-					)
-					throw new YDBError(beginTransactionResult.status, beginTransactionResult.issues)
-				}
-
-				attemptStore.transactionId = beginTransactionResult.txMeta!.id
-
-				let commitHooks: Array<(signal?: AbortSignal) => Promise<void> | void> = []
-				let rollbackHooks: Array<
-					(error: unknown, signal?: AbortSignal) => Promise<void> | void
-				> = []
-				let closeHooks: Array<
-					(committed: boolean, signal?: AbortSignal) => Promise<void> | void
-				> = []
-
-				let committed = false
-				try {
-					let tx = Object.assign(yqlQuery, {
-						nodeId: attemptStore.nodeId,
-						sessionId: attemptStore.sessionId,
-						transactionId: attemptStore.transactionId,
-						onRollback: (fn: () => Promise<void> | void) => {
-							rollbackHooks.push(fn)
-						},
-						onCommit: (fn: () => Promise<void> | void) => {
-							commitHooks.push(fn)
-						},
-						onClose: (fn: () => Promise<void> | void) => {
-							closeHooks.push(fn)
-						},
-					}) as TX
-
-					dbg.log('executing transaction body')
-					let result = await ctx.run(attemptStore, () => caller!(tx, signal))
-
-					dbg.log('executing %d commit hooks', commitHooks.length)
-					await Promise.all(
-						commitHooks.map(async (hook, i) => {
-							dbg.log('executing commit hook #%d', i + 1)
-							await hook(signal)
-							dbg.log('commit hook #%d completed', i + 1)
-						})
-					)
-
-					dbg.log('committing transaction')
-					let commitResult = await client.commitTransaction(
-						{
-							sessionId: attemptStore.sessionId!,
-							txId: attemptStore.transactionId,
-						},
-						{ signal }
-					)
-					if (commitResult.status !== StatusIds_StatusCode.SUCCESS) {
-						dbg.log('failed to commit transaction, status: %d', commitResult.status)
-						throw new CommitError(
-							'Transaction commit failed.',
-							new YDBError(commitResult.status, commitResult.issues)
-						)
-					}
-
-					committed = true
-					dbg.log('transaction committed successfully')
-					return result
-				} catch (error) {
-					dbg.log('transaction error: %O', error)
-
-					// Signal up to the retry callback that this attempt tore down
-					// because the session died — lets it retry with a fresh one
-					// if the caller opted into idempotent retries.
-					if (sessionLease.signal.aborted) {
-						sessionDiedLastAttempt = true
-					}
-
-					dbg.log('executing %d rollback hooks', rollbackHooks.length)
-					await Promise.all(
-						rollbackHooks.map(async (hook, i) => {
-							dbg.log('executing rollback hook #%d', i + 1)
-							await hook(error, signal)
-							dbg.log('rollback hook #%d completed', i + 1)
-						})
-					)
-
-					client
-						.rollbackTransaction({
-							sessionId: attemptStore.sessionId!,
-							txId: attemptStore.transactionId,
-						})
-						.catch(() => {})
-
-					if (!isRetryableError(error, idempotent)) {
-						dbg.log('transaction not retryable, aborting')
-						throw new Error('Transaction failed.', { cause: error })
-					}
-
-					throw error
-				} finally {
-					dbg.log('executing %d close hooks', closeHooks.length)
-					await Promise.all(
-						closeHooks.map(async (hook, i) => {
-							dbg.log('executing close hook #%d', i + 1)
-							await hook(committed, signal)
-							dbg.log('close hook #%d completed', i + 1)
-						})
+				if (commitResult.status !== StatusIds_StatusCode.SUCCESS) {
+					dbg.log('failed to commit transaction, status: %d', commitResult.status)
+					throw new CommitError(
+						'Transaction commit failed.',
+						new YDBError(commitResult.status, commitResult.issues)
 					)
 				}
+
+				committed = true
+				dbg.log('transaction committed successfully')
+				return result
+			} catch (error) {
+				dbg.log('transaction error: %O', error)
+
+				// Signal up to the retry callback that this attempt tore down
+				// because the session died — lets it retry with a fresh one
+				// if the caller opted into idempotent retries.
+				if (session.signal.aborted) {
+					sessionDiedLastAttempt = true
+				}
+
+				dbg.log('executing %d rollback hooks', rollbackHooks.length)
+				await Promise.all(
+					rollbackHooks.map(async (hook, i) => {
+						dbg.log('executing rollback hook #%d', i + 1)
+						await hook(error, signal)
+						dbg.log('rollback hook #%d completed', i + 1)
+					})
+				)
+
+				client
+					.rollbackTransaction({
+						sessionId: session.id,
+						txId: attemptStore.transactionId,
+					})
+					.catch(() => {})
+
+				if (!isRetryableError(error, idempotent)) {
+					dbg.log('transaction not retryable, aborting')
+					throw new Error('Transaction failed.', { cause: error })
+				}
+
+				throw error
+			} finally {
+				dbg.log('executing %d close hooks', closeHooks.length)
+				await Promise.all(
+					closeHooks.map(async (hook, i) => {
+						dbg.log('executing close hook #%d', i + 1)
+						await hook(committed, signal)
+						dbg.log('close hook #%d completed', i + 1)
+					})
+				)
 			}
-		)
+		}
+
+		let retryConfig: RetryConfig = {
+			...defaultRetryConfig,
+			signal: options.signal,
+			// Caller's flag flows through the retry layer unchanged and
+			// lands back in the callback as the second arg — single source
+			// of truth for whether the body is safe to replay.
+			idempotent,
+			retry: (error: unknown, idempotent: boolean) => {
+				let sessionDied = sessionDiedLastAttempt
+				sessionDiedLastAttempt = false
+				// A session abort mid-tx means we don't know whether the
+				// server applied any side effects — only re-open if the
+				// caller opted into idempotent retries.
+				return isRetryableError(error, idempotent) || (sessionDied && idempotent)
+			},
+			onRetry: (retryCtx: RetryContext) => {
+				dbg.log(
+					'retrying transaction, attempt %d, error: %O',
+					retryCtx.attempt,
+					retryCtx.error
+				)
+			},
+		}
+
+		return transactionCh.tracePromise(() => retry(retryConfig, runAttempt), {
+			isolation: options.isolation!,
+			idempotent,
+		})
 	}
 
 	return Object.assign(yqlQuery, {

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -29,6 +29,13 @@ let transactionCh = tracingChannel<TransactionContext, TransactionContext>(
 	'tracing:ydb:query.transaction'
 )
 
+type TxBeginContext = { sessionId: string; nodeId: bigint; isolation: string }
+type TxControlContext = { sessionId: string; nodeId: bigint; txId: string }
+
+let txBeginCh = tracingChannel<TxBeginContext, TxBeginContext>('tracing:ydb:query.begin')
+let txCommitCh = tracingChannel<TxControlContext, TxControlContext>('tracing:ydb:query.commit')
+let txRollbackCh = tracingChannel<TxControlContext, TxControlContext>('tracing:ydb:query.rollback')
+
 let dbg = loggers.query
 
 export type QueryOptions = {
@@ -226,14 +233,18 @@ export function query(driver: Driver, options?: QueryOptions): QueryClient {
 
 			let client = driver.createClient(QueryServiceDefinition, session.nodeId)
 
-			let beginTransactionResult = await client.beginTransaction(
-				{
-					sessionId: session.id,
-					txSettings: {
-						txMode: { case: options.isolation!, value: {} },
-					},
-				},
-				{ signal }
+			let beginTransactionResult = await txBeginCh.tracePromise(
+				() =>
+					client.beginTransaction(
+						{
+							sessionId: session.id,
+							txSettings: {
+								txMode: { case: options.isolation!, value: {} },
+							},
+						},
+						{ signal }
+					),
+				{ sessionId: session.id, nodeId: session.nodeId, isolation: options.isolation! }
 			)
 			if (beginTransactionResult.status !== StatusIds_StatusCode.SUCCESS) {
 				dbg.log('failed to begin transaction, status: %d', beginTransactionResult.status)
@@ -280,12 +291,21 @@ export function query(driver: Driver, options?: QueryOptions): QueryClient {
 				)
 
 				dbg.log('committing transaction')
-				let commitResult = await client.commitTransaction(
+				let txId = attemptStore.transactionId!
+				let commitResult = await txCommitCh.tracePromise(
+					() =>
+						client.commitTransaction(
+							{
+								sessionId: session.id,
+								txId,
+							},
+							{ signal }
+						),
 					{
 						sessionId: session.id,
-						txId: attemptStore.transactionId,
-					},
-					{ signal }
+						nodeId: session.nodeId,
+						txId,
+					}
 				)
 				if (commitResult.status !== StatusIds_StatusCode.SUCCESS) {
 					dbg.log('failed to commit transaction, status: %d', commitResult.status)
@@ -317,11 +337,23 @@ export function query(driver: Driver, options?: QueryOptions): QueryClient {
 					})
 				)
 
-				client
-					.rollbackTransaction({
-						sessionId: session.id,
-						txId: attemptStore.transactionId,
-					})
+				// Fire-and-forget rollback. tracePromise sees the underlying
+				// promise (so `error` sub-channel fires on failure); the outer
+				// `.catch` keeps the rejection from becoming unhandled here.
+				let rollbackTxId = attemptStore.transactionId!
+				txRollbackCh
+					.tracePromise(
+						() =>
+							client.rollbackTransaction({
+								sessionId: session.id,
+								txId: rollbackTxId,
+							}),
+						{
+							sessionId: session.id,
+							nodeId: session.nodeId,
+							txId: rollbackTxId,
+						}
+					)
 					.catch(() => {})
 
 				if (!isRetryableError(error, idempotent)) {

--- a/packages/query/src/query.ts
+++ b/packages/query/src/query.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events'
+import { tracingChannel } from 'node:diagnostics_channel'
 
 import { create } from '@bufbuild/protobuf'
 import { StatusIds_StatusCode } from '@ydbjs/api/operation'
@@ -28,7 +29,29 @@ import type { Metadata } from 'nice-grpc'
 
 import { ctx } from './ctx.js'
 import { linkSignals } from '@ydbjs/abortable'
-import type { SessionPool } from './session-pool.js'
+import { type SessionPool, sessionAcquireCh } from './session-pool.js'
+
+/**
+ * Where this query was issued from. Lets subscribers split latency by
+ * shape:
+ *   - 'standalone' — single-shot `sql\`...\`` outside any transaction.
+ *   - 'tx'         — inside a `sql.begin()` / `sql.transaction()` body.
+ *   - 'do'         — reserved for the future `sql.do(...)` runner.
+ */
+type QueryStage = 'standalone' | 'tx' | 'do'
+
+type QueryExecuteContext = {
+	text: string
+	sessionId: string
+	nodeId: bigint
+	idempotent: boolean
+	isolation: string
+	stage: QueryStage
+}
+
+let executeQueryCh = tracingChannel<QueryExecuteContext, QueryExecuteContext>(
+	'tracing:ydb:query.execute'
+)
 
 let dbg = loggers.query
 
@@ -110,14 +133,12 @@ export class Query<T extends any[] = unknown[]>
 
 	async #execute(): Promise<ArrayifyTuple<T>> {
 		let store = ctx.getStore() || {}
-		// `txSessionId` / `txNodeId` are set only when we run inside a
-		// transaction — the transaction body owns the session. Outside a
-		// transaction they stay undefined and every retry attempt grabs a
-		// fresh lease from the pool. Treating these as closure-local (vs
-		// mutating them per attempt) prevents a released session from being
-		// reused across retries by a different caller.
-		let txSessionId = store.sessionId
-		let txNodeId = store.nodeId
+		// `txSession` is set only when we run inside a transaction — the tx
+		// body owns the session. Outside a transaction it stays undefined and
+		// every retry attempt grabs a fresh lease from the pool. Treating
+		// this as closure-local (vs mutating per attempt) prevents a released
+		// session from being reused across retries by a different caller.
+		let txSession = store.session
 		let transactionId = store.transactionId
 		let txSignal = store.signal
 
@@ -169,18 +190,33 @@ export class Query<T extends any[] = unknown[]>
 
 		await this.#driver.ready(linkedSignal.signal)
 
-		this.#promise = retry(retryConfig, async (retrySignal) => {
+		let stage: QueryStage = txSession ? 'tx' : 'standalone'
+
+		let runAttempt = async (retrySignal: AbortSignal) => {
 			// Transaction-owned session stays pinned; out-of-transaction
 			// attempts always get a fresh lease — no cross-attempt reuse.
-			using sessionLease = txSessionId
+			using sessionLease = txSession
 				? undefined
-				: await this.#sessionPool.acquire(retrySignal)
-			let attemptSessionId = txSessionId ?? sessionLease!.id
-			let attemptNodeId = txNodeId ?? sessionLease!.nodeId
+				: await sessionAcquireCh.tracePromise(
+						() => this.#sessionPool.acquire(retrySignal),
+						{ kind: 'query' }
+					)
+			let session = txSession ?? sessionLease!.session
+			let attemptSessionId = session.id
+			let attemptNodeId = session.nodeId
+
+			// Single-threaded session guard. YDB processes RPCs on a session
+			// sequentially, so concurrent statements on the same session
+			// (e.g. `Promise.all([tx`a`, tx`b`])`) hang on a server-side lock
+			// and confuse retry semantics. `claim()` throws SessionBusyError
+			// (non-retryable) and is released on scope exit via `using`.
+			using _claim = session.claim()
 
 			// linkSignals cleans up listeners on dispose — no accumulation
-			// on the long-lived session signal across many queries.
-			using linked = linkSignals(retrySignal, sessionLease?.signal)
+			// on the long-lived session signal across many queries. We link to
+			// `session.signal` directly: in a tx body there's no lease (the tx
+			// owns the session), so the lease-mirrored signal isn't available.
+			using linked = linkSignals(retrySignal, session.signal)
 			let signal = linked.signal
 
 			if (sessionLease) {
@@ -223,87 +259,109 @@ export class Query<T extends any[] = unknown[]>
 				})
 			}
 
-			let stream = client.executeQuery(
-				{
-					sessionId: attemptSessionId,
-					execMode: ExecMode.EXECUTE,
-					query: {
-						case: 'queryContent',
-						value: {
-							syntax: this.#syntax,
-							text: this.text,
-						},
-					},
-					parameters,
-					statsMode: this.#statsMode,
-					...(this.#poolId && { poolId: this.#poolId }),
-					...(txControl && { txControl }),
-				},
-				{
-					signal,
-					onTrailer: (trailer) => {
-						this.emit('metadata', trailer)
-					},
-				}
-			)
-
-			let results = [] as ArrayifyTuple<T>
-
-			try {
-				for await (let part of stream) {
-					signal.throwIfAborted()
-
-					if (part.status !== StatusIds_StatusCode.SUCCESS) {
-						dbg.log('query part failed, status: %d', part.status)
-						throw new YDBError(part.status, part.issues)
-					}
-
-					if (part.execStats) {
-						dbg.log('received query stats')
-						this.#stats = part.execStats
-					}
-
-					if (!part.resultSet) {
-						continue
-					}
-
-					while (part.resultSetIndex >= results.length) {
-						results.push([])
-					}
-
-					for (let i = 0; i < part.resultSet.rows.length; i++) {
-						let result: any = this.#values ? [] : {}
-
-						for (let j = 0; j < part.resultSet.columns.length; j++) {
-							let column = part.resultSet.columns[j]!
-							let value = part.resultSet.rows[i]!.items[j]!
-
-							if (this.#values) {
-								result.push(this.#raw ? value : toJs(fromYdb(value, column.type!)))
-								continue
-							}
-
-							result[column.name] = this.#raw
-								? value
-								: toJs(fromYdb(value, column.type!))
-						}
-
-						results[Number(part.resultSetIndex)]!.push(result)
-					}
-				}
-			} catch (err) {
-				// Record whether this attempt failed because the session died.
-				// The retry callback uses this to decide — together with the
-				// idempotent flag — whether to retry against a fresh session.
-				if (sessionLease?.signal.aborted) {
-					sessionDiedLastAttempt = true
-				}
-				throw err
+			let executeCtx: QueryExecuteContext = {
+				text: this.text,
+				sessionId: attemptSessionId,
+				nodeId: attemptNodeId,
+				idempotent: this.#idempotent,
+				isolation: this.#isolation,
+				stage,
 			}
 
-			dbg.log('query executed successfully')
-			return results
-		})
+			return await executeQueryCh.tracePromise(async () => {
+				let stream = client.executeQuery(
+					{
+						sessionId: attemptSessionId,
+						execMode: ExecMode.EXECUTE,
+						query: {
+							case: 'queryContent',
+							value: {
+								syntax: this.#syntax,
+								text: this.text,
+							},
+						},
+						parameters,
+						statsMode: this.#statsMode,
+						...(this.#poolId && { poolId: this.#poolId }),
+						...(txControl && { txControl }),
+					},
+					{
+						signal,
+						onTrailer: (trailer) => {
+							this.emit('metadata', trailer)
+						},
+					}
+				)
+
+				let results = [] as ArrayifyTuple<T>
+
+				try {
+					for await (let part of stream) {
+						signal.throwIfAborted()
+
+						if (part.status !== StatusIds_StatusCode.SUCCESS) {
+							dbg.log('query part failed, status: %d', part.status)
+							throw new YDBError(part.status, part.issues)
+						}
+
+						if (part.execStats) {
+							dbg.log('received query stats')
+							this.#stats = part.execStats
+						}
+
+						if (!part.resultSet) {
+							continue
+						}
+
+						while (part.resultSetIndex >= results.length) {
+							results.push([])
+						}
+
+						for (let i = 0; i < part.resultSet.rows.length; i++) {
+							let result: any = this.#values ? [] : {}
+
+							for (let j = 0; j < part.resultSet.columns.length; j++) {
+								let column = part.resultSet.columns[j]!
+								let value = part.resultSet.rows[i]!.items[j]!
+
+								if (this.#values) {
+									result.push(
+										this.#raw ? value : toJs(fromYdb(value, column.type!))
+									)
+									continue
+								}
+
+								result[column.name] = this.#raw
+									? value
+									: toJs(fromYdb(value, column.type!))
+							}
+
+							results[Number(part.resultSetIndex)]!.push(result)
+						}
+					}
+				} catch (err) {
+					// Record whether this attempt failed because the session died.
+					// The retry callback uses this to decide — together with the
+					// idempotent flag — whether to retry against a fresh session.
+					if (session.signal.aborted) {
+						sessionDiedLastAttempt = true
+					}
+					throw err
+				}
+
+				dbg.log('query executed successfully')
+				return results
+			}, executeCtx)
+		}
+
+		// Inside a transaction body, the txn callback (`sql.begin()`) owns the
+		// retry loop — retrying a single statement against the same
+		// `transactionId` after a server-side abort cannot recover the
+		// transaction. Skip the retry wrapper entirely; the tx retries the
+		// whole body if it needs to.
+		this.#promise = (
+			txSession ? runAttempt(linkedSignal.signal) : retry(retryConfig, runAttempt)
+		)
 			.then((results) => {
 				if (this.#stats) {
 					this.emit('stats', this.#stats)

--- a/packages/query/src/session-pool.test.ts
+++ b/packages/query/src/session-pool.test.ts
@@ -12,7 +12,7 @@ import {
 import { Driver } from '@ydbjs/core'
 import { YDBError } from '@ydbjs/error'
 
-import { Session } from './session.ts'
+import { Session, SessionBusyError } from './session.ts'
 import { SessionLease, SessionPool, SessionPoolFullError } from './session-pool.ts'
 
 /**
@@ -279,4 +279,46 @@ test('Session.open aborts the attach stream when the caller signal fires mid-wai
 		() => {}
 	)
 	expect(srv.attachCalls).toHaveLength(1)
+})
+
+test('claim() throws SessionBusyError on a second concurrent caller', async () => {
+	srv = await startQueryServer()
+	let session = await Session.open(srv.driver)
+
+	let first = session.claim()
+	try {
+		expect(() => session.claim()).toThrow(SessionBusyError)
+	} finally {
+		first[Symbol.dispose]()
+		session.close()
+	}
+})
+
+test('claim() releases on dispose so the next caller succeeds', async () => {
+	srv = await startQueryServer()
+	let session = await Session.open(srv.driver)
+
+	{
+		using _ = session.claim()
+		// scope holds the slot
+	}
+
+	// previous claim disposed — a fresh claim must succeed
+	let again = session.claim()
+	again[Symbol.dispose]()
+	session.close()
+})
+
+test('claim() dispose is idempotent', async () => {
+	srv = await startQueryServer()
+	let session = await Session.open(srv.driver)
+
+	let held = session.claim()
+	held[Symbol.dispose]()
+	held[Symbol.dispose]() // second dispose is a no-op
+
+	// the slot must still be free
+	let again = session.claim()
+	again[Symbol.dispose]()
+	session.close()
 })

--- a/packages/query/src/session-pool.ts
+++ b/packages/query/src/session-pool.ts
@@ -21,10 +21,28 @@
  *     hot session serving N queries would accumulate N listeners.
  */
 
+import { channel as dc, tracingChannel } from 'node:diagnostics_channel'
+
 import { linkSignals } from '@ydbjs/abortable'
 import type { Driver } from '@ydbjs/core'
 import { loggers } from '@ydbjs/debug'
 import { Session } from './session.js'
+
+/** Reasons a session left the pool. See `ydb:session.closed`. */
+type SessionClosedReason = 'evicted' | 'pool_close'
+
+/** Call-site classifier for `tracing:ydb:session.acquire`. */
+type SessionAcquireKind = 'query' | 'transaction'
+
+export let sessionAcquireCh = tracingChannel<
+	{ kind: SessionAcquireKind },
+	{ kind: SessionAcquireKind }
+>('tracing:ydb:session.acquire')
+
+let sessionCreateCh = tracingChannel<
+	{ liveSessions: number; maxSize: number; creating: number },
+	{ liveSessions: number; maxSize: number; creating: number }
+>('tracing:ydb:session.create')
 
 let dbg = loggers.query.extend('pool2')
 
@@ -49,7 +67,7 @@ export type SessionPoolOptions = {
 	waitQueueFactor?: number
 }
 
-const DEFAULTS = {
+let DEFAULTS = {
 	maxSize: 50,
 	waitQueueFactor: 8,
 } satisfies Required<SessionPoolOptions>
@@ -121,6 +139,12 @@ export class SessionPool implements AsyncDisposable {
 	#creates = new Set<Promise<unknown>>()
 	#close = new AbortController()
 
+	// Per-session metadata used by `ydb:session.closed`. Held weakly so a
+	// session removed from #all without going through #publishClosed (defence
+	// in depth) doesn't keep its createdAt entry alive.
+	#createdAt = new WeakMap<Session, number>()
+	#evictionHandlers = new WeakMap<Session, () => void>()
+
 	constructor(driver: Driver, options: SessionPoolOptions = {}) {
 		this.#driver = driver
 		this.#maxSize = options.maxSize ?? DEFAULTS.maxSize
@@ -149,14 +173,18 @@ export class SessionPool implements AsyncDisposable {
 
 	release(session: Session): void {
 		// Session died while someone was using it. The eviction listener
-		// already popped it from #all; `close()` fires DeleteSession in the
-		// background.
+		// already popped it from #all and published `closed{evicted}`; just
+		// fire DeleteSession in the background.
 		if (!session.alive || !this.#all.has(session)) {
 			session.close()
 			return
 		}
 
 		if (this.closed) {
+			// Pool was closed between acquire() and release(); already-tracked
+			// sessions get a `pool_close` event so subscribers see one event
+			// per session lifecycle regardless of timing.
+			this.#publishClosed(session, 'pool_close')
 			this.#all.delete(session)
 			session.close()
 			return
@@ -195,7 +223,13 @@ export class SessionPool implements AsyncDisposable {
 		this.#all.clear()
 		this.#available.length = 0
 		// close() is sync + fire-and-forget — no need to await each RPC.
-		for (let s of sessions) s.close()
+		// Detach the eviction listener BEFORE close() so we don't double-fire
+		// `closed{evicted}` for sessions that the pool itself is tearing down.
+		for (let s of sessions) {
+			this.#detachEviction(s)
+			this.#publishClosed(s, 'pool_close')
+			s.close()
+		}
 		dbg.log('pool closed (%d sessions)', sessions.length)
 	}
 
@@ -230,7 +264,16 @@ export class SessionPool implements AsyncDisposable {
 		// close) when the block exits — no accumulation on #close.signal as
 		// many concurrent creates fan out.
 		using linked = linkSignals(signal, this.#close.signal)
-		let promise = Session.open(this.#driver, linked.signal)
+
+		let createCtx = {
+			liveSessions: this.#all.size,
+			maxSize: this.#maxSize,
+			creating: this.#creates.size,
+		}
+		let promise = sessionCreateCh.tracePromise(
+			() => Session.open(this.#driver, linked.signal),
+			createCtx
+		)
 		this.#creates.add(promise)
 
 		try {
@@ -243,7 +286,12 @@ export class SessionPool implements AsyncDisposable {
 			}
 
 			this.#all.add(session)
+			this.#createdAt.set(session, Date.now())
 			this.#bindEviction(session)
+			dc('ydb:session.created').publish({
+				sessionId: session.id,
+				nodeId: session.nodeId,
+			})
 			return session
 		} finally {
 			this.#creates.delete(promise)
@@ -251,17 +299,42 @@ export class SessionPool implements AsyncDisposable {
 	}
 
 	#bindEviction(session: Session): void {
-		session.signal.addEventListener(
-			'abort',
-			() => {
-				this.#all.delete(session)
-				let idx = this.#available.indexOf(session)
-				if (idx !== -1) this.#available.splice(idx, 1)
-				dbg.log('evicted session %s', session.id)
-				this.#pumpWaitersAfterEviction()
-			},
-			{ once: true }
-		)
+		let handler = () => {
+			this.#evictionHandlers.delete(session)
+			this.#all.delete(session)
+			let idx = this.#available.indexOf(session)
+			if (idx !== -1) this.#available.splice(idx, 1)
+			dbg.log('evicted session %s', session.id)
+			this.#publishClosed(session, 'evicted')
+			this.#pumpWaitersAfterEviction()
+		}
+		this.#evictionHandlers.set(session, handler)
+		session.signal.addEventListener('abort', handler, { once: true })
+	}
+
+	/**
+	 * Detach the eviction listener bound by #bindEviction. Used by close()
+	 * to avoid a double `closed` event when the pool itself tears down a
+	 * session (which abort() would otherwise reflect back through the
+	 * eviction listener).
+	 */
+	#detachEviction(session: Session): void {
+		let handler = this.#evictionHandlers.get(session)
+		if (!handler) return
+		this.#evictionHandlers.delete(session)
+		session.signal.removeEventListener('abort', handler)
+	}
+
+	#publishClosed(session: Session, reason: SessionClosedReason): void {
+		let createdAt = this.#createdAt.get(session)
+		let uptime = createdAt ? Date.now() - createdAt : 0
+		this.#createdAt.delete(session)
+		dc('ydb:session.closed').publish({
+			sessionId: session.id,
+			nodeId: session.nodeId,
+			reason,
+			uptime,
+		})
 	}
 
 	/**

--- a/packages/query/src/session-pool.ts
+++ b/packages/query/src/session-pool.ts
@@ -183,7 +183,10 @@ export class SessionPool implements AsyncDisposable {
 		if (this.closed) {
 			// Pool was closed between acquire() and release(); already-tracked
 			// sessions get a `pool_close` event so subscribers see one event
-			// per session lifecycle regardless of timing.
+			// per session lifecycle regardless of timing. Detach the eviction
+			// listener first — session.close() aborts the signal, which would
+			// otherwise re-fire `closed{evicted}` for the same session.
+			this.#detachEviction(session)
 			this.#publishClosed(session, 'pool_close')
 			this.#all.delete(session)
 			session.close()

--- a/packages/query/src/session.ts
+++ b/packages/query/src/session.ts
@@ -30,6 +30,24 @@ export class SessionAbortedError extends Error {
 	}
 }
 
+/**
+ * Thrown when an RPC is started against a session that already has an in-flight
+ * RPC. YDB processes RPCs on a session sequentially, so concurrent statements
+ * on the same session would otherwise block on a server-side lock.
+ */
+export class SessionBusyError extends Error {
+	readonly sessionId: string
+
+	constructor(sessionId: string) {
+		super(
+			`session ${sessionId} is already executing another RPC. ` +
+				`YDB sessions are single-threaded; await the previous statement before starting a new one.`
+		)
+		this.name = 'SessionBusyError'
+		this.sessionId = sessionId
+	}
+}
+
 export class Session {
 	readonly id: string
 	readonly nodeId: bigint
@@ -39,6 +57,10 @@ export class Session {
 	#life = new AbortController()
 	#attach = new AbortController()
 	#closing = false
+	// In-flight RPCs on this session. YDB sessions are single-threaded, so
+	// this counter must never exceed 1. `claim()` throws SessionBusyError on
+	// the second concurrent caller.
+	#inflight = 0
 
 	private constructor(driver: Driver, id: string, nodeId: bigint) {
 		this.#driver = driver
@@ -53,6 +75,27 @@ export class Session {
 
 	get alive(): boolean {
 		return !this.#life.signal.aborted
+	}
+
+	/**
+	 * Mark the session as serving an RPC. Throws SessionBusyError if another
+	 * RPC is already in flight on this session. The returned `Disposable`
+	 * releases the slot on dispose; pair every `claim()` with `using` or an
+	 * explicit dispose.
+	 */
+	claim(): Disposable {
+		if (this.#inflight > 0) {
+			throw new SessionBusyError(this.id)
+		}
+		this.#inflight++
+		let released = false
+		return {
+			[Symbol.dispose]: () => {
+				if (released) return
+				released = true
+				this.#inflight = Math.max(0, this.#inflight - 1)
+			},
+		}
 	}
 
 	/**

--- a/packages/query/tests/query.test.ts
+++ b/packages/query/tests/query.test.ts
@@ -6,6 +6,7 @@ import { Optional } from '@ydbjs/value/optional'
 import { Uint64, Uint64Type } from '@ydbjs/value/primitive'
 
 import { query } from '../src/index.js'
+import { SessionBusyError } from '../src/session.js'
 
 let driver = new Driver(inject('connectionString'), {
 	'ydb.sdk.enable_discovery': false,
@@ -277,70 +278,6 @@ test('executes transaction with multiple queries', async () => {
 	`)
 })
 
-test('executes parallel transactions and queries', async () => {
-	await using sql = query(driver)
-
-	let results = await Promise.all([
-		sql.begin(async (tx) => {
-			return await Promise.all([tx`SELECT 1 AS id`, tx`SELECT 2 AS id`, tx`SELECT 3 AS id`])
-		}),
-		sql.begin(async (tx) => {
-			return await Promise.all([tx`SELECT 4 AS id`, tx`SELECT 5 AS id`, tx`SELECT 6 AS id`])
-		}),
-	])
-
-	expect(results).toMatchInlineSnapshot(`
-		[
-		  [
-		    [
-		      [
-		        {
-		          "id": 1,
-		        },
-		      ],
-		    ],
-		    [
-		      [
-		        {
-		          "id": 2,
-		        },
-		      ],
-		    ],
-		    [
-		      [
-		        {
-		          "id": 3,
-		        },
-		      ],
-		    ],
-		  ],
-		  [
-		    [
-		      [
-		        {
-		          "id": 4,
-		        },
-		      ],
-		    ],
-		    [
-		      [
-		        {
-		          "id": 5,
-		        },
-		      ],
-		    ],
-		    [
-		      [
-		        {
-		          "id": 6,
-		        },
-		      ],
-		    ],
-		  ],
-		]
-	`)
-})
-
 test('works with custom session pool size', async () => {
 	await using sql = query(driver, { poolOptions: { maxSize: 2 } })
 
@@ -441,4 +378,24 @@ test('handles multiple concurrent transactions', async () => {
 	expect(results[0]).toEqual([[[{ id: 1 }]], [[{ id: 2 }]]])
 	expect(results[1]).toEqual([[[{ id: 3 }]], [[{ id: 4 }]]])
 	expect(results[2]).toEqual([[[{ id: 5 }]], [[{ id: 6 }]]])
+})
+
+test('rejects parallel statements inside a single transaction with SessionBusyError', async () => {
+	await using sql = query(driver)
+
+	// Two `tx` calls without `await` between them — same session, parallel.
+	// YDB sessions are single-threaded; the SDK must surface this eagerly.
+	// The tx runner wraps the body's error into `Error('Transaction failed.',
+	// { cause })`, so we assert against the cause chain.
+	let caught: unknown
+	try {
+		await sql.begin(async (tx) => {
+			return await Promise.all([tx`SELECT 1 AS a`, tx`SELECT 2 AS b`])
+		})
+	} catch (err) {
+		caught = err
+	}
+
+	expect(caught).toBeInstanceOf(Error)
+	expect((caught as Error).cause).toBeInstanceOf(SessionBusyError)
 })

--- a/packages/query/tests/query.test.ts
+++ b/packages/query/tests/query.test.ts
@@ -1,4 +1,5 @@
 import { expect, inject, test } from 'vitest'
+import { tracingChannel } from 'node:diagnostics_channel'
 
 import { Driver } from '@ydbjs/core'
 import { fromJs } from '@ydbjs/value'
@@ -7,6 +8,31 @@ import { Uint64, Uint64Type } from '@ydbjs/value/primitive'
 
 import { query } from '../src/index.js'
 import { SessionBusyError } from '../src/session.js'
+
+function collectTrace(name: string): {
+	start: object[]
+	asyncEnd: object[]
+	error: (object & { error: unknown })[]
+} & Disposable {
+	let ch = tracingChannel(name)
+	let start: object[] = []
+	let asyncEnd: object[] = []
+	let error: (object & { error: unknown })[] = []
+	let handlers = {
+		start: (ctx: any) => start.push({ ...ctx }),
+		asyncEnd: (ctx: any) => asyncEnd.push({ ...ctx }),
+		error: (ctx: any) => error.push({ ...ctx }),
+	}
+	ch.subscribe(handlers as any)
+	return {
+		start,
+		asyncEnd,
+		error,
+		[Symbol.dispose]() {
+			ch.unsubscribe(handlers as any)
+		},
+	}
+}
 
 let driver = new Driver(inject('connectionString'), {
 	'ydb.sdk.enable_discovery': false,
@@ -398,4 +424,50 @@ test('rejects parallel statements inside a single transaction with SessionBusyEr
 
 	expect(caught).toBeInstanceOf(Error)
 	expect((caught as Error).cause).toBeInstanceOf(SessionBusyError)
+})
+
+test('emits tracing:ydb:query.begin and query.commit on a successful transaction', async () => {
+	await using sql = query(driver)
+
+	using begin = collectTrace('tracing:ydb:query.begin')
+	using commit = collectTrace('tracing:ydb:query.commit')
+
+	await sql.begin(async (tx) => {
+		await tx`SELECT 1 AS a`
+	})
+
+	expect(begin.start).toHaveLength(1)
+	expect(begin.asyncEnd).toHaveLength(1)
+	expect(begin.error).toHaveLength(0)
+	expect(begin.start[0]).toMatchObject({ isolation: 'serializableReadWrite' })
+
+	expect(commit.start).toHaveLength(1)
+	expect(commit.asyncEnd).toHaveLength(1)
+	expect(commit.error).toHaveLength(0)
+	let cstart = commit.start[0] as any
+	expect(typeof cstart.sessionId).toBe('string')
+	expect(typeof cstart.txId).toBe('string')
+})
+
+test('emits tracing:ydb:query.rollback when the transaction body throws', async () => {
+	await using sql = query(driver)
+
+	using rollback = collectTrace('tracing:ydb:query.rollback')
+
+	await expect(
+		sql.begin(async (tx) => {
+			await tx`SELECT 1`
+			throw new Error('boom')
+		})
+	).rejects.toThrow(/Transaction failed|boom/)
+
+	// rollback is fire-and-forget; give the RPC a moment to settle so its
+	// asyncEnd lands before we assert.
+	await new Promise((r) => setTimeout(r, 50))
+
+	expect(rollback.start.length).toBeGreaterThanOrEqual(1)
+	expect(rollback.start[0]).toMatchObject({})
+	let rstart = rollback.start[0] as any
+	expect(typeof rstart.sessionId).toBe('string')
+	expect(typeof rstart.txId).toBe('string')
 })

--- a/packages/retry/README.md
+++ b/packages/retry/README.md
@@ -190,6 +190,66 @@ await retry(
 )
 ```
 
+## Observability via `node:diagnostics_channel`
+
+`@ydbjs/retry` publishes events to [`node:diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html) so external subscribers (`@ydbjs/telemetry`, OpenTelemetry, custom loggers) can build traces and metrics for retry behaviour without the caller knowing anything about them.
+
+Every code path that uses `retry()` — driver discovery, query execution, transactions, auth token refresh — inherits these channels automatically.
+
+### Channels
+
+| Channel                     | Type    | Payload                                                                             |
+| --------------------------- | ------- | ----------------------------------------------------------------------------------- |
+| `tracing:ydb:retry.run`     | tracing | `{ idempotent: boolean }` — whole retry loop                                        |
+| `tracing:ydb:retry.attempt` | tracing | `{ attempt: number, idempotent: boolean }` — a single attempt (including the first) |
+| `ydb:retry.exhausted`       | publish | `{ attempts: number, totalDuration: number, lastError: unknown }` — see below       |
+
+`retry.attempt` is published once per attempt starting from `attempt: 1`. The corresponding `error` sub-channel of `tracing:ydb:retry.attempt` fires for failed attempts that will be retried; the final attempt's failure is also visible on `tracing:ydb:retry.run`'s `error` sub-channel.
+
+`ydb:retry.exhausted` fires when the retry policy itself gives up — either the budget ran out or the predicate returned `false`. It does **not** fire when the loop exits via `AbortError` or `TimeoutError`: those are rethrown immediately as caller-driven cancellations. Subscribers tracking "retry budget exhausted" should not expect this event for cancellations or timeouts; use `tracing:ydb:retry.run.error` for the broader "retry loop failed" signal.
+
+### Subscribing
+
+```ts
+import { channel, tracingChannel } from 'node:diagnostics_channel'
+
+tracingChannel('tracing:ydb:retry.run').subscribe({
+  start(ctx) {
+    // ctx.idempotent
+  },
+  asyncEnd() {
+    /* success */
+  },
+  error(ctx) {
+    /* ctx.error is the final failure */
+  },
+})
+
+channel('ydb:retry.exhausted').subscribe((msg) => {
+  alert.budgetExhausted.add(1, { attempts: msg.attempts })
+})
+```
+
+### ⚠️ Subscribers must be safe
+
+**`node:diagnostics_channel` invokes subscribers synchronously.** Any exception thrown inside a subscriber propagates up the call stack and **will** disrupt the SDK — a buggy retry subscriber can break the very operation it observes. `@ydbjs/retry` does **not** wrap subscribers; wrap them yourself:
+
+```ts
+tracingChannel('tracing:ydb:retry.attempt').subscribe({
+  start(ctx) {
+    try {
+      span.startChild({ name: 'retry.attempt', attributes: { attempt: ctx.attempt } })
+    } catch (err) {
+      console.error('telemetry subscriber failed', err)
+    }
+  },
+})
+```
+
+### Stability
+
+Channel names and payload field names follow semantic versioning. Adding new optional fields is a minor change; renaming or removing fields is a major change. Treat the channel surface as a public API.
+
 ## Development
 
 To build the package:

--- a/packages/retry/README.md
+++ b/packages/retry/README.md
@@ -204,7 +204,7 @@ Every code path that uses `retry()` — driver discovery, query execution, trans
 | `tracing:ydb:retry.attempt` | tracing | `{ attempt: number, idempotent: boolean }` — a single attempt (including the first) |
 | `ydb:retry.exhausted`       | publish | `{ attempts: number, totalDuration: number, lastError: unknown }` — see below       |
 
-`retry.attempt` is published once per attempt starting from `attempt: 1`. The corresponding `error` sub-channel of `tracing:ydb:retry.attempt` fires for failed attempts that will be retried; the final attempt's failure is also visible on `tracing:ydb:retry.run`'s `error` sub-channel.
+`retry.attempt` is published once per attempt starting from `attempt: 1`. Because `tracingChannel.tracePromise` wraps every attempt, `tracing:ydb:retry.attempt.error` fires for **every** failed attempt — both the ones that will be retried and the final one that exits the loop. The final attempt's failure additionally surfaces on `tracing:ydb:retry.run.error`.
 
 `ydb:retry.exhausted` fires when the retry policy itself gives up — either the budget ran out or the predicate returned `false`. It does **not** fire when the loop exits via `AbortError` or `TimeoutError`: those are rethrown immediately as caller-driven cancellations. Subscribers tracking "retry budget exhausted" should not expect this event for cancellations or timeouts; use `tracing:ydb:retry.run.error` for the broader "retry loop failed" signal.
 

--- a/packages/retry/src/diagnostics.test.ts
+++ b/packages/retry/src/diagnostics.test.ts
@@ -1,0 +1,122 @@
+import { expect, test } from 'vitest'
+import { channel as dc, tracingChannel } from 'node:diagnostics_channel'
+
+import { retry } from './index.js'
+
+/** Subscribe to a plain channel; returned object is `Disposable`. */
+function collect(name: string): { payloads: unknown[] } & Disposable {
+	let payloads: unknown[] = []
+	let fn = (msg: unknown) => payloads.push(structuredClone(msg))
+	dc(name).subscribe(fn)
+	return {
+		payloads,
+		[Symbol.dispose]() {
+			dc(name).unsubscribe(fn)
+		},
+	}
+}
+
+/** Subscribe to a tracing channel; capture start / asyncEnd / error contexts. */
+function collectTrace(name: string): {
+	start: object[]
+	asyncEnd: object[]
+	error: (object & { error: unknown })[]
+} & Disposable {
+	let ch = tracingChannel(name)
+	let start: object[] = []
+	let asyncEnd: object[] = []
+	let error: (object & { error: unknown })[] = []
+	let handlers = {
+		start: (ctx: any) => start.push({ ...ctx }),
+		asyncEnd: (ctx: any) => asyncEnd.push({ ...ctx }),
+		error: (ctx: any) => error.push({ ...ctx }),
+	}
+	ch.subscribe(handlers as any)
+	return {
+		start,
+		asyncEnd,
+		error,
+		[Symbol.dispose]() {
+			ch.unsubscribe(handlers as any)
+		},
+	}
+}
+
+// ── retry.run ────────────────────────────────────────────────────────────────
+
+test('traces tracing:ydb:retry.run start and asyncEnd around a successful call', async () => {
+	using trace = collectTrace('tracing:ydb:retry.run')
+
+	let result = await retry({ idempotent: true }, async () => 42)
+
+	expect(result).toBe(42)
+	expect(trace.start).toHaveLength(1)
+	expect(trace.asyncEnd).toHaveLength(1)
+	expect(trace.error).toHaveLength(0)
+	expect(trace.start[0]).toMatchObject({ idempotent: true })
+})
+
+test('traces tracing:ydb:retry.run error when retries are exhausted', async () => {
+	using trace = collectTrace('tracing:ydb:retry.run')
+
+	await expect(
+		retry({ budget: 1, retry: false, idempotent: false }, () => {
+			throw new Error('nope')
+		})
+	).rejects.toThrow('nope')
+
+	expect(trace.start).toHaveLength(1)
+	expect(trace.error).toHaveLength(1)
+	expect(trace.error[0]?.error).toBeInstanceOf(Error)
+})
+
+// ── retry.attempt ────────────────────────────────────────────────────────────
+
+test('publishes tracing:ydb:retry.attempt once per attempt with monotonic numbers', async () => {
+	using trace = collectTrace('tracing:ydb:retry.attempt')
+
+	let calls = 0
+	let result = await retry(
+		{ retry: true, budget: 5, strategy: 0, idempotent: false },
+		async () => {
+			calls++
+			if (calls < 3) throw new Error('again')
+			return 'ok'
+		}
+	)
+
+	expect(result).toBe('ok')
+	expect(trace.start).toHaveLength(3)
+	expect(trace.start.map((c: any) => c.attempt)).toEqual([1, 2, 3])
+	expect(trace.asyncEnd).toHaveLength(3)
+	// First two attempts fail → error fires twice
+	expect(trace.error).toHaveLength(2)
+})
+
+// ── retry.exhausted ──────────────────────────────────────────────────────────
+
+test('publishes ydb:retry.exhausted with attempts, duration and lastError when budget runs out', async () => {
+	using exhausted = collect('ydb:retry.exhausted')
+
+	let err = new Error('done')
+	await expect(
+		retry({ retry: true, budget: 2, strategy: 0, idempotent: false }, () => {
+			throw err
+		})
+	).rejects.toBe(err)
+
+	expect(exhausted.payloads).toHaveLength(1)
+	let p = exhausted.payloads[0] as any
+	expect(p.attempts).toBe(2)
+	expect(typeof p.totalDuration).toBe('number')
+	expect(p.totalDuration).toBeGreaterThanOrEqual(0)
+	expect(p.lastError).toBeInstanceOf(Error)
+})
+
+test('skips ydb:retry.exhausted when the call succeeds', async () => {
+	using exhausted = collect('ydb:retry.exhausted')
+
+	await retry({ idempotent: true }, async () => 'ok')
+
+	expect(exhausted.payloads).toHaveLength(0)
+})

--- a/packages/retry/src/index.ts
+++ b/packages/retry/src/index.ts
@@ -1,3 +1,4 @@
+import { channel as dc, tracingChannel } from 'node:diagnostics_channel'
 import { setTimeout } from 'timers/promises'
 
 import { abortable, linkSignals } from '@ydbjs/abortable'
@@ -9,6 +10,14 @@ import { ClientError, Status } from 'nice-grpc'
 import type { RetryConfig } from './config.js'
 import type { RetryContext } from './context.js'
 import { type RetryStrategy, backoff, fixed } from './strategy.js'
+
+let retryRunCh = tracingChannel<{ idempotent: boolean }, { idempotent: boolean }>(
+	'tracing:ydb:retry.run'
+)
+let retryAttemptCh = tracingChannel<
+	{ attempt: number; idempotent: boolean },
+	{ attempt: number; idempotent: boolean }
+>('tracing:ydb:retry.attempt')
 
 export * from './config.js'
 export * from './context.js'
@@ -25,8 +34,18 @@ export async function retry<R>(
 	cfg: RetryConfig,
 	fn: (signal: AbortSignal) => R | Promise<R>
 ): Promise<R> {
+	let idempotent = cfg.idempotent ?? false
+	return retryRunCh.tracePromise(() => runLoop(cfg, fn), { idempotent })
+}
+
+async function runLoop<R>(
+	cfg: RetryConfig,
+	fn: (signal: AbortSignal) => R | Promise<R>
+): Promise<R> {
 	let config = Object.assign({}, defaultRetryConfig, cfg)
+	let idempotent = cfg.idempotent ?? false
 	let ctx: RetryContext = { attempt: 0, error: null }
+	let started = performance.now()
 
 	let budget: number
 	while (
@@ -38,13 +57,19 @@ export async function retry<R>(
 
 		let start = Date.now()
 		let signal = linkedSignal.signal
+		let attemptNumber = ctx.attempt + 1
 
 		try {
 			signal.throwIfAborted()
-			dbg.log('attempt %d: calling retry function', ctx.attempt + 1)
+
+			dbg.log('attempt %d: calling retry function', attemptNumber)
 			// oxlint-disable-next-line no-await-in-loop
-			let result = await abortable(signal, Promise.resolve(fn(signal)))
-			dbg.log('attempt %d: success', ctx.attempt + 1)
+			let result = await retryAttemptCh.tracePromise(
+				() => abortable(signal, Promise.resolve(fn(signal))),
+				{ attempt: attemptNumber, idempotent }
+			)
+
+			dbg.log('attempt %d: success', attemptNumber)
 			return result
 		} catch (error) {
 			ctx.error = error
@@ -64,7 +89,7 @@ export async function retry<R>(
 			if (typeof config.retry === 'boolean') {
 				willRetry = config.retry
 			} else {
-				willRetry = config.retry?.(ctx.error, cfg.idempotent ?? false) ?? false
+				willRetry = config.retry?.(ctx.error, idempotent) ?? false
 			}
 
 			if (!willRetry || ctx.attempt >= budget) {
@@ -98,6 +123,13 @@ export async function retry<R>(
 	}
 
 	dbg.log('retry failed after %d attempts, last error: %O', ctx.attempt, ctx.error)
+
+	dc('ydb:retry.exhausted').publish({
+		attempts: ctx.attempt,
+		totalDuration: performance.now() - started,
+		lastError: ctx.error,
+	})
+
 	throw ctx.error
 }
 

--- a/third-parties/auth-yandex-cloud/README.md
+++ b/third-parties/auth-yandex-cloud/README.md
@@ -99,6 +99,19 @@ Required fields:
 3. **Token Caching**: Caches the IAM token and automatically refreshes it before expiration (5 minute safety margin)
 4. **YDB Authentication**: Uses the IAM token as `x-ydb-auth-ticket` header for YDB requests
 
+## Observability
+
+This provider participates in the unified `node:diagnostics_channel` surface defined by `@ydbjs/auth`. Every token fetch publishes:
+
+- `tracing:ydb:auth.token.fetch` — span around `getToken()` (context: `{ provider: 'yc-service-account' }`).
+- `ydb:auth.token.refreshed` — fires after a successful IAM token exchange (`{ provider, expiresAt }`, unix ms).
+- `ydb:auth.token.expired` — fires once per incident when the cached token is observed past its expiry.
+- `ydb:auth.provider.failed` — fires when all retries are exhausted.
+
+Retry attempts inside the IAM exchange are also visible on `tracing:ydb:retry.run` / `tracing:ydb:retry.attempt` from `@ydbjs/retry`.
+
+See [`@ydbjs/auth` README](../../packages/auth/README.md#observability-via-nodediagnostics_channel) for the full channel contract, subscriber example, and the safety warning (subscribers run synchronously and must not throw).
+
 ## Security
 
 - Never commit authorized key files to version control

--- a/third-parties/auth-yandex-cloud/src/diagnostics.test.ts
+++ b/third-parties/auth-yandex-cloud/src/diagnostics.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import { channel as dc, tracingChannel } from 'node:diagnostics_channel'
+
+import { ServiceAccountCredentialsProvider, type ServiceAccountKey } from './service-account.js'
+
+// Same 2048-bit RSA private key used in service-account.test.ts.
+let mockKey: ServiceAccountKey = {
+	id: 'ajexxxxxxxxxxxxxxxxx',
+	service_account_id: 'ajexxxxxxxxxxxxxxxxx',
+	private_key: `-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCbreZrDAxMCwwt
+heq4OyYSaUXlBB+6zIRVIG3/VUFE18DSRzIotkw10nsRBAceSfdY6196Yoz8iOjU
+IOWG7Cjfl4iWzRQjsavN5WVtjnhexXr5DylEORVE5gsuxtYCThRcKF7Q0WAxrsAx
+cKYYEjNs1uppOKEAP2XTTuTFfc57uamrKCzGbAy5JSqgQVL8anTJ5JJTN+r+oDaD
+hzUH6nU9df4Yc+8c4B1FzGq4Sl6IBH0Dtf3VizBTeGAgkxfeiMSDo/kd3gdyzmL2
+lyqT6WZNn7HuGOw7TTtqantwjeE0dLEg4gKPzviTpB7DipYRJmTD9+3SfYl6AKPc
+ZXLGbIn3AgMBAAECggEARcE8zlg+plAI69jmXBg8reE3rS8U3IlI/i+iudbEgQk/
+X7kA85cDPNaLyAsK+Xpg9xm31UmVLI5X7Ly0u6jTg6QNUqyfSoMQnRgdQ2Kj8qr/
+t9sgPW5qZk3BUvtK5wt/Oe/o1B4MwRYxDbYQ5hY5rpn5vJ3gHhFKGc1u2kLNo0fR
+TeLhJuACksfJzViRQv/69X1H+/g4PTUB1fCWGvxcSryD34cpSI8wzQ91Xt14L/3j
+kvMlFKv9xfZYrNdoIeGtM8EWpomMO2POr6FPs2gGVbfPzDzQgZqoc2ScaRB2+WsS
+CX/JKAAWNKOa+dEMfapYSdNyV8Dli/QWJ4MzsBvr0QKBgQDUShNWbMiLFNZZ520p
+RrA/ZJQe+vehFkplh6nX8YnkQ4OaM3d99h/lTkLxkD7xV+vHLs6YIaYPsTMBB4Ta
+ky3js3X82PxvWiiUoIG/i4bIxg9fJY70eSrd6nFhYsI08LS99KKu5qhZpSkjg8wX
+8+U2FlwPefBWlrhzJZYc7lZO+QKBgQC7u94bMn58iPTwFDcCbBgeJCDzl0wDLQMr
+r1gngKBesxk0nfzPToSBwLMLhI0fJnipsGeX2XWsqRrQZMCJkH1CvLgFQHEt55DW
+wP/h0Op1lif7x1bZN00FcLmYB6IWn6K7fKUg1mT6Vzomaoo1fP7f62UIHsI+jbpk
+sYhRYLmsbwKBgGL4rg9K5CxDaLO9e10VAbJsV8ohwzUsyT6QgxSUHW94MnC/sePd
+zX0AgaFRWKb4EIpqPhMbDOqf+GFwefXVTD2uO0HIf9gCNo0kT5lXmV0dSalYP0+m
+9d9EH9wBSP2ZgwpUdUwJaU9x+r3+AjbglGok/oKQnQYhepjkWxnd3AsxAoGALyFi
+CEfr803a2C7rBIOopmCBmUXhgmaZhi0WH4yuNjgWWtxS7KSUpZKAIKMdXrWk000D
+JN8mKLunjKvOnnqUx91jAYaFI3YgKZn4Y3O0eOLClPYdepjkkDoVjfJUogNfslv/
+hLfuT974LU7P9c+0mPiau6glMdkY81CSnYN/+acCgYBECj8LvJzv+XQ0maNPBLtg
+gwodhiizlzVuQ5Rd9FLK6dtVRv1LLrycf6f9LPCN33EiEwrmMst8dHWXgsvBvLyh
+nvtD9shYTO/sNlqeMph4NmocaLnEqd84EGVdmPMJXmnkJGmnivd9nW7rknff9hdo
+qmi1rcP923/IkrkU3VQCUw==
+-----END PRIVATE KEY-----`,
+}
+
+afterEach(() => {
+	vi.restoreAllMocks()
+})
+
+/** Subscribe to a plain channel; returned object is `Disposable`. */
+function collect(name: string): { payloads: unknown[] } & Disposable {
+	let payloads: unknown[] = []
+	let fn = (msg: unknown) => payloads.push(structuredClone(msg))
+	dc(name).subscribe(fn)
+	return {
+		payloads,
+		[Symbol.dispose]() {
+			dc(name).unsubscribe(fn)
+		},
+	}
+}
+
+/** Subscribe to a tracing channel; capture start / asyncEnd / error contexts. */
+function collectTrace(name: string): {
+	start: object[]
+	asyncEnd: object[]
+	error: (object & { error: unknown })[]
+} & Disposable {
+	let ch = tracingChannel(name)
+	let start: object[] = []
+	let asyncEnd: object[] = []
+	let error: (object & { error: unknown })[] = []
+	let handlers = {
+		start: (ctx: any) => start.push({ ...ctx }),
+		asyncEnd: (ctx: any) => asyncEnd.push({ ...ctx }),
+		error: (ctx: any) => error.push({ ...ctx }),
+	}
+	ch.subscribe(handlers as any)
+	return {
+		start,
+		asyncEnd,
+		error,
+		[Symbol.dispose]() {
+			ch.unsubscribe(handlers as any)
+		},
+	}
+}
+
+function mockOkResponse(expiresInMs = 3600 * 1000) {
+	global.fetch = vi.fn(async () => {
+		let response = new Response(
+			JSON.stringify({
+				iamToken: 't1.xxxxxxxxxxxxxxx',
+				expiresAt: new Date(Date.now() + expiresInMs).toISOString(),
+			})
+		)
+		response.headers.set('Content-Type', 'application/json')
+		return response
+	})
+}
+
+test('traces yc-service-account getToken via tracing:ydb:auth.token.fetch', async () => {
+	mockOkResponse()
+	using trace = collectTrace('tracing:ydb:auth.token.fetch')
+
+	let provider = new ServiceAccountCredentialsProvider(mockKey)
+	await provider.getToken(true)
+
+	expect(trace.start.length).toBeGreaterThanOrEqual(1)
+	expect(trace.asyncEnd.length).toBeGreaterThanOrEqual(1)
+	expect(trace.error).toHaveLength(0)
+	expect(trace.start[0]).toMatchObject({ provider: 'yc-service-account' })
+})
+
+test('publishes ydb:auth.token.refreshed with expiresAt for yc-service-account', async () => {
+	let before = Date.now()
+	mockOkResponse(60_000)
+	using refreshed = collect('ydb:auth.token.refreshed')
+
+	let provider = new ServiceAccountCredentialsProvider(mockKey)
+	await provider.getToken(true)
+
+	expect(refreshed.payloads).toHaveLength(1)
+	let p = refreshed.payloads[0] as any
+	expect(p.provider).toBe('yc-service-account')
+	expect(typeof p.expiresAt).toBe('number')
+	expect(p.expiresAt).toBeGreaterThanOrEqual(before + 60_000)
+})
+
+test('publishes ydb:auth.provider.failed when IAM API rejects the JWT', async () => {
+	global.fetch = vi.fn(async () => new Response('forbidden', { status: 403 }))
+	using failed = collect('ydb:auth.provider.failed')
+
+	let provider = new ServiceAccountCredentialsProvider(mockKey)
+
+	await expect(provider.getToken(true, AbortSignal.timeout(200))).rejects.toThrow(
+		/IAM API error|aborted/i
+	)
+
+	expect(failed.payloads.length).toBeGreaterThanOrEqual(1)
+	let p = failed.payloads[0] as any
+	expect(p.provider).toBe('yc-service-account')
+	expect(p.error).toBeDefined()
+})

--- a/third-parties/auth-yandex-cloud/src/diagnostics.test.ts
+++ b/third-parties/auth-yandex-cloud/src/diagnostics.test.ts
@@ -121,6 +121,50 @@ test('publishes ydb:auth.token.refreshed with expiresAt for yc-service-account',
 	expect(p.expiresAt).toBeGreaterThanOrEqual(before + 60_000)
 })
 
+test('opportunistic background refresh emits the same tracing/publish events as a forced refresh', async () => {
+	// First getToken populates the cache with a near-expiry token (within
+	// the 5-minute refresh window) so the next getToken returns immediately
+	// and triggers #refreshTokenInBackground.
+	mockOkResponse(4 * 60 * 1000)
+	let provider = new ServiceAccountCredentialsProvider(mockKey)
+	await provider.getToken(true)
+
+	using fetchTrace = collectTrace('tracing:ydb:auth.token.fetch')
+	using refreshed = collect('ydb:auth.token.refreshed')
+
+	mockOkResponse(60 * 60 * 1000) // background refresh returns a fresh token
+
+	await provider.getToken() // returns cached, kicks off background refresh
+
+	// Drain microtasks/timers so the background fetch settles before assert.
+	await new Promise((r) => setTimeout(r, 50))
+
+	expect(fetchTrace.start.length).toBeGreaterThanOrEqual(1)
+	expect(fetchTrace.asyncEnd.length).toBeGreaterThanOrEqual(1)
+	expect(fetchTrace.error).toHaveLength(0)
+	expect(fetchTrace.start[0]).toMatchObject({ provider: 'yc-service-account' })
+	expect(refreshed.payloads.length).toBeGreaterThanOrEqual(1)
+})
+
+test('failed background refresh publishes ydb:auth.provider.failed without breaking the cached token', async () => {
+	mockOkResponse(4 * 60 * 1000)
+	let provider = new ServiceAccountCredentialsProvider(mockKey)
+	let cached = await provider.getToken(true)
+
+	using failed = collect('ydb:auth.provider.failed')
+
+	// Background fetch fails — provider must still return the cached token.
+	global.fetch = vi.fn(async () => new Response('forbidden', { status: 403 }))
+
+	let token = await provider.getToken()
+	expect(token).toBe(cached)
+
+	await new Promise((r) => setTimeout(r, 50))
+
+	expect(failed.payloads.length).toBeGreaterThanOrEqual(1)
+	expect(failed.payloads[0]).toMatchObject({ provider: 'yc-service-account' })
+})
+
 test('publishes ydb:auth.provider.failed when IAM API rejects the JWT', async () => {
 	global.fetch = vi.fn(async () => new Response('forbidden', { status: 403 }))
 	using failed = collect('ydb:auth.provider.failed')

--- a/third-parties/auth-yandex-cloud/src/service-account.ts
+++ b/third-parties/auth-yandex-cloud/src/service-account.ts
@@ -1,12 +1,18 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { constants, createPrivateKey, sign } from 'node:crypto'
+import { channel as dc, tracingChannel } from 'node:diagnostics_channel'
 import { CredentialsProvider } from '@ydbjs/auth'
 import { loggers } from '@ydbjs/debug'
 import { type RetryConfig, retry } from '@ydbjs/retry'
 import { type RetryStrategy, exponential, fixed } from '@ydbjs/retry/strategy'
 
 let dbg = loggers.auth.extend('yc-sa')
+
+let authTokenFetchCh = tracingChannel<
+	{ provider: 'yc-service-account' },
+	{ provider: 'yc-service-account' }
+>('tracing:ydb:auth.token.fetch')
 
 /**
  * HTTP error with status code for IAM API requests.
@@ -64,6 +70,10 @@ export class ServiceAccountCredentialsProvider extends CredentialsProvider {
 	#token: IamToken | null = null
 	#promise: Promise<string> | null = null
 	#iamEndpoint: string = 'https://iam.api.cloud.yandex.net/iam/v1/tokens'
+
+	// Fire `token.expired` at most once per incident; reset on every successful
+	// refresh. Mirrors the per-incident semantics of @ydbjs/auth providers.
+	#expiredReported = false
 
 	/**
 	 * Creates an instance of ServiceAccountCredentialsProvider.
@@ -183,62 +193,83 @@ export class ServiceAccountCredentialsProvider extends CredentialsProvider {
 			return this.#promise
 		}
 
+		if (this.#token && this.#token.expires_at <= now && !this.#expiredReported) {
+			this.#expiredReported = true
+			dc('ydb:auth.token.expired').publish({
+				provider: 'yc-service-account',
+				stalenessMs: now - this.#token.expires_at,
+			})
+		}
+
 		dbg.log('fetching new IAM token (token expired or force=true, key ID: %s)', this.#key.id)
 
-		this.#promise = (async (): Promise<string> => {
-			try {
-				this.#token = await this.#fetchIamToken(signal)
-				dbg.log(
-					'IAM token fetched successfully, expires at %s (key ID: %s)',
-					new Date(this.#token.expires_at).toISOString(),
-					this.#key.id
-				)
-				return this.#token.value
-			} finally {
-				this.#promise = null
-			}
-		})()
+		this.#promise = this.#refreshOnce(signal).finally(() => {
+			this.#promise = null
+		})
 
 		return this.#promise
 	}
 
 	/**
-	 * Refreshes token in background without blocking.
-	 * Does nothing if refresh is already in progress.
+	 * Refresh the token in the background without blocking the caller.
+	 * Reuses the same refresh path as `getToken(force)` so blocking and
+	 * opportunistic refreshes behave identically from the caller's point
+	 * of view.
 	 */
 	#refreshTokenInBackground(signal?: AbortSignal): void {
 		if (this.#promise) {
 			return
 		}
 
-		// Track promise to prevent duplicate refreshes, but don't await it (non-blocking)
 		let refreshPromise: Promise<string> | null = null
-		refreshPromise = (async (): Promise<string> => {
-			try {
-				this.#token = await this.#fetchIamToken(signal)
-				dbg.log(
-					'background IAM token refresh successful, expires at %s (key ID: %s)',
-					new Date(this.#token.expires_at).toISOString(),
-					this.#key.id
-				)
-				return this.#token.value
-			} catch (error) {
-				// Don't throw - failed background refresh will retry on next getToken call
-				// Return existing token if available to avoid breaking ongoing requests
+		refreshPromise = this.#refreshOnce(signal)
+			.catch((error) => {
+				// Don't throw — failed background refresh will retry on next
+				// getToken call. Return the existing token to avoid breaking
+				// ongoing requests; if there's nothing cached, propagate.
 				dbg.log('background IAM token refresh failed: %O (key ID: %s)', error, this.#key.id)
-				if (this.#token) {
-					return this.#token.value
-				}
+				if (this.#token) return this.#token.value
 				throw error
-			} finally {
-				// Check promise reference to avoid clearing if another refresh started (race condition)
+			})
+			.finally(() => {
 				if (this.#promise === refreshPromise) {
 					this.#promise = null
 				}
-			}
-		})()
+			})
 
 		this.#promise = refreshPromise
+	}
+
+	/**
+	 * Performs one IAM-token exchange against Yandex Cloud and updates the
+	 * cached token. Used by both blocking and background refresh.
+	 */
+	async #refreshOnce(signal?: AbortSignal): Promise<string> {
+		try {
+			return await authTokenFetchCh.tracePromise(
+				async (): Promise<string> => {
+					this.#token = await this.#fetchIamToken(signal)
+					dbg.log(
+						'IAM token fetched successfully, expires at %s (key ID: %s)',
+						new Date(this.#token.expires_at).toISOString(),
+						this.#key.id
+					)
+					this.#expiredReported = false
+					dc('ydb:auth.token.refreshed').publish({
+						provider: 'yc-service-account',
+						expiresAt: this.#token.expires_at,
+					})
+					return this.#token.value
+				},
+				{ provider: 'yc-service-account' }
+			)
+		} catch (error) {
+			dc('ydb:auth.provider.failed').publish({
+				provider: 'yc-service-account',
+				error,
+			})
+			throw error
+		}
 	}
 
 	/**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,10 +11,13 @@ export default defineConfig({
 						label: 'uni',
 						color: 'yellow',
 					},
-					include: ['packages/*/src/**/*.test.ts'],
+					include: ['packages/*/src/**/*.test.ts', 'third-parties/*/src/**/*.test.ts'],
 					environment: 'node',
 					benchmark: {
-						include: ['packages/*/src/**/*.bench.ts'],
+						include: [
+							'packages/*/src/**/*.bench.ts',
+							'third-parties/*/src/**/*.bench.ts',
+						],
 					},
 				},
 			},


### PR DESCRIPTION
## What

Instruments the SDK with `node:diagnostics_channel` so external subscribers (`@ydbjs/telemetry`, OpenTelemetry, custom loggers) can build traces, metrics, and logs without coupling the SDK to any telemetry stack. Five packages in scope: `@ydbjs/core`, `@ydbjs/retry`, `@ydbjs/auth`, `@ydbjs/auth-yandex-cloud`, `@ydbjs/query`.

Supersedes #596 with a finalized channel contract, fixed lifecycle semantics, and a working example.

## Why

`@ydbjs/telemetry` is on the roadmap. To build it as a clean external subscriber (zero SDK dependencies on OTel), the SDK must publish a stable, documented event surface. Hooks (`DriverHooks.onCall` etc.) are already in the codebase but cover only a slice of driver internals and don't compose across packages. `node:diagnostics_channel` (stable since Node 19.9, available on Bun and Deno via `node:` compat) is the right primitive: zero-cost when no subscribers, ALS-propagated, multi-subscriber out of the box.

Once this lands, an OTel/Pino/Datadog subscriber gets a full retry/session/query span tree with no per-callsite imports.

## Changes

5 commits, one per package surface:

### `@ydbjs/core` — driver, discovery, pool

| Channel | Type | Payload |
|---|---|---|
| `tracing:ydb:discovery` | tracing | `{ database }` |
| `ydb:discovery.completed` | publish | `{ database, addedCount, removedCount, totalCount, duration }` |
| `ydb:driver.ready` | publish | `{ database, duration }` |
| `ydb:driver.failed` | publish | `{ database, duration, error }` |
| `ydb:driver.closed` | publish | `{ database, uptime }` |
| `ydb:pool.connection.added` | publish | `{ nodeId, address, location }` |
| `ydb:pool.connection.pessimized` | publish | `{ nodeId, address, location, until }` |
| `ydb:pool.connection.unpessimized` | publish | `{ nodeId, address, location, pessimizedDuration }` |
| `ydb:pool.connection.retired` | publish | `{ nodeId, address, location, reason: 'stale_active' \| 'stale_pessimized' }` — channel is alive, draining streams |
| `ydb:pool.connection.removed` | publish | `{ nodeId, address, location, reason: 'replaced' \| 'idle' \| 'pool_close' }` — channel physically closed |

Connection lifecycle is split into `retired` (out of routing, channel kept open for in-flight streams) and `removed` (channel torn down). Lets subscribers track both "routable connections" and "alive channels" gauges separately.

`Driver` constructor refactored — extract `#parseConnectionString`, `#mergeOptions`, `#assertDiscoveryTimings`, `#initialEndpoint`, `#createChannelCredentials`, `#buildMiddleware`, `#startDiscoveryLoop`, `#markReady`, `#markFailed`. All private methods grouped at the bottom of the class.

### `@ydbjs/retry`

| Channel | Type | Payload |
|---|---|---|
| `tracing:ydb:retry.run` | tracing | `{ idempotent }` — whole retry loop |
| `tracing:ydb:retry.attempt` | tracing | `{ attempt, idempotent }` — per-attempt span (including the first) |
| `ydb:retry.exhausted` | publish | `{ attempts, totalDuration, lastError }` |

Published from inside `retry()` itself. Every caller (driver discovery, query execution, transactions, auth token refresh) inherits the retry-span hierarchy automatically — no per-callsite `tracingChannel` imports.

### `@ydbjs/auth` + `@ydbjs/auth-yandex-cloud`

| Channel | Type | Payload |
|---|---|---|
| `tracing:ydb:auth.token.fetch` | tracing | `{ provider }` |
| `ydb:auth.token.refreshed` | publish | `{ provider, expiresAt }` (unix ms — uniform across providers) |
| `ydb:auth.token.expired` | publish | `{ provider, stalenessMs }` — fires once per incident, not per call |
| `ydb:auth.provider.failed` | publish | `{ provider, error }` |

`provider` is a closed enum: `'static' | 'metadata' | 'yc-service-account'` (extendable by external providers using namespaced strings).

### `@ydbjs/query`

| Channel | Type | Payload |
|---|---|---|
| `tracing:ydb:query.execute` | tracing | `{ text, sessionId, nodeId, idempotent, isolation, stage }` — one `ExecuteQuery` RPC. `stage` ∈ `'standalone' \| 'tx' \| 'do'`. |
| `tracing:ydb:query.transaction` | tracing | `{ isolation, idempotent }` — `tx.begin` → `commit`/`rollback` |
| `tracing:ydb:session.acquire` | tracing | `{ kind: 'query' \| 'transaction' }` |
| `tracing:ydb:session.create` | tracing | `{ liveSessions, maxSize, creating }` |
| `ydb:session.created` | publish | `{ sessionId, nodeId }` |
| `ydb:session.closed` | publish | `{ sessionId, nodeId, reason: 'evicted' \| 'pool_close' \| 'released_dead', uptime }` — single channel for the entire session-lifecycle teardown |

Other internal cleanups in this commit, not strictly DC but required to make the contract clean:

- **No retry inside transaction body.** Statements inside `sql.begin()` no longer wrap themselves in `retry()` — the tx callback owns the retry loop. Eliminates vacuous nested `retry.run`/`retry.attempt` spans per statement.
- **`Session.claim()` guard** + new `SessionBusyError`. Throws non-retryable error if a second concurrent RPC is started on the same session (e.g. `Promise.all([tx`a`, tx`b`])`). YDB sessions are single-threaded; the SDK now surfaces this eagerly instead of hanging on a server-side lock.
- **`Context` (AsyncLocalStorage) reduced** to `{ session, transactionId, signal }`. `sessionId` and `nodeId` are derived from `session` — no parallel duplicate fields.
- **Tx queries link to `session.signal`** so a session death mid-tx aborts pending statements immediately rather than waiting on the server.

### `examples/diagnostics`

A single 200-line `index.js` that subscribes to every channel above, runs one SELECT and one transaction, and pretty-prints the full event tree to the console. Demonstrates:

- Correct nesting via `tracePromise` + `AsyncLocalStorage`.
- `using driver` + `await using sql` for clean shutdown order (`session.closed{pool_close}` → `driver.closed`).
- Collapsing `error` + `asyncEnd` (DC fires both on rejection by design) into one log line per span.

## Testing

| Suite | Count | Status |
|---|---|---|
| Unit (`uni` project) | 444 | ✅ |
| Integration core+query+auth+coordination | 47 | ✅ |
| Integration topic (incl. 60s reconnect test) | passes | ✅ |
| `examples/diagnostics` against real local-ydb | manual | ✅ |

New unit tests cover every channel: 14 in `core/diagnostics.test.ts`, 5 in `retry/`, 7 in `auth/` + 3 in `auth-yandex-cloud/`, 5 in `query/diagnostics.test.ts`, plus 3 unit tests for `Session.claim()` and 1 integration test asserting `SessionBusyError` on parallel statements in tx.

## Subscribers must be safe

Documented in every package README: `node:diagnostics_channel` invokes subscribers synchronously. A throwing subscriber will disrupt the SDK. Each package's "Observability" section ends with the warning and a `try/catch` example.

## Checklist

- [x] Changeset added — minor for `@ydbjs/core`, `@ydbjs/retry`, `@ydbjs/auth`, `@ydbjs/auth-yandex-cloud`, `@ydbjs/query`
- [x] README updated for every public-facing package + the example
- [x] Channel names, payload field names, and enum values declared as part of the public API (SemVer-stable)

Closes #596 (the original PR; this branch supersedes it with the finalized contract).
