### PR TITLE
Add @ydbjs/telemetry: OpenTelemetry spans and metrics

### DIFF
--- a/.changeset/telemetry-metrics-pipeline.md
+++ b/.changeset/telemetry-metrics-pipeline.md
@@ -1,0 +1,42 @@
+---
+'@ydbjs/telemetry': minor
+'@ydbjs/query': minor
+'@ydbjs/retry': minor
+'@ydbjs/core': patch
+---
+
+OpenTelemetry metrics pipeline, semantic-convention cleanup, and a `DeleteSession` span.
+
+`@ydbjs/telemetry`:
+
+- Attribute / event / metric constants are split across `src/semconv/{common,spans,events,metrics}.ts`. The old `src/attributes.ts` is gone; unused `ATTR_YDB_POOL_*` keys (`max_size`, `creating`, `live_sessions`) were dead and have been removed.
+- Connection-pool event names are now component-scoped: `ydb.pool.connection.*` → `ydb.driver.connection.*`. Same for `ATTR_YDB_POOL_*` → `ATTR_YDB_DRIVER_CONNECTION_*` (used as `addEvent` attributes).
+- `db.operation.name` carries a service prefix (`Query.ExecuteQuery`, `Query.BeginTransaction`, `Discovery.ListEndpoints`, ...) so traces stay unambiguous if the Table service is instrumented alongside Query later.
+- Time values: `node:diagnostics_channel` payloads stay in milliseconds (Node convention — `performance.now()` and `Date.now()` units). The OTel mapping divides by 1000 when assigning to attributes / metric data points, whose semantic unit is seconds. Attribute keys no longer carry the `_ms` suffix (e.g. `ydb.retry.backoff`, `ydb.discovery.duration`).
+- A new `ydb.DeleteSession` span (channel `tracing:ydb:query.session.delete`) wraps the per-session `DeleteSession` RPC, with `db.operation.name="Query.DeleteSession"`, `ydb.session.id`, `ydb.node.id`, `ydb.session.close.reason`, `ydb.session.uptime`.
+- Metrics pipeline (first cut) registers the following synchronous instruments via the package's OTel `Meter`:
+  - `db.client.operation.duration` (Histogram, `s`) — emitted on every leaf CLIENT tracing channel, tagged with `db.operation.name`. Standard OTel database metric so off-the-shelf dashboards work out of the box.
+  - `ydb.driver.connection.pessimizations` (Counter)
+  - `ydb.query.session.create.duration` / `ydb.query.session.acquire.duration` (Histogram)
+  - `ydb.query.session.closed` (Counter, tagged with `ydb.session.close.reason`)
+  - `ydb.auth.token.fetch.duration` (Histogram), `ydb.auth.token.fetch.failures` (Counter), `ydb.auth.token.expirations` (Counter)
+  - `ydb.retry.attempts` (Counter, tagged with `ydb.retry.outcome`), `ydb.retry.duration` (Histogram, end-to-end including backoffs)
+- Two observable instruments are also emitted, fed by an internal per-`DriverIdentity` state registry that subscribes to existing lifecycle events:
+  - `ydb.driver.connection.count` (`ObservableUpDownCounter`, tagged with `ydb.connection.state` ∈ `{live, pessimized}`)
+  - `ydb.query.session.count` (`ObservableUpDownCounter`, total only — state breakdown is a follow-up that needs `session.acquired/released` events from `@ydbjs/query`)
+
+`@ydbjs/query`:
+
+- `SessionPool` accepts a new `minSize?: number` option (default `0`) — reported as `ydb.query.session.min` once that observable is wired up. No eager session pre-warm is performed today; the option exists for parity with other YDB SDKs and for future warm-up logic.
+- `ydb:query.session.pool.opened` payload now includes `minSize`.
+- `Session.close()` accepts a `SessionCloseReason` (`pool_close` | `evicted` | `release_dead` | `attach_failed` | `user_close`). The `DeleteSession` RPC is now published via `tracingChannel('tracing:ydb:query.session.delete')` so subscribers see a span around each background delete, with the reason on the context.
+- Session uptime is tracked on the `Session` itself (`readonly createdAt`) instead of in a parallel `WeakMap` inside the pool.
+
+`@ydbjs/retry`:
+
+- New `ydb:retry.attempt.completed` event published after every attempt, with `{ attempt, idempotent, outcome }` where `outcome` is `'success' | 'retried' | 'non_retryable' | 'exhausted'`. Feeds the `ydb.retry.attempts` counter.
+- `tracing:ydb:retry.run` context now carries an `outcome` field (set by the runner before resolve / throw) so subscribers can tag end-to-end retry duration histograms by outcome.
+
+`@ydbjs/core`:
+
+- Bug fix: `ConnectionPool.unpessimize` previously published the `ydb:driver.connection.unpessimized` event with a `pessimizedDuration` field, while every documented subscriber (including `@ydbjs/telemetry`) reads `duration`. Renamed to `duration` so the event is no longer silently dropped.

--- a/.changeset/telemetry-metrics-pipeline.md
+++ b/.changeset/telemetry-metrics-pipeline.md
@@ -39,4 +39,4 @@ OpenTelemetry metrics pipeline, semantic-convention cleanup, and a `DeleteSessio
 
 `@ydbjs/core`:
 
-- Bug fix: `ConnectionPool.unpessimize` previously published the `ydb:driver.connection.unpessimized` event with a `pessimizedDuration` field, while every documented subscriber (including `@ydbjs/telemetry`) reads `duration`. Renamed to `duration` so the event is no longer silently dropped.
+- `ydb:driver.connection.unpessimized` payload field is `duration` (ms).

--- a/.changeset/telemetry-metrics-pipeline.md
+++ b/.changeset/telemetry-metrics-pipeline.md
@@ -29,7 +29,7 @@ OpenTelemetry metrics pipeline, semantic-convention cleanup, and a `DeleteSessio
 
 - `SessionPool` accepts a new `minSize?: number` option (default `0`) — reported as `ydb.query.session.min` once that observable is wired up. No eager session pre-warm is performed today; the option exists for parity with other YDB SDKs and for future warm-up logic.
 - `ydb:query.session.pool.opened` payload now includes `minSize`.
-- `Session.close()` accepts a `SessionCloseReason` (`pool_close` | `evicted` | `release_dead` | `attach_failed` | `user_close`). The `DeleteSession` RPC is now published via `tracingChannel('tracing:ydb:query.session.delete')` so subscribers see a span around each background delete, with the reason on the context.
+- `Session.close()` accepts a `SessionCloseReason` (`pool_close` | `attach_failed` | `stream_closed` | `stream_error`). The `DeleteSession` RPC is now published via `tracingChannel('tracing:ydb:query.session.delete')` so subscribers see a span around each background delete, with the reason on the context.
 - Session uptime is tracked on the `Session` itself (`readonly createdAt`) instead of in a parallel `WeakMap` inside the pool.
 
 `@ydbjs/retry`:

--- a/.changeset/telemetry-metrics-pipeline.md
+++ b/.changeset/telemetry-metrics-pipeline.md
@@ -1,5 +1,4 @@
 ---
-'@ydbjs/telemetry': minor
 '@ydbjs/query': minor
 '@ydbjs/retry': minor
 '@ydbjs/core': patch

--- a/.changeset/telemetry-metrics-pipeline.md
+++ b/.changeset/telemetry-metrics-pipeline.md
@@ -1,10 +1,10 @@
 ---
 '@ydbjs/query': minor
 '@ydbjs/retry': minor
-'@ydbjs/core': patch
+'@ydbjs/core': minor
 ---
 
-OpenTelemetry metrics pipeline, semantic-convention cleanup, and a `DeleteSession` span.
+OpenTelemetry metrics pipeline, semantic-convention cleanup, a `DeleteSession` span, and W3C trace context propagation in `@ydbjs/core`.
 
 `@ydbjs/telemetry`:
 
@@ -23,6 +23,7 @@ OpenTelemetry metrics pipeline, semantic-convention cleanup, and a `DeleteSessio
 - Two observable instruments are also emitted, fed by an internal per-`DriverIdentity` state registry that subscribes to existing lifecycle events:
   - `ydb.driver.connection.count` (`ObservableUpDownCounter`, tagged with `ydb.connection.state` ∈ `{live, pessimized}`)
   - `ydb.query.session.count` (`ObservableUpDownCounter`, total only — state breakdown is a follow-up that needs `session.acquired/released` events from `@ydbjs/query`)
+- W3C trace context propagation: `register()` installs a gRPC client middleware (via `@ydbjs/core`'s new `addClientMiddleware`) that calls `propagation.inject(context.active(), metadata, …)` on every outgoing YDB RPC. Always on while the instrumentation is enabled — without an OTel SDK the global propagator is a no-op. Must be called before `new Driver(...)` for the middleware to apply.
 
 `@ydbjs/query`:
 
@@ -39,3 +40,10 @@ OpenTelemetry metrics pipeline, semantic-convention cleanup, and a `DeleteSessio
 `@ydbjs/core`:
 
 - `ydb:driver.connection.unpessimized` payload field is `duration` (ms).
+- New `addClientMiddleware(mw)` API — appends a `ClientMiddleware` to a
+  process-global registry that `Driver` composes into its gRPC client chain
+  at construction time. Returns a `Disposable` for cleanup. Used by
+  `@ydbjs/telemetry` to install W3C trace context propagation without
+  pulling OTel packages into `@ydbjs/core`. Drivers constructed before the
+  registration do not pick up the new middleware — call before
+  `new Driver(...)`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,68 @@ Main categories: `api`, `auth`, `grpc`, `driver`, `query`, `topic`, `tx`, `retry
 
 ---
 
+## Diagnostics Channels
+
+**Module:** `node:diagnostics_channel` — the SDK publishes structured events
+that `@ydbjs/telemetry` and future metrics/logs subscribers consume.
+
+### Channel naming
+
+```
+ydb:<subsystem>.<concept>[.<sub>].<action>
+tracing:ydb:<subsystem>.<concept>[.<sub>].<operation>
+```
+
+- **`<subsystem>`** — the package or logical owner of the event:
+  `driver`, `query`, `auth`. Add new ones (e.g. `topic`) as packages publish channels.
+- **`<concept>`** — the noun the event is about: `connection`, `session`,
+  `transaction`, `token`, `discovery`, etc.
+- **`<action>`** — verb / state in past tense for plain events
+  (`added`, `removed`, `closed`, `completed`) or operation name for tracing
+  (`acquire`, `create`, `execute`).
+- **`pool`** appears only when the event is about the pool *itself*
+  (`opened`, `closed`, `stats`), not about its contents. Events about
+  contents drop the `pool` segment because the pool is the implicit owner.
+
+**Examples (correct):**
+
+```
+ydb:driver.connection.added           // ConnectionPool added a connection
+ydb:query.session.created             // SessionPool created a session
+ydb:query.session.pool.opened         // SessionPool itself was opened
+tracing:ydb:driver.discovery          // discovery operation tracing
+tracing:ydb:query.session.acquire     // session acquisition tracing
+```
+
+**Examples (wrong):**
+
+```
+ydb:pool.connection.added             // ❌ which pool? core/ConnectionPool, query/SessionPool, ...
+ydb:session.created                   // ❌ whose session?
+tracing:ydb:discovery                 // ❌ missing subsystem prefix
+```
+
+### Exception: `retry`
+
+`@ydbjs/retry` keeps the `ydb:` / `tracing:ydb:` vendor prefix but omits
+the subsystem segment:
+
+```
+tracing:ydb:retry.run
+tracing:ydb:retry.attempt
+ydb:retry.exhausted
+```
+
+### Payload rules
+
+- Every db-scoped channel carries `driver: DriverIdentity`. No ALS for identity.
+- `DriverIdentity` is opaque; reference is stable for the driver's lifetime — safe as a `Map`/`WeakMap` key.
+- Per-event channels carry only event data. Config snapshots go on `*.pool.opened`, fired once.
+- Durations/timestamps in payloads are ms. OTel-second conversion happens in the telemetry subscriber, not in producers.
+- Don't mutate the publisher's `ctx`. Key per-call state by `ctx` reference in a private `WeakMap<object, T>`.
+
+---
+
 ## Development Workflow
 
 ### Essential Commands

--- a/e2e/topic/read-write.test.ts
+++ b/e2e/topic/read-write.test.ts
@@ -87,7 +87,7 @@ test('writes and reads messages from a topic', async () => {
 	}
 })
 
-// oxlint-disable-next-line eslint-plugin-jest(expect-expect)
+// oxlint-disable-next-line expect-expect
 test('writes and reads concurrently', { timeout: 60_000 }, async (tc) => {
 	const BATCH_SIZE = 1024
 	const MESSAGE_SIZE = 16 * 1024

--- a/examples/README.MD
+++ b/examples/README.MD
@@ -87,6 +87,17 @@ cd examples/fsm
 npm install && npm start
 ```
 
+### 📁 [telemetry/](./telemetry/)
+
+EN: OpenTelemetry tracing + metrics via `@ydbjs/telemetry`, OTLP/HTTP export, W3C trace context propagation to YDB.
+
+RU: OpenTelemetry трейсы и метрики через `@ydbjs/telemetry`, OTLP/HTTP экспорт, W3C trace context propagation в YDB.
+
+```bash
+cd examples/telemetry
+npm install && npm start
+```
+
 ### 📁 [service-account/](./service-account/)
 
 EN: Yandex Cloud Service Account authentication with authorized key JSON file.
@@ -142,6 +153,7 @@ cd examples/tls && npm start
 cd examples/topic && npm start
 cd examples/coordination && npm start
 cd examples/fsm && npm start
+cd examples/telemetry && npm start
 cd examples/service-account && npm start
 ```
 

--- a/examples/telemetry/README.md
+++ b/examples/telemetry/README.md
@@ -1,0 +1,61 @@
+# YDB OpenTelemetry Example
+
+Wires `@ydbjs/telemetry` into a standard OpenTelemetry Node SDK setup and
+exports both **traces** and **metrics** over OTLP/HTTP. Demonstrates:
+
+- Starting `NodeSDK` before YDB code runs so the global `TracerProvider` /
+  `MeterProvider` / `ContextManager` are in place when
+  `@ydbjs/telemetry` subscribes.
+- Calling `register({ ... })` to enable the instrumentation.
+- Wrapping the workload in a user-created span — `@ydbjs/core`'s propagation
+  middleware reads `context.active()` on every outgoing gRPC call and
+  injects W3C `traceparent` / `tracestate` headers so the YDB server sees
+  the same trace id.
+- Graceful teardown that flushes pending telemetry before the process exits.
+
+## Run
+
+```bash
+# Defaults to grpc://localhost:2136/local and OTLP http://localhost:4318.
+node index.js
+
+# Or point at a real collector / cluster:
+YDB_CONNECTION_STRING=grpcs://your.host:2135/?database=/ru/your/database \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://collector.local:4318 \
+  node index.js
+```
+
+A quick local collector (one of):
+
+- [Jaeger ≥ 1.50](https://www.jaegertracing.io/docs/latest/getting-started/) —
+  ships with an OTLP/HTTP receiver on `:4318`.
+- [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) — full
+  pipeline, can fan out to Jaeger + Prometheus + your APM of choice.
+
+## What you should see
+
+In your collector UI:
+
+- A root `demo.workload` span (your own).
+- Children: `ydb.Query.ExecuteQuery` (for the standalone `SELECT 1`) and
+  `ydb.Query.BeginTransaction` → `ydb.Query.ExecuteQuery` × 2 →
+  `ydb.Query.CommitTransaction` for the transaction block.
+- Pool lifecycle spans (`ydb.AttachSession`, `ydb.DeleteSession`) once the
+  example shuts down.
+
+In Prometheus / your metrics backend:
+
+- `db_client_operation_duration` histogram, tagged by `db.operation.name`.
+- `ydb_query_session_count` / `ydb_query_session_create_duration` / etc.
+
+## Tweaks
+
+| Knob                     | Where                                  | Default                                |
+| ------------------------ | -------------------------------------- | -------------------------------------- |
+| `captureQueryText`       | `register({ … })`                      | `false`                                |
+| `emitAcquireSessionSpan` | `register({ … })`                      | `false`                                |
+| Service name             | `new NodeSDK({ … })`                   | —                                      |
+| Metric export interval   | `PeriodicExportingMetricReader({ … })` | `5_000ms` here, `60_000ms` SDK default |
+
+See `packages/telemetry/README.md` for the full attribute / metric / span
+catalogue.

--- a/examples/telemetry/index.js
+++ b/examples/telemetry/index.js
@@ -1,0 +1,108 @@
+/**
+ * YDB OpenTelemetry Example
+ *
+ * Wires `@ydbjs/telemetry` into a typical OpenTelemetry Node SDK setup, runs
+ * a couple of queries inside a user-created span, and exports both spans and
+ * metrics via OTLP/HTTP.
+ *
+ * Run:
+ *   YDB_CONNECTION_STRING=grpc://localhost:2136/local node index.js
+ *
+ * Default exporter target is http://localhost:4318 (the OTLP/HTTP port of an
+ * OpenTelemetry Collector or Jaeger ≥ 1.50). Override with
+ * `OTEL_EXPORTER_OTLP_ENDPOINT=…`.
+ */
+
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http'
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
+import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics'
+import { NodeSDK } from '@opentelemetry/sdk-node'
+import { trace } from '@opentelemetry/api'
+import { Driver } from '@ydbjs/core'
+import { query } from '@ydbjs/query'
+import { register } from '@ydbjs/telemetry'
+
+let connectionString = process.env.YDB_CONNECTION_STRING || 'grpc://localhost:2136/local'
+
+// 1. Start the OTel Node SDK BEFORE any YDB code imports/runs. NodeSDK
+//    installs an AsyncLocalStorage-backed context manager, which is what
+//    `@ydbjs/core`'s propagation middleware reads from to write `traceparent`
+//    into outgoing gRPC metadata.
+let sdk = new NodeSDK({
+	serviceName: 'ydb-telemetry-example',
+	traceExporter: new OTLPTraceExporter(),
+	metricReader: new PeriodicExportingMetricReader({
+		exporter: new OTLPMetricExporter(),
+		// Demos export quickly so you see metrics without waiting; production
+		// defaults to 60s.
+		exportIntervalMillis: 5_000,
+	}),
+})
+sdk.start()
+
+// 2. Register `@ydbjs/telemetry` — `InstrumentationBase` subclass that
+//    subscribes to SDK `diagnostics_channel` events and emits spans + metrics
+//    via the global TracerProvider/MeterProvider installed in step 1.
+let instrumentation = register({
+	// Off by default — query text can carry PII via interpolated literals.
+	// Turn on per-environment when you control the data.
+	captureQueryText: false,
+	// Off by default — warm-pool session acquires are sub-ms and only add
+	// noise to traces. Turn on to debug pool starvation.
+	emitAcquireSessionSpan: false,
+})
+
+// 3. Construct the driver. No hooks wiring required — `@ydbjs/telemetry`
+//    plugs into `node:diagnostics_channel` topics that `@ydbjs/core`
+//    publishes natively. We close driver / query explicitly later so the
+//    teardown order is observable: workload → query close → driver close →
+//    instrumentation disable → SDK shutdown.
+let driver = new Driver(connectionString)
+await driver.ready()
+
+let sql = query(driver)
+
+// `Query` extends `EventEmitter`; its `.finally` aborts an internal controller
+// which can synthesise a stray `'error'` event after the awaited result is
+// already resolved. Demos silence it; production code should attach
+// `.on('error', …)` per query or install a process-level handler.
+process.on('uncaughtException', (err) => {
+	if (err instanceof Error && err.name === 'AbortError') return
+	throw err
+})
+
+// 4. Wrap the workload in a user-created span. The propagation middleware in
+//    `@ydbjs/core` reads `context.active()` on every outgoing RPC and injects
+//    W3C `traceparent` / `tracestate` headers — so the server sees this trace
+//    id and any future server-side instrumentation can correlate.
+let tracer = trace.getTracer('ydb-telemetry-example')
+
+await tracer.startActiveSpan('demo.workload', async (span) => {
+	try {
+		console.log('\n# 1. single-shot SELECT 1\n')
+		let [[row]] = await sql`SELECT 1 AS n`
+		console.log(`  → result: ${JSON.stringify(row)}\n`)
+
+		console.log('\n# 2. transaction with two SELECTs\n')
+		let result = await sql.begin(async (tx) => {
+			let [[a]] = await tx`SELECT 1 AS a`
+			let [[b]] = await tx`SELECT ${a.a + 1} AS b`
+			return b.b
+		})
+		console.log(`  → result: ${result}\n`)
+	} finally {
+		span.end()
+	}
+})
+
+console.log('\n# done, shutting down\n')
+
+// 5. Drain query (publishes `session.closed{pool_close}` for each pooled
+//    session) → close driver (publishes `driver.closed`) → disable
+//    instrumentation so any post-shutdown events stop generating spans →
+//    flush the OTel SDK so the final span batch and metric tick reach the
+//    collector before the process exits.
+await sql[Symbol.asyncDispose]()
+driver[Symbol.dispose]()
+instrumentation.disable()
+await sdk.shutdown()

--- a/examples/telemetry/package.json
+++ b/examples/telemetry/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "@ydbjs/examples-telemetry",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"publishConfig": {
+		"access": "restricted"
+	},
+	"scripts": {
+		"start": "node index.js"
+	},
+	"dependencies": {
+		"@opentelemetry/api": "^1.9.1",
+		"@opentelemetry/exporter-metrics-otlp-http": "^0.218.0",
+		"@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
+		"@opentelemetry/sdk-metrics": "^2.7.1",
+		"@opentelemetry/sdk-node": "^0.218.0",
+		"@ydbjs/core": "^6.1.1",
+		"@ydbjs/query": "^6.1.0",
+		"@ydbjs/telemetry": "^6.0.0"
+	},
+	"engines": {
+		"node": ">=20.19.0",
+		"npm": ">=10"
+	},
+	"engineStrict": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 				"third-parties/*"
 			],
 			"devDependencies": {
+				"@arethetypeswrong/cli": "0.17.4",
 				"@types/node": "^25.9.1",
 				"@vitest/coverage-v8": "^4.1.5",
 				"@vitest/ui": "^4.1.5",
@@ -174,6 +175,68 @@
 				"npm": ">=10"
 			}
 		},
+		"node_modules/@andrewbranch/untar.js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@andrewbranch/untar.js/-/untar.js-1.0.3.tgz",
+			"integrity": "sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==",
+			"dev": true
+		},
+		"node_modules/@arethetypeswrong/cli": {
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.17.4.tgz",
+			"integrity": "sha512-AeiKxtf67XD/NdOqXgBOE5TZWH3EOCt+0GkbUpekOzngc+Q/cRZ5azjWyMxISxxfp0EItgm5NoSld9p7BAA5xQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@arethetypeswrong/core": "0.17.4",
+				"chalk": "^4.1.2",
+				"cli-table3": "^0.6.3",
+				"commander": "^10.0.1",
+				"marked": "^9.1.2",
+				"marked-terminal": "^7.1.0",
+				"semver": "^7.5.4"
+			},
+			"bin": {
+				"attw": "dist/index.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@arethetypeswrong/core": {
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.17.4.tgz",
+			"integrity": "sha512-Izvir8iIoU+X4SKtDAa5kpb+9cpifclzsbA8x/AZY0k0gIfXYQ1fa1B6Epfe6vNA2YfDX8VtrZFgvnXB6aPEoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@andrewbranch/untar.js": "^1.0.3",
+				"@loaderkit/resolve": "^1.0.2",
+				"cjs-module-lexer": "^1.2.3",
+				"fflate": "^0.8.2",
+				"lru-cache": "^10.4.3",
+				"semver": "^7.5.4",
+				"typescript": "5.6.1-rc",
+				"validate-npm-package-name": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@arethetypeswrong/core/node_modules/typescript": {
+			"version": "5.6.1-rc",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.1-rc.tgz",
+			"integrity": "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
 		"node_modules/@assemblyscript/loader": {
 			"version": "0.19.23",
 			"license": "Apache-2.0"
@@ -227,6 +290,13 @@
 			"engines": {
 				"node": ">=18"
 			}
+		},
+		"node_modules/@braidai/lang": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@braidai/lang/-/lang-1.1.2.tgz",
+			"integrity": "sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/@bufbuild/buf": {
 			"version": "1.66.1",
@@ -313,6 +383,17 @@
 			},
 			"engines": {
 				"node": ">=14.17"
+			}
+		},
+		"node_modules/@colors/colors": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.1.90"
 			}
 		},
 		"node_modules/@date-fns/tz": {
@@ -431,6 +512,16 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/js-sdsl"
+			}
+		},
+		"node_modules/@loaderkit/resolve": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@loaderkit/resolve/-/resolve-1.0.6.tgz",
+			"integrity": "sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@braidai/lang": "^1.0.0"
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
@@ -2441,6 +2532,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@sindresorhus/is": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
+			}
+		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -3282,6 +3386,58 @@
 				"acorn": "^8"
 			}
 		},
+		"node_modules/ansi-escapes": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+			"integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"environment": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/assertion-error": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3351,6 +3507,33 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/char-regex": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/character-entities-html4": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
@@ -3379,6 +3562,76 @@
 			"integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
 			"license": "MIT"
 		},
+		"node_modules/cli-highlight": {
+			"version": "2.1.11",
+			"resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+			"integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"highlight.js": "^10.7.1",
+				"mz": "^2.4.0",
+				"parse5": "^5.1.1",
+				"parse5-htmlparser2-tree-adapter": "^6.0.0",
+				"yargs": "^16.0.0"
+			},
+			"bin": {
+				"highlight": "bin/highlight"
+			},
+			"engines": {
+				"node": ">=8.0.0",
+				"npm": ">=5.0.0"
+			}
+		},
+		"node_modules/cli-table3": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+			"integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"string-width": "^4.2.0"
+			},
+			"engines": {
+				"node": "10.* || >= 12.*"
+			},
+			"optionalDependencies": {
+				"@colors/colors": "1.5.0"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/comma-separated-tokens": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -3388,6 +3641,16 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/commander": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+			"integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/convert-source-map": {
@@ -3459,6 +3722,20 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/emojilib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+			"integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/entities": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
@@ -3470,6 +3747,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/environment": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+			"integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/es-errors": {
@@ -3487,6 +3777,16 @@
 			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/estree-walker": {
 			"version": "3.0.3",
@@ -3567,6 +3867,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"dev": true,
@@ -3637,6 +3947,16 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/highlight.js": {
+			"version": "10.7.3",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/hookable": {
 			"version": "5.5.3",
 			"resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
@@ -3685,6 +4005,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/istanbul-lib-coverage": {
@@ -3982,6 +4312,13 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
 			"dev": true,
@@ -4018,6 +4355,54 @@
 			"version": "8.11.1",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/marked": {
+			"version": "9.1.6",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
+			"integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 16"
+			}
+		},
+		"node_modules/marked-terminal": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
+			"integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-escapes": "^7.0.0",
+				"ansi-regex": "^6.1.0",
+				"chalk": "^5.4.1",
+				"cli-highlight": "^2.1.11",
+				"cli-table3": "^0.6.5",
+				"node-emoji": "^2.2.0",
+				"supports-hyperlinks": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"marked": ">=1 <16"
+			}
+		},
+		"node_modules/marked-terminal/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
 		},
 		"node_modules/mdast-util-to-hast": {
 			"version": "13.2.1",
@@ -4160,6 +4545,18 @@
 			"version": "2.1.3",
 			"license": "MIT"
 		},
+		"node_modules/mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"any-promise": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"thenify-all": "^1.0.0"
+			}
+		},
 		"node_modules/nanoid": {
 			"version": "3.3.11",
 			"dev": true,
@@ -4191,6 +4588,32 @@
 			"license": "MIT",
 			"dependencies": {
 				"ts-error": "^1.0.6"
+			}
+		},
+		"node_modules/node-emoji": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+			"integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/is": "^4.6.0",
+				"char-regex": "^1.0.2",
+				"emojilib": "^2.4.0",
+				"skin-tone": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/obug": {
@@ -4320,6 +4743,30 @@
 			"version": "1.0.11",
 			"license": "(MIT AND Zlib)"
 		},
+		"node_modules/parse5": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+			"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+			"integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"parse5": "^6.0.1"
+			}
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/path-parse": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -4426,6 +4873,16 @@
 			"integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/require-in-the-middle": {
 			"version": "7.5.2",
@@ -4596,6 +5053,19 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/skin-tone": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+			"integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"unicode-emoji-modifier-base": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"dev": true,
@@ -4629,6 +5099,21 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/stringify-entities": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -4644,6 +5129,29 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"dev": true,
@@ -4653,6 +5161,23 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/supports-hyperlinks": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+			"integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
 			}
 		},
 		"node_modules/supports-preserve-symlinks-flag": {
@@ -4673,6 +5198,29 @@
 			"integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/thenify": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"any-promise": "^1.0.0"
+			}
+		},
+		"node_modules/thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"thenify": ">= 3.1.0 < 4"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
 		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",
@@ -4796,6 +5344,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/unicode-emoji-modifier-base": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+			"integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/unist-util-is": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
@@ -4867,6 +5425,16 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/validate-npm-package-name": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
+			"integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/vfile": {
@@ -5712,12 +6280,40 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
 		"node_modules/xstate": {
 			"version": "5.28.0",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/xstate"
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/yaml": {
@@ -5733,6 +6329,35 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/zwitch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,12 @@
 				"third-parties/*"
 			],
 			"devDependencies": {
-				"@types/node": "^25.6.0",
+				"@types/node": "^25.9.1",
 				"@vitest/coverage-v8": "^4.1.5",
 				"@vitest/ui": "^4.1.5",
-				"oxfmt": "^0.46.0",
-				"oxlint": "^1.61.0",
-				"turbo": "^2.9.6",
+				"oxfmt": "^0.51.0",
+				"oxlint": "^1.66.0",
+				"turbo": "^2.9.14",
 				"typescript": "^5.9.3",
 				"vitest": "^4.1.5",
 				"zx": "^8.8.5"
@@ -124,6 +124,24 @@
 				"@ydbjs/auth": "^6.2.1",
 				"@ydbjs/core": "^6.1.1",
 				"@ydbjs/query": "^6.1.0"
+			},
+			"engines": {
+				"node": ">=20.19.0",
+				"npm": ">=10"
+			}
+		},
+		"examples/telemetry": {
+			"name": "@ydbjs/examples-telemetry",
+			"version": "0.1.0",
+			"dependencies": {
+				"@opentelemetry/api": "^1.9.1",
+				"@opentelemetry/exporter-metrics-otlp-http": "^0.218.0",
+				"@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
+				"@opentelemetry/sdk-metrics": "^2.7.1",
+				"@opentelemetry/sdk-node": "^0.218.0",
+				"@ydbjs/core": "^6.1.1",
+				"@ydbjs/query": "^6.1.0",
+				"@ydbjs/telemetry": "^6.0.0"
 			},
 			"engines": {
 				"node": ">=20.19.0",
@@ -444,9 +462,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/api-logs": {
-			"version": "0.215.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.215.0.tgz",
-			"integrity": "sha512-xrFlqhdhUyO8wSRn6DjE0145/HPWSJ5Nm0C7vWua6TdL/FSEAZvEyvdsa9CRXuxo9ebb7j/NEPhEcO62IJ0qUA==",
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+			"integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.3.0"
@@ -455,11 +473,26 @@
 				"node": ">=8.0.0"
 			}
 		},
+		"node_modules/@opentelemetry/configuration": {
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/configuration/-/configuration-0.218.0.tgz",
+			"integrity": "sha512-W8wIz7H2R1pufR5jfjb3gU2XkMpm2x/7b1RJcsuzvd70Il/rWWE+g5/Od7hQKrxRTSrTrOWlru101PWXz5I1EQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.7.1",
+				"yaml": "^2.0.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0"
+			}
+		},
 		"node_modules/@opentelemetry/context-async-hooks": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz",
 			"integrity": "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -469,9 +502,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/core": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
-			"integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+			"integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "^1.29.0"
@@ -483,23 +516,220 @@
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
-		"node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-			"version": "0.215.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.215.0.tgz",
-			"integrity": "sha512-FRydO5j7MWnXK9ghfykKxiSM8I5UeiicK/UNl3/mv86xoEKkb+LKz1I3WXgkuYVOQf22VNqbPO58s2W1mVWtEQ==",
+		"node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.218.0.tgz",
+			"integrity": "sha512-hoxrNH1l/Xy6F9WTJ5IK+6j1r9nQFlPOmrnTlhYHTySdunfXLmUCPv3bQtKYntxag9h3wLYBZQ2HI6FOx+BT2g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.7.0",
-				"@opentelemetry/otlp-exporter-base": "0.215.0",
-				"@opentelemetry/otlp-transformer": "0.215.0",
-				"@opentelemetry/resources": "2.7.0",
-				"@opentelemetry/sdk-metrics": "2.7.0"
+				"@grpc/grpc-js": "^1.14.3",
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/otlp-exporter-base": "0.218.0",
+				"@opentelemetry/otlp-grpc-exporter-base": "0.218.0",
+				"@opentelemetry/otlp-transformer": "0.218.0",
+				"@opentelemetry/sdk-logs": "0.218.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-logs-otlp-http": {
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.218.0.tgz",
+			"integrity": "sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api-logs": "0.218.0",
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/otlp-exporter-base": "0.218.0",
+				"@opentelemetry/otlp-transformer": "0.218.0",
+				"@opentelemetry/sdk-logs": "0.218.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-logs-otlp-proto": {
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.218.0.tgz",
+			"integrity": "sha512-1/noQNsp9gXD75HPzgjBrcF1+XTtry7pFAUfxVEJgg7mPv2AawKQuYkhMmJ8qjxz4Ubc3Y8bwvfxevXsKTq4cg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api-logs": "0.218.0",
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/otlp-exporter-base": "0.218.0",
+				"@opentelemetry/otlp-transformer": "0.218.0",
+				"@opentelemetry/resources": "2.7.1",
+				"@opentelemetry/sdk-logs": "0.218.0",
+				"@opentelemetry/sdk-trace-base": "2.7.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.218.0.tgz",
+			"integrity": "sha512-YapQ9vNMX0NSZF6LK5pWAFfjpJleV2O9uYWfYGeb/5F1Kb9rPGK8tZDMJFa/sOksgdFuflDvYuA0B4qjDB4fjQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@grpc/grpc-js": "^1.14.3",
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/exporter-metrics-otlp-http": "0.218.0",
+				"@opentelemetry/otlp-exporter-base": "0.218.0",
+				"@opentelemetry/otlp-grpc-exporter-base": "0.218.0",
+				"@opentelemetry/otlp-transformer": "0.218.0",
+				"@opentelemetry/resources": "2.7.1",
+				"@opentelemetry/sdk-metrics": "2.7.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.218.0.tgz",
+			"integrity": "sha512-bV7d2OuMpZu2+gAaxUAhzfZ0h3WVZk8ETQUEE3DNSntbTaMpuITjtm8I0rNyHFdm7Ax57K6ty7SgFXlBmOLIvQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/otlp-exporter-base": "0.218.0",
+				"@opentelemetry/otlp-transformer": "0.218.0",
+				"@opentelemetry/resources": "2.7.1",
+				"@opentelemetry/sdk-metrics": "2.7.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.218.0.tgz",
+			"integrity": "sha512-ubLddKjWULhla9YZRCj/rTBeppjJYE4e9w0icx5mTu3eFhWjQzbV75NYjXuIlEG+NJsBl6d+sTFw5Qu+oej4oQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/exporter-metrics-otlp-http": "0.218.0",
+				"@opentelemetry/otlp-exporter-base": "0.218.0",
+				"@opentelemetry/otlp-transformer": "0.218.0",
+				"@opentelemetry/resources": "2.7.1",
+				"@opentelemetry/sdk-metrics": "2.7.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-prometheus": {
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.218.0.tgz",
+			"integrity": "sha512-RT5oEyu1kddZJ1vt7/BUo5wV+P7hpNAESsR3dUd3+8deHuX7gWNoCOZn+SfDT+hJHlIJ5h/AxiCLXIrutswDJg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/resources": "2.7.1",
+				"@opentelemetry/sdk-metrics": "2.7.1",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.218.0.tgz",
+			"integrity": "sha512-3fXxVQEj9TNAFaCi79JeFKfeLd0sDtInaR3gaZDVlzNSPHtz8PZuCV34JKWjD4XXzT20IdMe8IpX6mRVNDA4Tw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@grpc/grpc-js": "^1.14.3",
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/otlp-exporter-base": "0.218.0",
+				"@opentelemetry/otlp-grpc-exporter-base": "0.218.0",
+				"@opentelemetry/otlp-transformer": "0.218.0",
+				"@opentelemetry/resources": "2.7.1",
+				"@opentelemetry/sdk-trace-base": "2.7.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-trace-otlp-http": {
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.218.0.tgz",
+			"integrity": "sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/otlp-exporter-base": "0.218.0",
+				"@opentelemetry/otlp-transformer": "0.218.0",
+				"@opentelemetry/resources": "2.7.1",
+				"@opentelemetry/sdk-trace-base": "2.7.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.218.0.tgz",
+			"integrity": "sha512-r1Msf8SNLRmwh9J6XQ5uh82D7CdDWMNHnPB7LAVHjzut0TkSeKc5KcIvr4SvHvfk/xwN5gxC+VLKQ1k0o8PSPw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/otlp-exporter-base": "0.218.0",
+				"@opentelemetry/otlp-transformer": "0.218.0",
+				"@opentelemetry/resources": "2.7.1",
+				"@opentelemetry/sdk-trace-base": "2.7.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-zipkin": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.7.1.tgz",
+			"integrity": "sha512-mfsD9bKAxcKrh5+y08TPodvClBO0CznBE3p79YAGnO81WI4LrdsGA65T53e4iTSbCalW4WaUpkbeJcbpyIUHfg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/resources": "2.7.1",
+				"@opentelemetry/sdk-trace-base": "2.7.1",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation": {
@@ -535,13 +765,31 @@
 			}
 		},
 		"node_modules/@opentelemetry/otlp-exporter-base": {
-			"version": "0.215.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.215.0.tgz",
-			"integrity": "sha512-lHrfbmeLSmesGSkkHiqDwOzfaEMSWXdc7q6UoLfbW8byONCb+bE/zkAr0kapN4US1baT/2nbpNT7Cn9XoB96Vg==",
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
+			"integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.7.0",
-				"@opentelemetry/otlp-transformer": "0.215.0"
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/otlp-transformer": "0.218.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.218.0.tgz",
+			"integrity": "sha512-H/lCGJ536N98VpYJOaWTQOkv4Dx6TnmStK6Rqfu1W7KkFbPAx04hjdYEMZF/YbnHzPUSIK4kM6OE2GKGBTpV9A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@grpc/grpc-js": "^1.14.3",
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/otlp-exporter-base": "0.218.0",
+				"@opentelemetry/otlp-transformer": "0.218.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -551,18 +799,17 @@
 			}
 		},
 		"node_modules/@opentelemetry/otlp-transformer": {
-			"version": "0.215.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.215.0.tgz",
-			"integrity": "sha512-cWwBvaV+vkXHkSoTYR8hGw+AW03UlgTr6xtrUKOMeum3T+8vffYXIfXu6KY5MLu8O9QtoBKqaKWw9I5xoOepng==",
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+			"integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "0.215.0",
-				"@opentelemetry/core": "2.7.0",
-				"@opentelemetry/resources": "2.7.0",
-				"@opentelemetry/sdk-logs": "0.215.0",
-				"@opentelemetry/sdk-metrics": "2.7.0",
-				"@opentelemetry/sdk-trace-base": "2.7.0",
-				"protobufjs": "^8.0.1"
+				"@opentelemetry/api-logs": "0.218.0",
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/resources": "2.7.1",
+				"@opentelemetry/sdk-logs": "0.218.0",
+				"@opentelemetry/sdk-metrics": "2.7.1",
+				"@opentelemetry/sdk-trace-base": "2.7.1"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -571,13 +818,43 @@
 				"@opentelemetry/api": "^1.3.0"
 			}
 		},
-		"node_modules/@opentelemetry/resources": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.0.tgz",
-			"integrity": "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==",
+		"node_modules/@opentelemetry/propagator-b3": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.7.1.tgz",
+			"integrity": "sha512-RJid6E2CKyeGfKBzXKF21ejabGMHypFkPAh3qZ+NvI+SGjuIye79t3PmiqcDgtRzdKH6ynXzbfslQ8DfpRUg2A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.7.0",
+				"@opentelemetry/core": "2.7.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/propagator-jaeger": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.7.1.tgz",
+			"integrity": "sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.7.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/resources": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+			"integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.7.1",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -588,14 +865,14 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-logs": {
-			"version": "0.215.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.215.0.tgz",
-			"integrity": "sha512-y3ucOmphzc4vgBTyIGchs+N/1rkACmoka8QalT2z1LBNM232Z17zMYayHcMl+dgMoOadZ0b72UZv7mDtqy1cFA==",
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+			"integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "0.215.0",
-				"@opentelemetry/core": "2.7.0",
-				"@opentelemetry/resources": "2.7.0",
+				"@opentelemetry/api-logs": "0.218.0",
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/resources": "2.7.1",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -606,13 +883,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-metrics": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.0.tgz",
-			"integrity": "sha512-Vd7h95av/LYRsAVN7wbprvvJnHkq7swMXAo7Uad0Uxf9jl6NSReLa0JNivrcc5BVIx/vl2t+cgdVQQbnVhsR9w==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
+			"integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.7.0",
-				"@opentelemetry/resources": "2.7.0"
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/resources": "2.7.1"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -621,14 +898,104 @@
 				"@opentelemetry/api": ">=1.9.0 <1.10.0"
 			}
 		},
-		"node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.0.tgz",
-			"integrity": "sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==",
+		"node_modules/@opentelemetry/sdk-node": {
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.218.0.tgz",
+			"integrity": "sha512-tPMjHrLV5gsfNdYqoRHjeGbCAZBXXD9c1Qo/2ut7VwnUABDNh76xNxrT0SEhkIIJuCN45bbN1vZnYL1gY0IkOg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.7.0",
-				"@opentelemetry/resources": "2.7.0",
+				"@opentelemetry/api-logs": "0.218.0",
+				"@opentelemetry/configuration": "0.218.0",
+				"@opentelemetry/context-async-hooks": "2.7.1",
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/exporter-logs-otlp-grpc": "0.218.0",
+				"@opentelemetry/exporter-logs-otlp-http": "0.218.0",
+				"@opentelemetry/exporter-logs-otlp-proto": "0.218.0",
+				"@opentelemetry/exporter-metrics-otlp-grpc": "0.218.0",
+				"@opentelemetry/exporter-metrics-otlp-http": "0.218.0",
+				"@opentelemetry/exporter-metrics-otlp-proto": "0.218.0",
+				"@opentelemetry/exporter-prometheus": "0.218.0",
+				"@opentelemetry/exporter-trace-otlp-grpc": "0.218.0",
+				"@opentelemetry/exporter-trace-otlp-http": "0.218.0",
+				"@opentelemetry/exporter-trace-otlp-proto": "0.218.0",
+				"@opentelemetry/exporter-zipkin": "2.7.1",
+				"@opentelemetry/instrumentation": "0.218.0",
+				"@opentelemetry/otlp-exporter-base": "0.218.0",
+				"@opentelemetry/propagator-b3": "2.7.1",
+				"@opentelemetry/propagator-jaeger": "2.7.1",
+				"@opentelemetry/resources": "2.7.1",
+				"@opentelemetry/sdk-logs": "0.218.0",
+				"@opentelemetry/sdk-metrics": "2.7.1",
+				"@opentelemetry/sdk-trace-base": "2.7.1",
+				"@opentelemetry/sdk-trace-node": "2.7.1",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation": {
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.218.0.tgz",
+			"integrity": "sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api-logs": "0.218.0",
+				"import-in-the-middle": "^3.0.0",
+				"require-in-the-middle": "^8.0.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-node/node_modules/cjs-module-lexer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+			"license": "MIT"
+		},
+		"node_modules/@opentelemetry/sdk-node/node_modules/import-in-the-middle": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+			"integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"acorn": "^8.15.0",
+				"acorn-import-attributes": "^1.9.5",
+				"cjs-module-lexer": "^2.2.0",
+				"module-details-from-path": "^1.0.4"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-node/node_modules/require-in-the-middle": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+			"integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.3.5",
+				"module-details-from-path": "^1.0.3"
+			},
+			"engines": {
+				"node": ">=9.3.0 || >=8.10.0 <9.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-base": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+			"integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/resources": "2.7.1",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -642,7 +1009,6 @@
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.7.1.tgz",
 			"integrity": "sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/context-async-hooks": "2.7.1",
@@ -654,57 +1020,6 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-			"integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/resources": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
-			"integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.7.1",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
-			"integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.7.1",
-				"@opentelemetry/resources": "2.7.1",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
@@ -727,9 +1042,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-android-arm-eabi": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.46.0.tgz",
-			"integrity": "sha512-b1doV4WRcJU+BESSlCvCjV+5CEr/T6h0frArAdV26Nir+gGNFNaylvDiiMPfF1pxeV0txZEs38ojzJaxBYg+ng==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.51.0.tgz",
+			"integrity": "sha512-Ni0sCqg5CIHaLIYFGj+ncbcumylvNC6FE4rfD0KfdmnWHbPJ+zev0qZCXKxy2hFVa0fYRK0yPzf5nzPbkZou7g==",
 			"cpu": [
 				"arm"
 			],
@@ -744,9 +1059,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-android-arm64": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.46.0.tgz",
-			"integrity": "sha512-v6+HhjsoV3GO0u2u9jLSAZrvWfTraDxKofUIQ7/ktS7tzS+epVsxdHmeM+XxuNcAY/nWxxU1Sg4JcGTNRXraBA==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.51.0.tgz",
+			"integrity": "sha512-eu5lAZjuo0KAkp+M24EhDqfOwA8owQ8d7wyBlOUUGRbDLHpU3IRlDHp8Dif+YqGlxs6jra7yS6WQu/NkPhAxeg==",
 			"cpu": [
 				"arm64"
 			],
@@ -761,9 +1076,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-darwin-arm64": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.46.0.tgz",
-			"integrity": "sha512-3eeooJGrqGIlI5MyryDZsAcKXSmKIgAD4yYtfRrRJzXZ0UTFZtiSveIur56YPrGMYZwT4XyVhHsMqrNwr1XeFA==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.51.0.tgz",
+			"integrity": "sha512-6LsUNIdURhhcIfIn8+xsOb61mSTa9msAHTeSGx9Jf4rsP/gN8PGCF+SKWPAQZbND2w/WBkqQ6303jqEEIXzMdQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -778,9 +1093,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-darwin-x64": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.46.0.tgz",
-			"integrity": "sha512-QG8BDM0CXWbu84k2SKmCqfEddPQPFiBicwtYnLqHRWZZl57HbtOLRMac/KTq2NO4AEc4ICCBpFxJIV9zcqYfkQ==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.51.0.tgz",
+			"integrity": "sha512-9aUMGmVxdHjYMsEAW1tNRoieTJXlVNDFkRvIR1J7LttJXWjVYCu2ekclLij2KJtxBxSQOYSHd12ME/adVGVbZg==",
 			"cpu": [
 				"x64"
 			],
@@ -795,9 +1110,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-freebsd-x64": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.46.0.tgz",
-			"integrity": "sha512-9DdCqS/n2ncu/Chazvt3cpgAjAmIGQDz7hFKSrNItMApyV/Ja9mz3hD4JakIE3nS8PW9smEbPWnb389QLBY4nw==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.51.0.tgz",
+			"integrity": "sha512-mkY1nhZTqYb+NHaAWxOCKISN6FwdrwMNsu17vTUA3wzUV2VJ+Paq15ZokRcsMU/2PUdHO73prxyeJpjXQ3MPpQ==",
 			"cpu": [
 				"x64"
 			],
@@ -812,9 +1127,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.46.0.tgz",
-			"integrity": "sha512-Dgs7VeE2jT0LHMhw6tPEt0xQYe54kBqHEovmWsv4FVQlegCOvlIJNx0S8n4vj8WUtpT+Z6BD2HhKJPLglLxvZg==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.51.0.tgz",
+			"integrity": "sha512-wtFwNwE4+YCNuPaWoGDZeGsKvD6D1YSUNBJNn/rJBh7CrDBThFE+TBI5kY7vRW9rIOQRsbW2IpyyL3Du4Zqwiw==",
 			"cpu": [
 				"arm"
 			],
@@ -829,9 +1144,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.46.0.tgz",
-			"integrity": "sha512-Zxn3adhTH13JKnU4xXJj8FeEfF680XjXh3gSShKl57HCMBRde2tUJTgogV/1MSHA80PJEVrDa7r66TLVq3Ia7Q==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.51.0.tgz",
+			"integrity": "sha512-rnOaNx86G7iRKM6lsCIQMux0SMGNC/TEbFR+r7lpruJ12bnrIWgxd5w1PLqOvgR9r8ZJbpK/zfRKctJnh8/Jfg==",
 			"cpu": [
 				"arm"
 			],
@@ -846,13 +1161,16 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-arm64-gnu": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.46.0.tgz",
-			"integrity": "sha512-+TWipjrgVM8D7aIdDD0tlr3teLTTvQTn7QTE5BpT10H1Fj82gfdn9X6nn2sDgx/MepuSCfSnzFNJq2paLL0OiA==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.51.0.tgz",
+			"integrity": "sha512-jOgDzSqWcICGRjsp4mc08FxKMN8vzP2Kgs4E0d2HUP99F+nJDQKklRV4Zuj+0gcBgjrzx2CbpqaIdUVPepCojA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -863,13 +1181,16 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-arm64-musl": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.46.0.tgz",
-			"integrity": "sha512-aAUPBWJ1lGwwnxZUEDLJ94+Iy6MuwJwPxUgO4sCA5mEEyDk7b+cDQ+JpX1VR150Zoyd+D49gsrUzpUK5h587Eg==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.51.0.tgz",
+			"integrity": "sha512-KBUCdrH5bwVrAvI9gU/1S55oH6fzXjr++J/oVocdu7bYTks1l7DNNT+rLd/1TDdAEjObGwmfWamn7LC1m8A0DQ==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -880,13 +1201,16 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.46.0.tgz",
-			"integrity": "sha512-ufBCJukyFX/UDrokP/r6BGDoTInnsDs7bxyzKAgMiZlt2Qu8GPJSJ6Zm6whIiJzKk0naxA8ilwmbO1LMw6Htxw==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.51.0.tgz",
+			"integrity": "sha512-NapfjYsABFqTJ1Dn9Efq6sN5esaHconVKwVLbDGNQLrwpOx/g17mkwErHzU72PutL67nf3wNAkbq122H+zLxag==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -897,13 +1221,16 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.46.0.tgz",
-			"integrity": "sha512-eqtlC2YmPqjun76R1gVfGLuKWx7NuEnLEAudZ7n6ipSKbCZTqIKSs1b5Y8K/JHZsRpLkeSmAAjig5HOIg8fQzQ==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.51.0.tgz",
+			"integrity": "sha512-5dlDt1dUZCVi6elIhiK1PWg9wpTzTcIuj0IZnSurvIoMrhOWqqTcc1dSTxcSkNaBZhfsNqRZdINI1zAgbKkJNQ==",
 			"cpu": [
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -914,13 +1241,16 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-riscv64-musl": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.46.0.tgz",
-			"integrity": "sha512-yccVOO2nMXkQLGgy0He3EQEwKD7NF0zEk+/OWmroznkqXyJdN6bfK0LtNnr6/14Bh3FjpYq7bP33l/VloCnxpA==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.51.0.tgz",
+			"integrity": "sha512-pgdWUJn0S5nulyiVdlFV8DzCUnGXkU99W5PSkkmbaZW+LrZBPxpezun4G0DDHbQaVYuJeCuKsXsGKGo77CkUTQ==",
 			"cpu": [
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -931,13 +1261,16 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-s390x-gnu": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.46.0.tgz",
-			"integrity": "sha512-aAf7fG23OQCey6VRPj9IeCraoYtpgtx0ZyJ1CXkPyT1wjzBE7c3xtuxHe/AdHaJfVVb/SXpSk8Gl1LzyQupSqw==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.51.0.tgz",
+			"integrity": "sha512-2XTFUe97CbDGAI8vjwDfZ1HdakO0XIADyJ24idEg64SC4/K4in/OisXVnrW4NMK7I6TgC7EqRhC0Ln/nKhAemA==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -948,13 +1281,16 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-x64-gnu": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.46.0.tgz",
-			"integrity": "sha512-q0JPsTMyJNjYrBvYFDz4WbVsafNZaPCZv4RnFypRotLqpKROtBZcEaXQW4eb9YmvLU3NckVemLJnzkSZSdmOxw==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.51.0.tgz",
+			"integrity": "sha512-kQ1OuCqqt/yyf0ZN9VFxW1/JnlgJgii3Dr7pWf9vNBvrX1hv6g39/+mc5oGRHRGJFZtl3zsGDWR9c5N2B/gwBw==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -965,13 +1301,16 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-x64-musl": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.46.0.tgz",
-			"integrity": "sha512-7LsLY9Cw57GPkhSR+duI3mt9baRczK/DtHYSldQ4BEU92da9igBQNl4z7Vq5U9NNPsh1FmpKvv1q9WDtiUQR1A==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.51.0.tgz",
+			"integrity": "sha512-ARTYqxHF475o96Gbn41hvSWSSRygPlRDXZZgZ9I2scU1y0qiWpCQyZCoefaQa0mwv+wwtZ+luS4YOzsRzM/izg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -982,9 +1321,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-openharmony-arm64": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.46.0.tgz",
-			"integrity": "sha512-lHiBOz8Duaku7JtRNLlps3j++eOaICPZSd8FCVmTDM4DFOPT71Bjn7g6iar1z7StXlKRweUKxWUs4sA+zWGDXg==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.51.0.tgz",
+			"integrity": "sha512-QiC1XrCl6a6BmqMzduO8hdIRMf1m44hCkt2Q68KWkTvUB/E7fd2iomyNh6KnnRca5w6eBrRAAtLFqTh+xjsjJA==",
 			"cpu": [
 				"arm64"
 			],
@@ -999,9 +1338,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-win32-arm64-msvc": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.46.0.tgz",
-			"integrity": "sha512-/5ktYUliP89RhgC37DBH1x20U5zPSZMy3cMEcO0j3793rbHP9MWsknBwQB6eozRzWmYrh0IFM/p20EbPvDlYlg==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.51.0.tgz",
+			"integrity": "sha512-NC/hJb9dtU23Zf8L7IVK95xnFjiQ7AfcLO2l5pb69TDEr958qxrtnB2CveeeNSCBFNIkgaTCfd/vHNSoG78l9g==",
 			"cpu": [
 				"arm64"
 			],
@@ -1016,9 +1355,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-win32-ia32-msvc": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.46.0.tgz",
-			"integrity": "sha512-3WTnoiuIr8XvV0DIY7SN+1uJSwKf4sPpcbHfobcRT9JutGcLaef/miyBB87jxd3aqH+mS0+G5lsgHuXLUwjjpQ==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.51.0.tgz",
+			"integrity": "sha512-2C45za4Rj36n8YIbhRL1PQbxmXJYf81WEcAgvj5I4ptRROG+A+81hREEN5bmCHADE1UfYaN312U6tkILoZZy6w==",
 			"cpu": [
 				"ia32"
 			],
@@ -1033,9 +1372,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-win32-x64-msvc": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.46.0.tgz",
-			"integrity": "sha512-IXxiQpkYnOwNfP23vzwSfhdpxJzyiPTY7eTn6dn3DsriKddESzM8i6kfq9R7CD/PUJwCvQT22NgtygBeug3KoA==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.51.0.tgz",
+			"integrity": "sha512-73RqdAuVKQTkjZIDw08JaDHUM4lav5Qu+CaPwg4QbbA7k8o7LEW0p3UsfZ/F8dsO/pwVYh3RzFcanwLRTTahbQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1050,9 +1389,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-android-arm-eabi": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.61.0.tgz",
-			"integrity": "sha512-6eZBPgiigK5txqoVgRqxbaxiom4lM8AP8CyKPPvpzKnQ3iFRFOIDc+0AapF+qsUSwjOzr5SGk4SxQDpQhkSJMQ==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.66.0.tgz",
+			"integrity": "sha512-f7kq8N51T4phpzqfBpA2qaVTI/KrkCmNwaj3t/97I/WLTDI+UhlP5GL9eER+zVxBhtlx5rKXWByJU1/zDAvyaw==",
 			"cpu": [
 				"arm"
 			],
@@ -1067,9 +1406,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-android-arm64": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.61.0.tgz",
-			"integrity": "sha512-CkwLR69MUnyv5wjzebvbbtTSUwqLxM35CXE79bHqDIK+NtKmPEUpStTcLQRZMCo4MP0qRT6TXIQVpK0ZVScnMA==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.66.0.tgz",
+			"integrity": "sha512-xu6QO71tdDS9mjmLZ3AqhtaVHBvdmsOKkYnReNNDgh+XiwnsipeQOIxbiYOOO0iAXycJ+GK0wdMSZP/2j/AmSg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1084,9 +1423,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-darwin-arm64": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.61.0.tgz",
-			"integrity": "sha512-8JbefTkbmvqkqWjmQrHke+MdpgT2UghhD/ktM4FOQSpGeCgbMToJEKdl9zwhr/YWTl92i4QI1KiTwVExpcUN8A==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.66.0.tgz",
+			"integrity": "sha512-HZ24VimSOC7mxuEA99e0H2FS0C1yO3+iW13jPRAk+e2njsUs3QeAXsafCDyaIrV/MirdOVez+etQNQsJE43zNQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1101,9 +1440,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-darwin-x64": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.61.0.tgz",
-			"integrity": "sha512-uWpoxDT47hTnDLcdEh5jVbso8rlTTu5o0zuqa9J8E0JAKmIWn7kGFEIB03Pycn2hd2vKxybPGLhjURy/9We5FQ==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.66.0.tgz",
+			"integrity": "sha512-awhj8ZvJrrRSnXj7V++rpZvTmnl99L6mi0B7gg7Cp7BN6cKpzuI481bHNLvXGA9GB1/oEgA3ponuyoAc6Md12A==",
 			"cpu": [
 				"x64"
 			],
@@ -1118,9 +1457,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-freebsd-x64": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.61.0.tgz",
-			"integrity": "sha512-K/o4hEyW7flfMel0iBVznmMBt7VIMHGdjADocHKpK1DUF9erpWnJ+BSSWd2W0c8K3mPtpph+CuHzRU6CI3l9jQ==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.66.0.tgz",
+			"integrity": "sha512-KQF0oVV21/FjIqkRuL8Q1vh8ECsE5+ocdH5tcqTQ4ZnYuDVoYibQUNfqBjQaUsP6UIIda5Y75Wpm5p4RgQWiWw==",
 			"cpu": [
 				"x64"
 			],
@@ -1135,9 +1474,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.61.0.tgz",
-			"integrity": "sha512-P6040ZkcyweJ0Po9yEFqJCdvZnf3VNCGs1SIHgXDf8AAQNC6ID/heXQs9iSgo2FH7gKaKq32VWc59XZwL34C5Q==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.66.0.tgz",
+			"integrity": "sha512-9u1rgwZSEXWb30vbFZzQ78HVXBo0WCKNwJ3a2InRUTNMRng+PUDIoSFmA+m4HdUfBaIqftShq8J8qHc+eE/Vig==",
 			"cpu": [
 				"arm"
 			],
@@ -1152,9 +1491,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-arm-musleabihf": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.61.0.tgz",
-			"integrity": "sha512-bwxrGCzTZkuB+THv2TQ1aTkVEfv5oz8sl+0XZZCpoYzErJD8OhPQOTA0ENPd1zJz8QsVdSzSrS2umKtPq4/JXg==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.66.0.tgz",
+			"integrity": "sha512-Ynot2HR1bHxUaNWoC280MVTDfZuaWuP3XfSMRDhyuZrVjhzoaBCVFlw8h8qeZjWKVUBhPWFIxB7AQTlK8Z2WWg==",
 			"cpu": [
 				"arm"
 			],
@@ -1169,13 +1508,16 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-arm64-gnu": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.61.0.tgz",
-			"integrity": "sha512-vkhb9/wKguMkLlrm3FoJW/Xmdv31GgYAE+x8lxxQ+7HeOxXUySI0q36a3NTVIuQUdLzxCI1zzMGsk1o37FOe3w==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.66.0.tgz",
+			"integrity": "sha512-xCbgzciGgo+A4aQZEknsNrNiIwY7sU5SfRuMmRjPIvZAgdF34cIHiKvwOsS5XRLjlTVSFwitmq6YclTtHTfU+g==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1186,13 +1528,16 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-arm64-musl": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.61.0.tgz",
-			"integrity": "sha512-bl1dQh8LnVqsj6oOQAcxwbuOmNJkwc4p6o//HTBZhNTzJy21TLDwAviMqUFNUxDHkPGpmdKTSN4tWTjLryP8xg==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.66.0.tgz",
+			"integrity": "sha512-hmo+ZB/lHkR1HdDmnziNpzSLmulnUSu10VEqX2Yex7OwvoBAbjJQLvy4gIBRV3AAwWnCvAxKp5Nv1GE6LU1QMg==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1203,13 +1548,16 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-ppc64-gnu": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.61.0.tgz",
-			"integrity": "sha512-QoOX6KB2IiEpyOj/HKqaxi+NQHPnOgNgnr22n9N4ANJCzXkUlj1UmeAbFb4PpqdlHIzvGDM5xZ0OKtcLq9RhiQ==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.66.0.tgz",
+			"integrity": "sha512-2Invd4Uyy81mVooQC5FBtfxSNrvcX1OxbMlVQ6M2erRrNI2awFYF26YNW2yFxdVFZ4ffNOWKghtMjhnUPsXsVA==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1220,13 +1568,16 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-riscv64-gnu": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.61.0.tgz",
-			"integrity": "sha512-1TGcTerjY6p152wCof3oKElccq3xHljS/Mucp04gV/4ATpP6nO7YNnp7opEg6SHkv2a57/b4b8Ndm9znJ1/qAw==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.66.0.tgz",
+			"integrity": "sha512-s0iXPDQVdgayE3RGa/N2DZF7tjgg0TwEtD1sGoDxqPDGrIXgo45H0yHknT0f9A0yteASsweYZtDyTuVlM4aSag==",
 			"cpu": [
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1237,13 +1588,16 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-riscv64-musl": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.61.0.tgz",
-			"integrity": "sha512-65wXEmZIrX2ADwC8i/qFL4EWLSbeuBpAm3suuX1vu4IQkKd+wLT/HU/BOl84kp91u2SxPkPDyQgu4yrqp8vwVA==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.66.0.tgz",
+			"integrity": "sha512-OekL4XFiu7RPK0JIZi8VeHgtIXPREf42t8Cy/rKEsC+P3gcqDgNAAGiyuUOpdbG4wwbfue1q4CHcCO7spSve6w==",
 			"cpu": [
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1254,13 +1608,16 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-s390x-gnu": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.61.0.tgz",
-			"integrity": "sha512-TVvhgMvor7Qa6COeXxCJ7ENOM+lcAOGsQ0iUdPSCv2hxb9qSHLQ4XF1h50S6RE1gBOJ0WV3rNukg4JJJP1LWRA==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.66.0.tgz",
+			"integrity": "sha512-Ga1D0kj1SFslm34ThA/BdkUlyAYEnTsXyRC4pF0C5agZSwtGdHYWMTQWemUfBGp4RCG4QWXgdO+HmmmKqOtlBg==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1271,13 +1628,16 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-x64-gnu": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.61.0.tgz",
-			"integrity": "sha512-SjpS5uYuFoDnDdZPwZE59ndF95AsY47R5MliuneTWR1pDm2CxGJaYXbKULI71t5TVfLQUWmrHEGRL9xvuq6dnA==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.66.0.tgz",
+			"integrity": "sha512-p5jfP1wUZe/IC3qpQO84n9DRnf9g3lKRtLBlQq23ykyrDglHcVx7sWmVTlPuU6SBw8mNnPzyOn022G3XZHnlww==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1288,13 +1648,16 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-x64-musl": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.61.0.tgz",
-			"integrity": "sha512-gGfAeGD4sNJGILZbc/yKcIimO9wQnPMoYp9swAaKeEtwsSQAbU+rsdQze5SBtIP6j0QDzeYd4XSSUCRCF+LIeQ==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.66.0.tgz",
+			"integrity": "sha512-vUB/sYlYZorDL1ZD+o9mRv7zbsykrrFRtmgS6R8musZqLtrPRQn1gc1eGpuX+sfdccz42STl/AqldY6XRb2upQ==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1305,9 +1668,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-openharmony-arm64": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.61.0.tgz",
-			"integrity": "sha512-OlVT0LrG/ct33EVtWRyR+B/othwmDWeRxfi13wUdPeb3lAT5TgTcFDcfLfarZtzB4W1nWF/zICMgYdkggX2WmQ==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.66.0.tgz",
+			"integrity": "sha512-yde+6p/F59xRkGR9H1HfngWRif1QRJjynZK349l+UI0H6w9hL3G8/AVaTHFyTtLVQ56qtNbX2/5Dc77n1ovnOg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1322,9 +1685,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-win32-arm64-msvc": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.61.0.tgz",
-			"integrity": "sha512-vI//NZPJk6DToiovPtaiwD4iQ7kO1r5ReWQD0sOOyKRtP3E2f6jxin4uvwi3OvDzHA2EFfd7DcZl5dtkQh7g1w==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.66.0.tgz",
+			"integrity": "sha512-O9GLucgoTdmOrbBX+EjzNe7o/Ze5TFOvXcib6bzUOtBOmj6cV+zw18NgB+cGKAkDw1Pdqs8vGkfHbbsLuDtXWg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1339,9 +1702,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-win32-ia32-msvc": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.61.0.tgz",
-			"integrity": "sha512-0ySj4/4zd2XjePs3XAQq7IigIstN4LPQZgCyigX5/ERMLjdWAJfnxcTsrtxZxuij8guJW8foXuHmhGxW0H4dDA==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.66.0.tgz",
+			"integrity": "sha512-m3Pjwc2MfTcom4E4gOv7DyuGyt7OfGNCbmqDHd+N7EzXmP+ppHuudm2NjcA3AjV5TSeGxaguVF4SbTKHe1USYA==",
 			"cpu": [
 				"ia32"
 			],
@@ -1356,9 +1719,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-win32-x64-msvc": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.61.0.tgz",
-			"integrity": "sha512-0xgSiyeqDLDZxXoe9CVJrOx3TUVsfyoOY7cNi03JbItNcC9WCZqrSNdrAbHONxhSPaVh/lzfnDcON1RqSUMhHw==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.66.0.tgz",
+			"integrity": "sha512-/DbBvw8UFBhja6PqudUjV4UtfsJr0Oa7jUjWVKB0g86lj/VwnPrkngn0sFql3c9RDA0O16dh7ozsXb6GjNAzBQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1378,70 +1741,6 @@
 			"integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@protobufjs/aspromise": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/base64": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/codegen": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/eventemitter": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/fetch": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.1",
-				"@protobufjs/inquire": "^1.1.0"
-			}
-		},
-		"node_modules/@protobufjs/float": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/inquire": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/path": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/pool": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/utf8": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
 			"version": "1.0.0-rc.16",
@@ -2150,9 +2449,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@turbo/darwin-64": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.6.tgz",
-			"integrity": "sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==",
+			"version": "2.9.14",
+			"resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.14.tgz",
+			"integrity": "sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==",
 			"cpu": [
 				"x64"
 			],
@@ -2164,9 +2463,9 @@
 			]
 		},
 		"node_modules/@turbo/darwin-arm64": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.9.6.tgz",
-			"integrity": "sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw==",
+			"version": "2.9.14",
+			"resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.9.14.tgz",
+			"integrity": "sha512-d23147mC9BsCPA9mJ0h/ubcpbRgcJBXbcG3+Vq7YLhjz3IXuvQsJ1UXH8f4MD76ZjJ4m/E4aRdJV+MW88CDfbw==",
 			"cpu": [
 				"arm64"
 			],
@@ -2178,9 +2477,9 @@
 			]
 		},
 		"node_modules/@turbo/linux-64": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.6.tgz",
-			"integrity": "sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA==",
+			"version": "2.9.14",
+			"resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.14.tgz",
+			"integrity": "sha512-P3ZKB5tuUDdDQWuAsACGUR1qv9W7BNWxdxqVJ0kZNuNNPRaVYTPPikLcp79+GiEcW3npsR+KyP38lnQiBc5aSA==",
 			"cpu": [
 				"x64"
 			],
@@ -2192,9 +2491,9 @@
 			]
 		},
 		"node_modules/@turbo/linux-arm64": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.6.tgz",
-			"integrity": "sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g==",
+			"version": "2.9.14",
+			"resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.14.tgz",
+			"integrity": "sha512-ZRTlzcUMrrPv9ZuDzRF9n60Ym13bKeG9jDB8WjxyLhWNzV+AJQN+zdpIk3NJYf2zQsGUm1mNar2P0elRzLw25g==",
 			"cpu": [
 				"arm64"
 			],
@@ -2206,9 +2505,9 @@
 			]
 		},
 		"node_modules/@turbo/windows-64": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.6.tgz",
-			"integrity": "sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g==",
+			"version": "2.9.14",
+			"resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.14.tgz",
+			"integrity": "sha512-exanwN6sIduZwykYeiTQj8kCmOhazP5WOz3bvXMcYtjhL6Z3iRWLewKrXCBq0bqwSP3iBMb/AerRCnHI4lx46A==",
 			"cpu": [
 				"x64"
 			],
@@ -2220,9 +2519,9 @@
 			]
 		},
 		"node_modules/@turbo/windows-arm64": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.6.tgz",
-			"integrity": "sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A==",
+			"version": "2.9.14",
+			"resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.14.tgz",
+			"integrity": "sha512-fVdCsnmYoKICsycbWuuGp6Jvi51/3G/UluFWuAUCvR8PIW5IJkAk5BM9UF8PSm0Q2IphWHFZjYEgjHsh3B9y/g==",
 			"cpu": [
 				"arm64"
 			],
@@ -2320,12 +2619,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.6.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"version": "25.9.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+			"integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.19.0"
+				"undici-types": ">=7.24.0 <7.24.7"
 			}
 		},
 		"node_modules/@types/shimmer": {
@@ -2915,6 +3215,10 @@
 		},
 		"node_modules/@ydbjs/examples-sls": {
 			"resolved": "examples/sls",
+			"link": true
+		},
+		"node_modules/@ydbjs/examples-telemetry": {
+			"resolved": "examples/telemetry",
 			"link": true
 		},
 		"node_modules/@ydbjs/examples-tls": {
@@ -3678,12 +3982,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/long": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-			"license": "Apache-2.0"
-		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
 			"dev": true,
@@ -3926,9 +4224,9 @@
 			}
 		},
 		"node_modules/oxfmt": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.46.0.tgz",
-			"integrity": "sha512-CopwJOwPAjZ9p76fCvz+mSOJTw9/NY3cSksZK3VO/bUQ8UoEcketNgUuYS0UB3p+R9XnXe7wGGXUmyFxc7QxJA==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.51.0.tgz",
+			"integrity": "sha512-l/AoAnaEOV7Q5/Z9kHOMDehVJnCgYN7wRoooWCTUMBMi16BJhLZqd9cmCnwcVFfVlzkt53zK2KLPFNp8vSsoDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3944,31 +4242,39 @@
 				"url": "https://github.com/sponsors/Boshen"
 			},
 			"optionalDependencies": {
-				"@oxfmt/binding-android-arm-eabi": "0.46.0",
-				"@oxfmt/binding-android-arm64": "0.46.0",
-				"@oxfmt/binding-darwin-arm64": "0.46.0",
-				"@oxfmt/binding-darwin-x64": "0.46.0",
-				"@oxfmt/binding-freebsd-x64": "0.46.0",
-				"@oxfmt/binding-linux-arm-gnueabihf": "0.46.0",
-				"@oxfmt/binding-linux-arm-musleabihf": "0.46.0",
-				"@oxfmt/binding-linux-arm64-gnu": "0.46.0",
-				"@oxfmt/binding-linux-arm64-musl": "0.46.0",
-				"@oxfmt/binding-linux-ppc64-gnu": "0.46.0",
-				"@oxfmt/binding-linux-riscv64-gnu": "0.46.0",
-				"@oxfmt/binding-linux-riscv64-musl": "0.46.0",
-				"@oxfmt/binding-linux-s390x-gnu": "0.46.0",
-				"@oxfmt/binding-linux-x64-gnu": "0.46.0",
-				"@oxfmt/binding-linux-x64-musl": "0.46.0",
-				"@oxfmt/binding-openharmony-arm64": "0.46.0",
-				"@oxfmt/binding-win32-arm64-msvc": "0.46.0",
-				"@oxfmt/binding-win32-ia32-msvc": "0.46.0",
-				"@oxfmt/binding-win32-x64-msvc": "0.46.0"
+				"@oxfmt/binding-android-arm-eabi": "0.51.0",
+				"@oxfmt/binding-android-arm64": "0.51.0",
+				"@oxfmt/binding-darwin-arm64": "0.51.0",
+				"@oxfmt/binding-darwin-x64": "0.51.0",
+				"@oxfmt/binding-freebsd-x64": "0.51.0",
+				"@oxfmt/binding-linux-arm-gnueabihf": "0.51.0",
+				"@oxfmt/binding-linux-arm-musleabihf": "0.51.0",
+				"@oxfmt/binding-linux-arm64-gnu": "0.51.0",
+				"@oxfmt/binding-linux-arm64-musl": "0.51.0",
+				"@oxfmt/binding-linux-ppc64-gnu": "0.51.0",
+				"@oxfmt/binding-linux-riscv64-gnu": "0.51.0",
+				"@oxfmt/binding-linux-riscv64-musl": "0.51.0",
+				"@oxfmt/binding-linux-s390x-gnu": "0.51.0",
+				"@oxfmt/binding-linux-x64-gnu": "0.51.0",
+				"@oxfmt/binding-linux-x64-musl": "0.51.0",
+				"@oxfmt/binding-openharmony-arm64": "0.51.0",
+				"@oxfmt/binding-win32-arm64-msvc": "0.51.0",
+				"@oxfmt/binding-win32-ia32-msvc": "0.51.0",
+				"@oxfmt/binding-win32-x64-msvc": "0.51.0"
+			},
+			"peerDependencies": {
+				"svelte": "^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"svelte": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/oxlint": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.61.0.tgz",
-			"integrity": "sha512-ZC0ALuhDZ6ivOFG+sy0D0pEDN49EvsId98zVlmYdkcXHsEM14m/qTNUEsUpiFiCVbpIxYtVBmmLE87nsbUHohQ==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.66.0.tgz",
+			"integrity": "sha512-N4LLxYLd94KEBqXDMDM5f+2PUpItTjDLreXe2Gn5KhjhCK4Qp2YUXaBi8Yu325ryOgKwt22m45fpD7nPOn69Yw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -3981,28 +4287,28 @@
 				"url": "https://github.com/sponsors/Boshen"
 			},
 			"optionalDependencies": {
-				"@oxlint/binding-android-arm-eabi": "1.61.0",
-				"@oxlint/binding-android-arm64": "1.61.0",
-				"@oxlint/binding-darwin-arm64": "1.61.0",
-				"@oxlint/binding-darwin-x64": "1.61.0",
-				"@oxlint/binding-freebsd-x64": "1.61.0",
-				"@oxlint/binding-linux-arm-gnueabihf": "1.61.0",
-				"@oxlint/binding-linux-arm-musleabihf": "1.61.0",
-				"@oxlint/binding-linux-arm64-gnu": "1.61.0",
-				"@oxlint/binding-linux-arm64-musl": "1.61.0",
-				"@oxlint/binding-linux-ppc64-gnu": "1.61.0",
-				"@oxlint/binding-linux-riscv64-gnu": "1.61.0",
-				"@oxlint/binding-linux-riscv64-musl": "1.61.0",
-				"@oxlint/binding-linux-s390x-gnu": "1.61.0",
-				"@oxlint/binding-linux-x64-gnu": "1.61.0",
-				"@oxlint/binding-linux-x64-musl": "1.61.0",
-				"@oxlint/binding-openharmony-arm64": "1.61.0",
-				"@oxlint/binding-win32-arm64-msvc": "1.61.0",
-				"@oxlint/binding-win32-ia32-msvc": "1.61.0",
-				"@oxlint/binding-win32-x64-msvc": "1.61.0"
+				"@oxlint/binding-android-arm-eabi": "1.66.0",
+				"@oxlint/binding-android-arm64": "1.66.0",
+				"@oxlint/binding-darwin-arm64": "1.66.0",
+				"@oxlint/binding-darwin-x64": "1.66.0",
+				"@oxlint/binding-freebsd-x64": "1.66.0",
+				"@oxlint/binding-linux-arm-gnueabihf": "1.66.0",
+				"@oxlint/binding-linux-arm-musleabihf": "1.66.0",
+				"@oxlint/binding-linux-arm64-gnu": "1.66.0",
+				"@oxlint/binding-linux-arm64-musl": "1.66.0",
+				"@oxlint/binding-linux-ppc64-gnu": "1.66.0",
+				"@oxlint/binding-linux-riscv64-gnu": "1.66.0",
+				"@oxlint/binding-linux-riscv64-musl": "1.66.0",
+				"@oxlint/binding-linux-s390x-gnu": "1.66.0",
+				"@oxlint/binding-linux-x64-gnu": "1.66.0",
+				"@oxlint/binding-linux-x64-musl": "1.66.0",
+				"@oxlint/binding-openharmony-arm64": "1.66.0",
+				"@oxlint/binding-win32-arm64-msvc": "1.66.0",
+				"@oxlint/binding-win32-ia32-msvc": "1.66.0",
+				"@oxlint/binding-win32-x64-msvc": "1.66.0"
 			},
 			"peerDependencies": {
-				"oxlint-tsgolint": ">=0.18.0"
+				"oxlint-tsgolint": ">=0.22.1"
 			},
 			"peerDependenciesMeta": {
 				"oxlint-tsgolint": {
@@ -4093,30 +4399,6 @@
 		"node_modules/proposal-decimal": {
 			"version": "20250613.0.0",
 			"license": "BSD-2-Clause"
-		},
-		"node_modules/protobufjs": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
-			"integrity": "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==",
-			"hasInstallScript": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.2",
-				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.4",
-				"@protobufjs/eventemitter": "^1.1.0",
-				"@protobufjs/fetch": "^1.1.0",
-				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.0",
-				"@protobufjs/path": "^1.1.2",
-				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.0",
-				"@types/node": ">=13.7.0",
-				"long": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
 		},
 		"node_modules/regex": {
 			"version": "6.1.0",
@@ -4478,21 +4760,21 @@
 			"optional": true
 		},
 		"node_modules/turbo": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.6.tgz",
-			"integrity": "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==",
+			"version": "2.9.14",
+			"resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.14.tgz",
+			"integrity": "sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"turbo": "bin/turbo"
 			},
 			"optionalDependencies": {
-				"@turbo/darwin-64": "2.9.6",
-				"@turbo/darwin-arm64": "2.9.6",
-				"@turbo/linux-64": "2.9.6",
-				"@turbo/linux-arm64": "2.9.6",
-				"@turbo/windows-64": "2.9.6",
-				"@turbo/windows-arm64": "2.9.6"
+				"@turbo/darwin-64": "2.9.14",
+				"@turbo/darwin-arm64": "2.9.14",
+				"@turbo/linux-64": "2.9.14",
+				"@turbo/linux-arm64": "2.9.14",
+				"@turbo/windows-64": "2.9.14",
+				"@turbo/windows-arm64": "2.9.14"
 			}
 		},
 		"node_modules/typescript": {
@@ -4508,9 +4790,10 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.19.2",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/unist-util-is": {
@@ -5437,6 +5720,21 @@
 				"url": "https://opencollective.com/xstate"
 			}
 		},
+		"node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
 		"node_modules/zwitch": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
@@ -5669,7 +5967,7 @@
 		},
 		"packages/telemetry": {
 			"name": "@ydbjs/telemetry",
-			"version": "0.1.0",
+			"version": "6.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",
@@ -5681,6 +5979,8 @@
 				"nice-grpc": "^2.1.13"
 			},
 			"devDependencies": {
+				"@opentelemetry/context-async-hooks": "^2.7.1",
+				"@opentelemetry/core": "^2.7.0",
 				"@opentelemetry/sdk-metrics": "^2.7.0",
 				"@opentelemetry/sdk-trace-base": "^2.0.0",
 				"@opentelemetry/sdk-trace-node": "^2.0.0",
@@ -5742,8 +6042,8 @@
 		"tests/slo": {
 			"name": "@ydbjs/slo",
 			"dependencies": {
-				"@opentelemetry/exporter-metrics-otlp-http": "^0.215.0",
-				"@opentelemetry/sdk-metrics": "^2.7.0",
+				"@opentelemetry/exporter-metrics-otlp-http": "^0.218.0",
+				"@opentelemetry/sdk-metrics": "^2.7.1",
 				"@ydbjs/api": "*",
 				"@ydbjs/core": "*",
 				"@ydbjs/query": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -436,6 +436,8 @@
 		},
 		"node_modules/@opentelemetry/api": {
 			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+			"integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8.0.0"
@@ -451,6 +453,19 @@
 			},
 			"engines": {
 				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/context-async-hooks": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz",
+			"integrity": "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/core": {
@@ -485,6 +500,38 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation": {
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+			"integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api-logs": "0.57.2",
+				"@types/shimmer": "^1.2.0",
+				"import-in-the-middle": "^1.8.1",
+				"require-in-the-middle": "^7.1.1",
+				"semver": "^7.5.2",
+				"shimmer": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation/node_modules/@opentelemetry/api-logs": {
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+			"integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/@opentelemetry/otlp-exporter-base": {
@@ -582,6 +629,75 @@
 			"dependencies": {
 				"@opentelemetry/core": "2.7.0",
 				"@opentelemetry/resources": "2.7.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-node": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.7.1.tgz",
+			"integrity": "sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/context-async-hooks": "2.7.1",
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/sdk-trace-base": "2.7.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+			"integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/resources": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+			"integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+			"integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/resources": "2.7.1",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -2212,6 +2328,12 @@
 				"undici-types": "~7.19.0"
 			}
 		},
+		"node_modules/@types/shimmer": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+			"integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+			"license": "MIT"
+		},
 		"node_modules/@types/unist": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2819,6 +2941,10 @@
 			"resolved": "tests/slo",
 			"link": true
 		},
+		"node_modules/@ydbjs/telemetry": {
+			"resolved": "packages/telemetry",
+			"link": true
+		},
 		"node_modules/@ydbjs/topic": {
 			"resolved": "packages/topic",
 			"link": true
@@ -2830,6 +2956,27 @@
 		"node_modules/abort-controller-x": {
 			"version": "0.4.3",
 			"license": "MIT"
+		},
+		"node_modules/acorn": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-import-attributes": {
+			"version": "1.9.5",
+			"resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+			"integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"acorn": "^8"
+			}
 		},
 		"node_modules/assertion-error": {
 			"version": "2.0.1",
@@ -2921,6 +3068,12 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
+		},
+		"node_modules/cjs-module-lexer": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+			"integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+			"license": "MIT"
 		},
 		"node_modules/comma-separated-tokens": {
 			"version": "2.0.3",
@@ -3015,6 +3168,15 @@
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/es-module-lexer": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
@@ -3092,12 +3254,33 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/hast-util-to-html": {
@@ -3171,6 +3354,33 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/import-in-the-middle": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+			"integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"acorn": "^8.14.0",
+				"acorn-import-attributes": "^1.9.5",
+				"cjs-module-lexer": "^1.2.2",
+				"module-details-from-path": "^1.0.3"
+			}
+		},
+		"node_modules/is-core-module": {
+			"version": "2.16.2",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+			"integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+			"license": "MIT",
+			"dependencies": {
+				"hasown": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/istanbul-lib-coverage": {
@@ -3632,6 +3842,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/module-details-from-path": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+			"integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+			"license": "MIT"
+		},
 		"node_modules/mrmime": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -3798,6 +4014,12 @@
 			"version": "1.0.11",
 			"license": "(MIT AND Zlib)"
 		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"license": "MIT"
+		},
 		"node_modules/pathe": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -3923,6 +4145,41 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/require-in-the-middle": {
+			"version": "7.5.2",
+			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+			"integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.3.5",
+				"module-details-from-path": "^1.0.3",
+				"resolve": "^1.22.8"
+			},
+			"engines": {
+				"node": ">=8.6.0"
+			}
+		},
+		"node_modules/resolve": {
+			"version": "1.22.12",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+			"integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"is-core-module": "^2.16.1",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/rolldown": {
 			"version": "1.0.0-rc.16",
 			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
@@ -4004,7 +4261,6 @@
 		},
 		"node_modules/semver": {
 			"version": "7.7.4",
-			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -4029,6 +4285,12 @@
 				"@shikijs/vscode-textmate": "^10.0.2",
 				"@types/hast": "^3.0.4"
 			}
+		},
+		"node_modules/shimmer": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/siginfo": {
 			"version": "2.0.0",
@@ -4109,6 +4371,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/tabbable": {
@@ -5387,6 +5661,30 @@
 				"@ydbjs/debug": "^6.0.0",
 				"@ydbjs/error": "^6.0.0",
 				"nice-grpc": "^2.1.13"
+			},
+			"engines": {
+				"node": ">=20.19.0",
+				"npm": ">=10"
+			}
+		},
+		"packages/telemetry": {
+			"name": "@ydbjs/telemetry",
+			"version": "0.1.0",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api": "^1.9.0",
+				"@opentelemetry/instrumentation": "^0.57.0",
+				"@opentelemetry/semantic-conventions": "^1.32.0",
+				"@ydbjs/api": "^6.0.0",
+				"@ydbjs/core": "^6.0.0",
+				"@ydbjs/error": "^6.0.0",
+				"nice-grpc": "^2.1.13"
+			},
+			"devDependencies": {
+				"@opentelemetry/sdk-metrics": "^2.7.0",
+				"@opentelemetry/sdk-trace-base": "^2.0.0",
+				"@opentelemetry/sdk-trace-node": "^2.0.0",
+				"@types/debug": "^4.1.12"
 			},
 			"engines": {
 				"node": ">=20.19.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"prepare": "git config core.hooksPath scripts/hooks"
 	},
 	"devDependencies": {
+		"@arethetypeswrong/cli": "0.17.4",
 		"@types/node": "^25.9.1",
 		"@vitest/coverage-v8": "^4.1.5",
 		"@vitest/ui": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -27,18 +27,19 @@
 		"prepare": "git config core.hooksPath scripts/hooks"
 	},
 	"devDependencies": {
-		"@types/node": "^25.6.0",
+		"@types/node": "^25.9.1",
 		"@vitest/coverage-v8": "^4.1.5",
 		"@vitest/ui": "^4.1.5",
-		"oxfmt": "^0.46.0",
-		"oxlint": "^1.61.0",
-		"turbo": "^2.9.6",
+		"oxfmt": "^0.51.0",
+		"oxlint": "^1.66.0",
+		"turbo": "^2.9.14",
 		"typescript": "^5.9.3",
 		"vitest": "^4.1.5",
 		"zx": "^8.8.5"
 	},
 	"overrides": {
 		"@grpc/proto-loader": "npm:dry-uninstall",
+		"protobufjs": "npm:dry-uninstall",
 		"esbuild": "^0.28.0"
 	},
 	"packageManager": "npm@11.5.1"

--- a/packages/auth/tests/static.test.ts
+++ b/packages/auth/tests/static.test.ts
@@ -1,3 +1,5 @@
+import { channel as dc } from 'node:diagnostics_channel'
+
 import { beforeEach, expect, inject, test, vi } from 'vitest'
 import { StaticCredentialsProvider } from '../src/static.js'
 
@@ -12,6 +14,28 @@ import { StaticCredentialsProvider } from '../src/static.js'
 // Expiry thresholds from static.ts
 const SOFT_EXPIRY_THRESHOLD_SECONDS = 120
 const HARD_EXPIRY_THRESHOLD_SECONDS = 30
+
+/**
+ * Direct refresh observation. JWT byte-equality is unreliable as a proxy
+ * — server stamps `iat` with 1s granularity and two refreshes inside one
+ * wall-clock second produce byte-identical tokens. Counting refresh events
+ * is the source of truth.
+ */
+function countRefreshes(): { count: number } & Disposable {
+	let state = { count: 0 }
+	let onRefresh = () => {
+		state.count++
+	}
+	dc('ydb:auth.token.refreshed').subscribe(onRefresh)
+	return {
+		get count() {
+			return state.count
+		},
+		[Symbol.dispose]() {
+			dc('ydb:auth.token.refreshed').unsubscribe(onRefresh)
+		},
+	}
+}
 
 beforeEach(() => {
 	vi.useRealTimers()
@@ -79,85 +103,84 @@ test('returns cached token when fresh (outside soft expiry threshold)', async ()
 	expect(token2).toBe(token1)
 })
 
-test('starts background refresh when approaching soft expiry threshold', async () => {
+test('returns cached token and fires a background refresh in the soft expiry zone', async () => {
 	let endpoint = inject('credentialsEndpoint')
 	let username = inject('credentialsUsername')
 	let password = inject('credentialsPassword')
 
 	let provider = new StaticCredentialsProvider({ username, password }, endpoint)
+	using refreshes = countRefreshes()
 
-	// Get initial token
 	let token1 = await provider.getToken()
-	expect(token1).toBeDefined()
+	let baseline = refreshes.count // initial login completed
 
-	// Move time to soft expiry threshold (120 seconds before expiry)
+	// Move time into the soft expiry zone (120 seconds before expiry)
 	vi.useFakeTimers()
 	let timeToSoftExpiry = (12 * 60 * 60 - SOFT_EXPIRY_THRESHOLD_SECONDS) * 1000
 	vi.setSystemTime(new Date(vi.getRealSystemTime() + timeToSoftExpiry))
 
-	// Should return cached token but start background refresh
+	// Soft zone: cached value returns immediately (byte-equal — no new token
+	// fetched yet), and a background refresh is kicked off asynchronously.
 	let token2 = await provider.getToken()
-	expect(token2).toBeDefined()
-	expect(token2).toBe(token1) // Still cached token
+	expect(token2).toBe(token1)
 
+	// Wait for the fire-and-forget background refresh to land.
 	vi.useRealTimers()
 	await new Promise((resolve) => setTimeout(resolve, 100))
 
-	let token3 = await provider.getToken()
-	expect(token3).toBeDefined()
-	expect(token3).not.toBe(token1) // Background refresh should have updated the token
+	expect(refreshes.count - baseline).toBeGreaterThanOrEqual(1)
 })
 
-test('forces synchronous refresh when approaching hard expiry threshold', async () => {
+test('blocks getToken on a fresh network refresh past the hard expiry threshold', async () => {
 	let endpoint = inject('credentialsEndpoint')
 	let username = inject('credentialsUsername')
 	let password = inject('credentialsPassword')
 
 	let provider = new StaticCredentialsProvider({ username, password }, endpoint)
+	using refreshes = countRefreshes()
 
-	// Get initial token
-	let token1 = await provider.getToken()
-	expect(token1).toBeDefined()
+	await provider.getToken()
+	let baseline = refreshes.count // initial login completed
 
-	// Move time to hard expiry threshold (30 seconds before expiry)
+	// Move time to the hard expiry threshold (30 seconds before expiry).
 	vi.useFakeTimers()
 	let timeToHardExpiry = (12 * 60 * 60 - HARD_EXPIRY_THRESHOLD_SECONDS) * 1000
 	vi.setSystemTime(new Date(vi.getRealSystemTime() + timeToHardExpiry))
 
-	// Should force synchronous refresh
-	let token2 = await provider.getToken()
-	expect(token2).toBeDefined()
-	expect(token2).not.toBe(token1)
+	// Synchronous refresh: getToken must NOT return until the network refresh
+	// has succeeded, so by the time it resolves the counter must have ticked.
+	await provider.getToken()
+	expect(refreshes.count - baseline).toBeGreaterThanOrEqual(1)
 })
 
-test('transitions from background to synchronous refresh', async () => {
+test('escalates from background to synchronous refresh across soft → hard zones', async () => {
 	let endpoint = inject('credentialsEndpoint')
 	let username = inject('credentialsUsername')
 	let password = inject('credentialsPassword')
 
 	let provider = new StaticCredentialsProvider({ username, password }, endpoint)
+	using refreshes = countRefreshes()
 
-	// Get initial token
-	let token1 = await provider.getToken()
-	expect(token1).toBeDefined()
+	await provider.getToken()
+	let baseline = refreshes.count // initial login completed
 
 	vi.useFakeTimers()
 
-	// Move to soft expiry threshold (background refresh)
+	// Soft zone: getToken returns the cached value immediately. A background
+	// refresh fires off but is not awaited by the caller — racing the assert
+	// here would be flaky; we only check the cumulative state at the end.
 	let timeToSoftExpiry = (12 * 60 * 60 - SOFT_EXPIRY_THRESHOLD_SECONDS) * 1000
 	vi.setSystemTime(new Date(vi.getRealSystemTime() + timeToSoftExpiry))
+	await provider.getToken()
 
-	let token2 = await provider.getToken()
-	expect(token2).toBeDefined()
-	expect(token2).toBe(token1)
-
-	// Move to hard expiry threshold (synchronous refresh)
+	// Hard zone: getToken blocks. The synchronous path here MUST produce a
+	// refresh — that's the contract under test. The earlier background may
+	// have landed too, so the delta is at least 1.
 	let timeToHardExpiry = (12 * 60 * 60 - HARD_EXPIRY_THRESHOLD_SECONDS) * 1000
 	vi.setSystemTime(new Date(vi.getRealSystemTime() + timeToHardExpiry))
+	await provider.getToken()
 
-	let token3 = await provider.getToken()
-	expect(token3).toBeDefined()
-	expect(token3).not.toBe(token1)
+	expect(refreshes.count - baseline).toBeGreaterThanOrEqual(1)
 })
 
 test('handles concurrent requests without duplicate authentication', async () => {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -78,39 +78,60 @@ Two primitives are used:
 - **`channel.publish`** — point-in-time state changes (gauges, counters, structured logs).
 - **`tracingChannel.tracePromise`** — bracketed operations with duration and possible error (spans, latency histograms).
 
+### Conventions
+
+All payloads share the same identity envelope, so multi-driver consumers can disambiguate:
+
+```ts
+type DriverIdentity = {
+  address: string         // host:port the driver was constructed with
+  port: number | undefined
+  database: string        // YDB database path
+  registeredAt: number    // Date.now() at Driver construction
+}
+```
+
+Time values follow Node.js conventions:
+
+- **Durations** are in **milliseconds** (`performance.now()` deltas).
+- **Timestamps** are in **epoch milliseconds** (`Date.now()`).
+- Subscribers that target OTel attributes / instruments (whose canonical unit is seconds) divide by 1000 at the mapping layer — `@ydbjs/telemetry` does this for you.
+
 ### Channels
 
 #### Driver lifecycle
 
-| Channel             | Type    | Payload                                                  |
-| ------------------- | ------- | -------------------------------------------------------- |
-| `ydb:driver.ready`  | publish | `{ database: string, duration: number }`                 |
-| `ydb:driver.failed` | publish | `{ database: string, duration: number, error: unknown }` |
-| `ydb:driver.closed` | publish | `{ database: string, uptime: number }`                   |
+| Channel             | Type    | Payload                                                              |
+| ------------------- | ------- | -------------------------------------------------------------------- |
+| `ydb:driver.ready`  | publish | `{ driver: DriverIdentity, duration: number }` (ms since `init`)     |
+| `ydb:driver.failed` | publish | `{ driver: DriverIdentity, duration: number, error: unknown }` (ms)  |
+| `ydb:driver.closed` | publish | `{ driver: DriverIdentity, uptime: number }` (ms since `ready`)      |
 
 #### Discovery
 
-| Channel                   | Type    | Payload                                                                                                |
-| ------------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
-| `tracing:ydb:discovery`   | tracing | `{ database: string }`                                                                                 |
-| `ydb:discovery.completed` | publish | `{ database: string, addedCount: number, removedCount: number, totalCount: number, duration: number }` |
+| Channel                          | Type    | Payload                                                                                                          |
+| -------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------- |
+| `tracing:ydb:driver.discovery`   | tracing | `{ driver: DriverIdentity }`                                                                                     |
+| `ydb:driver.discovery.completed` | publish | `{ driver: DriverIdentity, addedCount: number, removedCount: number, totalCount: number, duration: number }` (ms)|
 
 #### Connection pool
 
-| Channel                            | Type    | Payload                                                                                               |
-| ---------------------------------- | ------- | ----------------------------------------------------------------------------------------------------- |
-| `ydb:pool.connection.added`        | publish | `{ nodeId: bigint, address: string, location: string }`                                               |
-| `ydb:pool.connection.pessimized`   | publish | `{ nodeId: bigint, address: string, location: string, until: number }`                                |
-| `ydb:pool.connection.unpessimized` | publish | `{ nodeId: bigint, address: string, location: string, pessimizedDuration: number }`                   |
-| `ydb:pool.connection.retired`      | publish | `{ nodeId: bigint, address: string, location: string, reason: 'stale_active' \| 'stale_pessimized' }` |
-| `ydb:pool.connection.removed`      | publish | `{ nodeId: bigint, address: string, location: string, reason: 'replaced' \| 'idle' \| 'pool_close' }` |
+All connection-pool channels carry `{ driver: DriverIdentity, nodeId: bigint, address: string, location: string }` plus the extra field listed below.
 
-The pool exposes two distinct lifecycle events for connections:
+| Channel                              | Type    | Extra fields                                                            |
+| ------------------------------------ | ------- | ----------------------------------------------------------------------- |
+| `ydb:driver.connection.added`        | publish | (none)                                                                  |
+| `ydb:driver.connection.pessimized`   | publish | `until: number` — epoch ms when the pessimization window ends           |
+| `ydb:driver.connection.unpessimized` | publish | `duration: number` — ms the connection actually stayed pessimized       |
+| `ydb:driver.connection.retired`      | publish | `reason: 'stale_active' \| 'stale_pessimized'`                          |
+| `ydb:driver.connection.removed`      | publish | `reason: 'replaced' \| 'idle' \| 'pool_close'`                          |
+
+The pool exposes two distinct teardown events for connections:
 
 - `retired` — the connection was removed from active routing (e.g. its endpoint disappeared from discovery), but its gRPC channel is left open so in-flight streams can drain.
 - `removed` — the gRPC channel was physically closed. The `reason` field distinguishes whether it was a replacement, an idle teardown, or a pool shutdown.
 
-A gauge of "alive channels" can be reconstructed from the delta between `pool.connection.added` and `pool.connection.removed`. A gauge of "routable connections" should also subtract `retired`.
+A gauge of "alive channels" can be reconstructed from the delta between `connection.added` and `connection.removed`. A gauge of "routable connections" should also subtract `retired`. `@ydbjs/telemetry` does this with an in-memory `Map<DriverIdentity, ConnectionState>`.
 
 ### Subscribing
 
@@ -121,9 +142,9 @@ channel('ydb:driver.ready').subscribe((msg) => {
   console.log('driver ready', msg)
 })
 
-tracingChannel('tracing:ydb:discovery').subscribe({
+tracingChannel('tracing:ydb:driver.discovery').subscribe({
   start(ctx) {
-    // ctx.database === '/local'
+    // ctx.driver.database === '/local'
   },
   asyncEnd(ctx) {
     // discovery round succeeded
@@ -143,7 +164,7 @@ tracingChannel('tracing:ydb:discovery').subscribe({
 ```ts
 channel('ydb:driver.ready').subscribe((msg) => {
   try {
-    metrics.driverReady.add(1, { database: msg.database })
+    metrics.driverReady.add(1, { database: msg.driver.database })
   } catch (err) {
     // Never let a metrics failure escape — log it locally and move on.
     console.error('telemetry subscriber failed', err)

--- a/packages/core/src/diagnostics.test.ts
+++ b/packages/core/src/diagnostics.test.ts
@@ -30,6 +30,7 @@ function makePool(opts: { pessimizationTimeout?: number } = {}) {
 		idleTimeout: 0,
 		idleInterval: 0,
 		pessimizationTimeout: opts.pessimizationTimeout ?? 60_000,
+		identity: { database: '/local', address: '127.0.0.1' },
 	})
 }
 
@@ -51,9 +52,9 @@ function collect(name: string): { payloads: unknown[] } & Disposable {
 
 // ── added / removed via discovery ────────────────────────────────────────────
 
-test('publishes ydb:pool.connection.added when sync introduces a new endpoint', () => {
+test('publishes ydb:driver.connection.added when sync introduces a new endpoint', () => {
 	using pool = makePool()
-	using added = collect('ydb:pool.connection.added')
+	using added = collect('ydb:driver.connection.added')
 
 	pool.sync([makeProtoEndpoint(1)])
 
@@ -65,12 +66,12 @@ test('publishes ydb:pool.connection.added when sync introduces a new endpoint', 
 	})
 })
 
-test('publishes ydb:pool.connection.retired when an active endpoint disappears from discovery', () => {
+test('publishes ydb:driver.connection.retired when an active endpoint disappears from discovery', () => {
 	using pool = makePool()
 	pool.sync([makeProtoEndpoint(1)])
 
-	using retired = collect('ydb:pool.connection.retired')
-	using removed = collect('ydb:pool.connection.removed')
+	using retired = collect('ydb:driver.connection.retired')
+	using removed = collect('ydb:driver.connection.removed')
 
 	pool.sync([]) // node 1 is no longer in discovery
 
@@ -85,13 +86,13 @@ test('publishes ydb:pool.connection.retired when an active endpoint disappears f
 	})
 })
 
-test('publishes ydb:pool.connection.retired when a pessimized endpoint disappears from discovery', () => {
+test('publishes ydb:driver.connection.retired when a pessimized endpoint disappears from discovery', () => {
 	using pool = makePool()
 	pool.sync([makeProtoEndpoint(3)])
 	let [conn] = pool[POOL_GET_ACTIVE_FOR_TESTING]()
 	pool.pessimize(conn!)
 
-	using retired = collect('ydb:pool.connection.retired')
+	using retired = collect('ydb:driver.connection.retired')
 
 	pool.sync([])
 
@@ -104,13 +105,13 @@ test('publishes ydb:pool.connection.retired when a pessimized endpoint disappear
 
 // ── pessimize / unpessimize ──────────────────────────────────────────────────
 
-test('publishes ydb:pool.connection.pessimized with deadline when pessimize() is called', () => {
+test('publishes ydb:driver.connection.pessimized with deadline when pessimize() is called', () => {
 	let before = Date.now()
 	using pool = makePool({ pessimizationTimeout: 60_000 })
 	pool.sync([makeProtoEndpoint(2)])
 	let [conn] = pool[POOL_GET_ACTIVE_FOR_TESTING]()
 
-	using pessimized = collect('ydb:pool.connection.pessimized')
+	using pessimized = collect('ydb:driver.connection.pessimized')
 
 	pool.pessimize(conn!)
 
@@ -124,12 +125,12 @@ test('publishes ydb:pool.connection.pessimized with deadline when pessimize() is
 	expect(p.until).toBeGreaterThanOrEqual(before + 60_000)
 })
 
-test('does not re-publish ydb:pool.connection.pessimized when pessimize() refreshes an already-pessimized conn', () => {
+test('does not re-publish ydb:driver.connection.pessimized when pessimize() refreshes an already-pessimized conn', () => {
 	using pool = makePool({ pessimizationTimeout: 60_000 })
 	pool.sync([makeProtoEndpoint(20)])
 	let [conn] = pool[POOL_GET_ACTIVE_FOR_TESTING]()
 
-	using pessimized = collect('ydb:pool.connection.pessimized')
+	using pessimized = collect('ydb:driver.connection.pessimized')
 
 	pool.pessimize(conn!) // active → pessimized: fires
 	pool.pessimize(conn!) // already pessimized: timeout refresh, must not fire
@@ -138,7 +139,7 @@ test('does not re-publish ydb:pool.connection.pessimized when pessimize() refres
 	expect(pessimized.payloads).toHaveLength(1)
 })
 
-test('publishes ydb:pool.connection.unpessimized after the pessimization timeout elapses', async () => {
+test('publishes ydb:driver.connection.unpessimized after the pessimization timeout elapses', async () => {
 	// 1ms timeout + a small wait so `until < Date.now()` holds inside
 	// #refreshPessimized when acquire() runs.
 	using pool = makePool({ pessimizationTimeout: 1 })
@@ -148,7 +149,7 @@ test('publishes ydb:pool.connection.unpessimized after the pessimization timeout
 
 	await new Promise((r) => setTimeout(r, 5))
 
-	using unpessimized = collect('ydb:pool.connection.unpessimized')
+	using unpessimized = collect('ydb:driver.connection.unpessimized')
 
 	pool.acquire() // calls #refreshPessimized() — restores node 4
 
@@ -162,11 +163,11 @@ test('publishes ydb:pool.connection.unpessimized after the pessimization timeout
 
 // ── removed (physical close) by reason ───────────────────────────────────────
 
-test('publishes ydb:pool.connection.removed with reason=replaced on add() of an existing nodeId', () => {
+test('publishes ydb:driver.connection.removed with reason=replaced on add() of an existing nodeId', () => {
 	using pool = makePool()
 	pool.sync([makeProtoEndpoint(5)])
 
-	using removed = collect('ydb:pool.connection.removed')
+	using removed = collect('ydb:driver.connection.removed')
 
 	pool.add(makeProtoEndpoint(5)) // re-add — old channel must be replaced
 
@@ -177,11 +178,11 @@ test('publishes ydb:pool.connection.removed with reason=replaced on add() of an 
 	})
 })
 
-test('publishes ydb:pool.connection.removed with reason=pool_close on close()', () => {
+test('publishes ydb:driver.connection.removed with reason=pool_close on close()', () => {
 	let pool = makePool()
 	pool.sync([makeProtoEndpoint(6), makeProtoEndpoint(7)])
 
-	using removed = collect('ydb:pool.connection.removed')
+	using removed = collect('ydb:driver.connection.removed')
 
 	pool.close()
 
@@ -285,7 +286,7 @@ test('publishes ydb:driver.ready with duration after successful initial discover
 
 	expect(ready.payloads).toHaveLength(1)
 	let p = ready.payloads[0] as any
-	expect(p.database).toBe('/local')
+	expect(p.driver.database).toBe('/local')
 	expect(typeof p.duration).toBe('number')
 	expect(p.duration).toBeGreaterThanOrEqual(0)
 })
@@ -299,7 +300,7 @@ test('publishes ydb:driver.ready synchronously when discovery is disabled', () =
 
 	expect(driver.database).toBe('/local')
 	expect(ready.payloads).toHaveLength(1)
-	expect(ready.payloads[0]).toMatchObject({ database: '/local' })
+	expect(ready.payloads[0]).toMatchObject({ driver: { database: '/local' } })
 })
 
 test('publishes ydb:driver.failed with error and duration when initial discovery fails', async () => {
@@ -318,7 +319,7 @@ test('publishes ydb:driver.failed with error and duration when initial discovery
 
 	expect(failed.payloads.length).toBeGreaterThanOrEqual(1)
 	let p = failed.payloads[0] as any
-	expect(p.database).toBe('/local')
+	expect(p.driver.database).toBe('/local')
 	expect(typeof p.duration).toBe('number')
 	expect(p.error).toBeDefined()
 })
@@ -336,14 +337,14 @@ test('publishes ydb:driver.closed with uptime on close()', async () => {
 
 	expect(closed.payloads).toHaveLength(1)
 	let p = closed.payloads[0] as any
-	expect(p.database).toBe('/local')
+	expect(p.driver.database).toBe('/local')
 	expect(typeof p.uptime).toBe('number')
 	expect(p.uptime).toBeGreaterThanOrEqual(0)
 })
 
-test('publishes ydb:discovery.completed with added/removed/total counts', async () => {
+test('publishes ydb:driver.discovery.completed with added/removed/total counts', async () => {
 	await using server = await startDiscoveryServer()
-	using completed = collect('ydb:discovery.completed')
+	using completed = collect('ydb:driver.discovery.completed')
 
 	using driver = new Driver(`grpc://127.0.0.1:${server.port}/local`, {
 		'ydb.sdk.discovery_timeout_ms': 5_000,
@@ -353,7 +354,7 @@ test('publishes ydb:discovery.completed with added/removed/total counts', async 
 	expect(completed.payloads.length).toBeGreaterThanOrEqual(1)
 	let p = completed.payloads[0] as any
 	expect(p).toMatchObject({
-		database: '/local',
+		driver: { database: '/local' },
 		addedCount: 1,
 		removedCount: 0,
 		totalCount: 1,
@@ -361,9 +362,9 @@ test('publishes ydb:discovery.completed with added/removed/total counts', async 
 	expect(typeof p.duration).toBe('number')
 })
 
-test('traces tracing:ydb:discovery start and asyncEnd around a successful round', async () => {
+test('traces tracing:ydb:driver.discovery start and asyncEnd around a successful round', async () => {
 	await using server = await startDiscoveryServer()
-	using trace = collectTrace('tracing:ydb:discovery')
+	using trace = collectTrace('tracing:ydb:driver.discovery')
 
 	using driver = new Driver(`grpc://127.0.0.1:${server.port}/local`, {
 		'ydb.sdk.discovery_timeout_ms': 5_000,
@@ -373,7 +374,7 @@ test('traces tracing:ydb:discovery start and asyncEnd around a successful round'
 	expect(trace.start.length).toBeGreaterThanOrEqual(1)
 	expect(trace.asyncEnd.length).toBeGreaterThanOrEqual(1)
 	expect(trace.error).toHaveLength(0)
-	expect(trace.start[0]?.ctx).toMatchObject({ database: '/local' })
+	expect(trace.start[0]?.ctx).toMatchObject({ driver: { database: '/local' } })
 })
 
 test('close() during in-flight initial discovery suppresses ydb:driver.ready / .failed', async () => {
@@ -440,9 +441,9 @@ test('close() during in-flight initial discovery suppresses ydb:driver.ready / .
 	await server.shutdown()
 })
 
-test('traces tracing:ydb:discovery error when listEndpoints fails', async () => {
+test('traces tracing:ydb:driver.discovery error when listEndpoints fails', async () => {
 	await using server = await startDiscoveryServer({ fail: true })
-	using trace = collectTrace('tracing:ydb:discovery')
+	using trace = collectTrace('tracing:ydb:driver.discovery')
 
 	let driver = new Driver(`grpc://127.0.0.1:${server.port}/local`, {
 		'ydb.sdk.discovery_timeout_ms': 200,

--- a/packages/core/src/driver-identity.ts
+++ b/packages/core/src/driver-identity.ts
@@ -1,0 +1,11 @@
+/**
+ * Stable identity stamped onto diagnostics_channel payloads so multi-driver
+ * subscribers (telemetry / metrics) can attribute events to the right Driver
+ * without relying on AsyncLocalStorage. Producers attach this to the channel
+ * payload at publish-time; subscribers read it from the payload.
+ */
+export type DriverIdentity = {
+	database: string
+	address: string
+	port?: number
+}

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -31,6 +31,7 @@ import {
 import pkg from '../package.json' with { type: 'json' }
 import { BalancedChannel } from './channel.js'
 import { type Connection, GrpcConnection } from './conn.js'
+import type { DriverIdentity } from './driver-identity.js'
 import {
 	DriverCSDatabaseError,
 	DriverCSProtocolError,
@@ -44,9 +45,7 @@ import { debug } from './middleware.js'
 import { ConnectionPool } from './pool.js'
 import { detectRuntime } from './runtime.js'
 
-let discoveryCh = tracingChannel<{ database: string }, { database: string }>(
-	'tracing:ydb:discovery'
-)
+let discoveryCh = tracingChannel<{ driver: DriverIdentity }>('tracing:ydb:driver.discovery')
 
 export type { DriverHooks, EndpointInfo }
 
@@ -99,9 +98,11 @@ function databaseFromUrl(url: URL): string {
 	if (url.pathname && url.pathname !== '/') {
 		return url.pathname
 	}
+
 	if (url.searchParams.has('database')) {
 		return url.searchParams.get('database') || ''
 	}
+
 	return ''
 }
 
@@ -172,6 +173,12 @@ export class Driver implements Disposable {
 	#readyAt: number | undefined
 	#closed = false
 
+	// Referentially stable per driver instance — subscribers (telemetry
+	// registries, metric callbacks) key per-driver state by this reference.
+	// A new object per `get identity()` would shatter those keys and split
+	// every observable metric into one-shot series.
+	#identity!: DriverIdentity
+
 	constructor(connectionString: string, userOptions: Readonly<DriverOptions> = defaultOptions) {
 		dbg.log('Driver(connectionString: %s, options: %o)', connectionString, userOptions)
 
@@ -184,6 +191,8 @@ export class Driver implements Disposable {
 		this.cs = this.#parseConnectionString(connectionString)
 		this.options = this.#mergeOptions(userOptions)
 		this.#assertDiscoveryTimings()
+
+		this.#identity = this.#buildIdentity()
 
 		let channelCredentials = this.#createChannelCredentials()
 
@@ -205,6 +214,7 @@ export class Driver implements Disposable {
 
 		this.#pool = new ConnectionPool({
 			hooks: this.options.hooks,
+			identity: this.identity,
 			channelOptions: this.options.channelOptions,
 			channelCredentials: channelCredentials,
 			idleTimeout: this.options['ydb.sdk.connection_idle_timeout_ms']!,
@@ -246,6 +256,18 @@ export class Driver implements Disposable {
 		return ''
 	}
 
+	/**
+	 * Stable identity stamped onto every `diagnostics_channel` payload so
+	 * subscribers can attribute events to a specific Driver instance without
+	 * any AsyncLocalStorage cooperation from the publisher.
+	 *
+	 * Returns the same frozen object for the lifetime of the driver —
+	 * subscribers may use it as a Map key for per-driver state.
+	 */
+	get identity(): DriverIdentity {
+		return this.#identity
+	}
+
 	async ready(signal?: AbortSignal): Promise<void> {
 		dbg.log('waiting for driver to become ready')
 
@@ -269,23 +291,24 @@ export class Driver implements Disposable {
 		if (this.#closed) return
 		this.#closed = true
 
-		let uptime = this.#readyAt ? performance.now() - this.#readyAt : 0
-		dbg.log('closing driver (uptime %d ms)', uptime)
+		clearInterval(this.#rediscoverTimer)
 
 		// Cancel any in-flight discovery so its callbacks bail out instead of
 		// publishing `ydb:driver.ready` / `ydb:driver.failed` after this point.
 		this.#shutdown.abort(new Error('driver closed'))
+
 		// Unblock anyone waiting on ready() — markReady/markFailed are now
 		// guarded by #closed and won't settle the latch.
 		this.#ready.reject(new Error('driver closed'))
 
-		if (this.#rediscoverTimer) {
-			clearInterval(this.#rediscoverTimer)
-		}
 		this.#pool.close()
 		this.#connection.close()
 
-		dc('ydb:driver.closed').publish({ database: this.database, uptime })
+		let uptime = this.#readyAt ? performance.now() - this.#readyAt : 0
+
+		dc('ydb:driver.closed').publish({ driver: this.identity, uptime })
+
+		dbg.log('closing driver (uptime %d ms)', uptime)
 	}
 
 	/**
@@ -329,6 +352,17 @@ export class Driver implements Disposable {
 		return Promise.resolve(this.close())
 	}
 
+	#buildIdentity(): DriverIdentity {
+		// Drop `port` when the connection string has none rather than inventing
+		// a default — leaks fewer wrong values into telemetry.
+		let port = this.cs.port ? parseInt(this.cs.port, 10) : undefined
+		return Object.freeze({
+			database: this.database,
+			address: this.cs.hostname,
+			...(port !== undefined && { port }),
+		})
+	}
+
 	#parseConnectionString(cs: string): URL {
 		if (!cs) {
 			throw new Error('Invalid connection string. Must be a non-empty string')
@@ -370,6 +404,7 @@ export class Driver implements Disposable {
 			let secureContext = tls.createSecureContext(this.options.secureOptions)
 			return credentials.createFromSecureContext(secureContext)
 		}
+
 		return this.isSecure ? credentials.createSsl() : credentials.createInsecure()
 	}
 
@@ -419,25 +454,30 @@ export class Driver implements Disposable {
 		// Discovery resolved after close() — drop the event so subscribers don't
 		// see `ready` after `closed`. ready() already rejected via shutdown signal.
 		if (this.#closed) return
-		this.#readyAt = performance.now()
-		let duration = this.#readyAt - this.#initAt
-		dbg.log('driver ready in %d ms', duration)
+
 		this.#ready.resolve()
-		dc('ydb:driver.ready').publish({ database: this.database, duration })
+
+		let duration = performance.now() - this.#initAt
+		dc('ydb:driver.ready').publish({ driver: this.identity, duration })
+
+		dbg.log('driver ready in %d ms', duration)
 	}
 
 	#markFailed(error: unknown): void {
 		// Same reason as #markReady — don't publish failure after `closed`.
 		if (this.#closed) return
-		let duration = performance.now() - this.#initAt
-		dbg.log('driver init failed after %d ms: %O', duration, error)
+
 		this.#ready.reject(error)
-		dc('ydb:driver.failed').publish({ database: this.database, duration, error })
+
+		let duration = performance.now() - this.#initAt
+		dc('ydb:driver.failed').publish({ driver: this.identity, duration, error })
+
+		dbg.log('driver init failed after %d ms: %O', duration, error)
 	}
 
 	async #discovery(signal: AbortSignal): Promise<void> {
 		await discoveryCh.tracePromise(() => this.#runDiscoveryRound(signal), {
-			database: this.database,
+			driver: this.identity,
 		})
 	}
 
@@ -462,22 +502,6 @@ export class Driver implements Disposable {
 		let { added, removed } = this.#pool.sync(result.endpoints)
 		let duration = performance.now() - started
 
-		dbg.log(
-			'discovered %d endpoints (+%d / -%d) in %d ms',
-			result.endpoints.length,
-			added.length,
-			removed.length,
-			duration
-		)
-
-		dc('ydb:discovery.completed').publish({
-			database: this.database,
-			addedCount: added.length,
-			removedCount: removed.length,
-			totalCount: result.endpoints.length,
-			duration,
-		})
-
 		this.#safeHook('onDiscovery', () =>
 			this.options.hooks?.onDiscovery?.({
 				added,
@@ -491,6 +515,22 @@ export class Driver implements Disposable {
 					})
 				),
 			})
+		)
+
+		dc('ydb:driver.discovery.completed').publish({
+			driver: this.identity,
+			addedCount: added.length,
+			totalCount: result.endpoints.length,
+			removedCount: removed.length,
+			duration,
+		})
+
+		dbg.log(
+			'discovered %d endpoints (+%d / -%d) in %d ms',
+			result.endpoints.length,
+			added.length,
+			removed.length,
+			duration
 		)
 	}
 

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -1,6 +1,6 @@
-import * as tls from 'node:tls'
 import * as assert from 'node:assert/strict'
 import { channel as dc, tracingChannel } from 'node:diagnostics_channel'
+import * as tls from 'node:tls'
 
 import { create } from '@bufbuild/protobuf'
 import { anyUnpack } from '@bufbuild/protobuf/wkt'
@@ -29,6 +29,7 @@ import {
 } from 'nice-grpc'
 
 import pkg from '../package.json' with { type: 'json' }
+
 import { BalancedChannel } from './channel.js'
 import { type Connection, GrpcConnection } from './conn.js'
 import type { DriverIdentity } from './driver-identity.js'
@@ -41,7 +42,7 @@ import {
 	DriverResponseError,
 } from './errors.js'
 import type { DriverHooks, EndpointInfo } from './hooks.js'
-import { debug } from './middleware.js'
+import { debug, getRegisteredClientMiddlewares } from './middleware.js'
 import { ConnectionPool } from './pool.js'
 import { detectRuntime } from './runtime.js'
 
@@ -418,10 +419,19 @@ export class Driver implements Disposable {
 			return call.next(call.request, Object.assign(options, { metadata }))
 		}
 
-		return composeClientMiddleware(
-			composeClientMiddleware(debug, stamp),
-			this.#credentialsProvider.middleware
-		)
+		// Order: debug (logging) → stamp (SDK / db / app headers) → any
+		// externally-registered middleware (e.g. @ydbjs/telemetry's W3C
+		// propagator) → auth (x-ydb-auth-ticket). Auth runs last so a token
+		// refresh that fires from inside another middleware still wins the
+		// final header set.
+		//
+		// The registry snapshot is taken at construction time — call
+		// `addClientMiddleware()` BEFORE `new Driver(...)` for it to apply.
+		let chain = composeClientMiddleware(debug, stamp)
+		for (let mw of getRegisteredClientMiddlewares()) {
+			chain = composeClientMiddleware(chain, mw)
+		}
+		return composeClientMiddleware(chain, this.#credentialsProvider.middleware)
 	}
 
 	#startDiscoveryLoop(): void {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './driver.js'
+export type { DriverIdentity } from './driver-identity.js'
 export type {
 	DriverHooks,
 	EndpointInfo,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,12 +1,13 @@
-export * from './driver.js'
 export type { DriverIdentity } from './driver-identity.js'
+export * from './driver.js'
 export type {
+	CallCompleteEvent,
+	CallStartEvent,
+	DiscoveryErrorEvent,
+	DiscoveryEvent,
 	DriverHooks,
 	EndpointInfo,
-	CallStartEvent,
-	CallCompleteEvent,
 	PessimizeEvent,
 	UnpessimizeEvent,
-	DiscoveryEvent,
-	DiscoveryErrorEvent,
 } from './hooks.js'
+export { addClientMiddleware } from './middleware.js'

--- a/packages/core/src/middleware.test.ts
+++ b/packages/core/src/middleware.test.ts
@@ -1,0 +1,44 @@
+import type { ClientMiddleware, MethodDescriptor } from 'nice-grpc'
+import { expect, test } from 'vitest'
+
+import { addClientMiddleware, getRegisteredClientMiddlewares } from './middleware.ts'
+
+test('appends middleware to the registry and removes it on dispose', () => {
+	let before = getRegisteredClientMiddlewares().length
+	let mw: ClientMiddleware = async function* (call, options) {
+		return yield* call.next(call.request, options)
+	}
+
+	let handle = addClientMiddleware(mw)
+	expect(getRegisteredClientMiddlewares()).toContain(mw)
+	expect(getRegisteredClientMiddlewares().length).toBe(before + 1)
+
+	handle[Symbol.dispose]()
+	expect(getRegisteredClientMiddlewares()).not.toContain(mw)
+	expect(getRegisteredClientMiddlewares().length).toBe(before)
+})
+
+test('passes outgoing calls through registered middleware', async () => {
+	let seen: string | undefined
+	using _ = addClientMiddleware(async function* (call, options) {
+		seen = call.method.path
+		return yield* call.next(call.request, options)
+	})
+
+	// Drive the registered middleware directly to confirm it fires when
+	// composed into a chain. (Driver-level integration is covered by the
+	// telemetry package's propagation test.)
+	let mw = getRegisteredClientMiddlewares()[0]!
+	let call = {
+		method: { path: '/test/Method' } as unknown as MethodDescriptor,
+		request: undefined,
+		async *next() {
+			yield undefined
+		},
+	}
+
+	let gen = (mw as any)(call, {}) as AsyncGenerator
+	for await (let chunk of gen) void chunk
+
+	expect(seen).toBe('/test/Method')
+})

--- a/packages/core/src/middleware.ts
+++ b/packages/core/src/middleware.ts
@@ -24,3 +24,28 @@ export const debug: ClientMiddleware = async function* (call, options) {
 		}
 	}
 }
+
+// Process-global middleware registry. Drivers compose registered entries
+// into their gRPC client middleware chain at construction time. Used by
+// `@ydbjs/telemetry` to install W3C trace context propagation without
+// pulling `@opentelemetry/api` into `@ydbjs/core`.
+//
+// Timing: `addClientMiddleware()` must run **before** `new Driver(...)` for
+// the middleware to apply. Matches OTel's NodeSDK.start() pattern — start
+// instrumentation, then create application objects.
+let registeredMiddlewares: ClientMiddleware[] = []
+
+export function addClientMiddleware(mw: ClientMiddleware): Disposable {
+	registeredMiddlewares.push(mw)
+
+	return {
+		[Symbol.dispose]() {
+			let i = registeredMiddlewares.indexOf(mw)
+			if (i >= 0) registeredMiddlewares.splice(i, 1)
+		},
+	}
+}
+
+export function getRegisteredClientMiddlewares(): readonly ClientMiddleware[] {
+	return registeredMiddlewares
+}

--- a/packages/core/src/pool.ts
+++ b/packages/core/src/pool.ts
@@ -510,7 +510,7 @@ export class ConnectionPool implements Disposable {
 			nodeId: conn.endpoint.nodeId,
 			address: conn.endpoint.address,
 			location: conn.endpoint.location,
-			until: until,
+			until,
 		})
 
 		dbg.log('pessimized node %d address %s', conn.endpoint.nodeId, conn.endpoint.address)

--- a/packages/core/src/pool.ts
+++ b/packages/core/src/pool.ts
@@ -6,6 +6,7 @@ import { loggers } from '@ydbjs/debug'
 import type { ChannelCredentials, ChannelOptions } from 'nice-grpc'
 
 import { type Connection, GrpcConnection } from './conn.js'
+import type { DriverIdentity } from './driver-identity.js'
 import type { DriverHooks, EndpointInfo } from './hooks.js'
 
 /**
@@ -39,6 +40,8 @@ export interface ConnectionPoolOptions {
 	idleTimeout: number
 	idleInterval: number
 	pessimizationTimeout: number
+	/** Stamped onto every `ydb:driver.connection.*` event so multi-driver subscribers can attribute. */
+	identity: DriverIdentity
 }
 
 export class ConnectionPool implements Disposable {
@@ -133,29 +136,7 @@ export class ConnectionPool implements Disposable {
 			this.#connections.splice(index, 1)
 		}
 
-		// Don't double-pessimize — refresh the timestamp if already pessimized
-		let wasPessimized = this.#pessimized.has(conn)
-		let until = Date.now() + this.options.pessimizationTimeout
-		this.#pessimized.set(conn, until)
-
-		dbg.log('pessimized node %d address %s', conn.endpoint.nodeId, conn.endpoint.address)
-
-		// Only fire on the active→pessimized transition. Re-pessimize of an
-		// already-pessimized connection is a timeout refresh, not a state
-		// change — subscribers reconstructing pool state from delta events
-		// must not see it as a fresh transition.
-		if (!wasPessimized) {
-			dc('ydb:pool.connection.pessimized').publish({
-				nodeId: conn.endpoint.nodeId,
-				address: conn.endpoint.address,
-				location: conn.endpoint.location,
-				until,
-			})
-
-			this.#safeHook('onPessimize', () => {
-				this.options.hooks?.onPessimize?.({ endpoint: conn.endpoint })
-			})
-		}
+		this.#pessimizeConnection(conn)
 	}
 
 	/**
@@ -212,18 +193,19 @@ export class ConnectionPool implements Disposable {
 
 		this.#connections.push(conn)
 
+		dc('ydb:driver.connection.added').publish({
+			driver: this.options.identity,
+			nodeId: conn.endpoint.nodeId,
+			address: conn.endpoint.address,
+			location: conn.endpoint.location,
+		})
+
 		dbg.log(
 			'added connection to node %d address %s (pool size: %d)',
 			conn.endpoint.nodeId,
 			conn.endpoint.address,
 			this.#connections.length
 		)
-
-		dc('ydb:pool.connection.added').publish({
-			nodeId: conn.endpoint.nodeId,
-			address: conn.endpoint.address,
-			location: conn.endpoint.location,
-		})
 	}
 
 	/**
@@ -399,22 +381,23 @@ export class ConnectionPool implements Disposable {
 				this.#pessimized.delete(conn)
 				this.#connections.push(conn)
 
+				this.#safeHook('onUnpessimize', () => {
+					this.options.hooks?.onUnpessimize?.({ endpoint: conn.endpoint })
+				})
+
+				dc('ydb:driver.connection.unpessimized').publish({
+					driver: this.options.identity,
+					nodeId: conn.endpoint.nodeId,
+					address: conn.endpoint.address,
+					location: conn.endpoint.location,
+					duration: this.options.pessimizationTimeout - (until - now),
+				})
+
 				dbg.log(
 					'un-pessimized node %d address %s',
 					conn.endpoint.nodeId,
 					conn.endpoint.address
 				)
-
-				dc('ydb:pool.connection.unpessimized').publish({
-					nodeId: conn.endpoint.nodeId,
-					address: conn.endpoint.address,
-					location: conn.endpoint.location,
-					pessimizedDuration: this.options.pessimizationTimeout - (until - now),
-				})
-
-				this.#safeHook('onUnpessimize', () => {
-					this.options.hooks?.onUnpessimize?.({ endpoint: conn.endpoint })
-				})
 			}
 		}
 	}
@@ -503,6 +486,36 @@ export class ConnectionPool implements Disposable {
 		}
 	}
 
+	#pessimizeConnection(conn: Connection): void {
+		let now = Date.now()
+		let until = now + this.options.pessimizationTimeout
+
+		let pessimized = this.#pessimized.has(conn)
+		this.#pessimized.set(conn, until)
+
+		// Only fire on the active→pessimized transition. Re-pessimize of an
+		// already-pessimized connection is a timeout refresh, not a state
+		// change — subscribers reconstructing pool state from delta events
+		// must not see it as a fresh transition.
+		if (!pessimized) {
+			return
+		}
+
+		this.#safeHook('onPessimize', () => {
+			this.options.hooks?.onPessimize?.({ endpoint: conn.endpoint })
+		})
+
+		dc('ydb:driver.connection.pessimized').publish({
+			driver: this.options.identity,
+			nodeId: conn.endpoint.nodeId,
+			address: conn.endpoint.address,
+			location: conn.endpoint.location,
+			until: until,
+		})
+
+		dbg.log('pessimized node %d address %s', conn.endpoint.nodeId, conn.endpoint.address)
+	}
+
 	/**
 	 * Move a connection to the retired set. The gRPC channel stays open so
 	 * in-flight streams can drain; the idle sweep closes it later. Caller
@@ -518,7 +531,8 @@ export class ConnectionPool implements Disposable {
 			reason
 		)
 
-		dc('ydb:pool.connection.retired').publish({
+		dc('ydb:driver.connection.retired').publish({
+			driver: this.options.identity,
 			nodeId: conn.endpoint.nodeId,
 			address: conn.endpoint.address,
 			location: conn.endpoint.location,
@@ -540,7 +554,8 @@ export class ConnectionPool implements Disposable {
 			reason
 		)
 
-		dc('ydb:pool.connection.removed').publish({
+		dc('ydb:driver.connection.removed').publish({
+			driver: this.options.identity,
 			nodeId: conn.endpoint.nodeId,
 			address: conn.endpoint.address,
 			location: conn.endpoint.location,

--- a/packages/core/src/pool.ts
+++ b/packages/core/src/pool.ts
@@ -497,7 +497,7 @@ export class ConnectionPool implements Disposable {
 		// already-pessimized connection is a timeout refresh, not a state
 		// change — subscribers reconstructing pool state from delta events
 		// must not see it as a fresh transition.
-		if (!pessimized) {
+		if (pessimized) {
 			return
 		}
 

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -177,30 +177,40 @@ Security note: identifier() only quotes the name and escapes backticks. Do not p
 
 `@ydbjs/query` publishes events on [`node:diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html) so external subscribers (`@ydbjs/telemetry`, OpenTelemetry, custom loggers) can build traces, metrics, and logs without coupling the SDK to a specific telemetry stack.
 
+Every payload starts with a `driver: DriverIdentity` field (defined in `@ydbjs/core`) so multi-driver consumers can attribute events. Durations are in **milliseconds** (Node.js convention — `performance.now()` / `Date.now()`).
+
 ### Channels
 
 #### Query execution
 
-| Channel                         | Type    | Payload                                                                                        |
-| ------------------------------- | ------- | ---------------------------------------------------------------------------------------------- |
-| `tracing:ydb:query.execute`     | tracing | `{ text, sessionId, nodeId, idempotent, isolation, stage }` — one `ExecuteQuery` RPC           |
-| `tracing:ydb:query.transaction` | tracing | `{ isolation, idempotent }` — from `tx.begin` to `commit`/`rollback`, including the retry loop |
-| `tracing:ydb:query.begin`       | tracing | `{ sessionId, nodeId, isolation }` — one `BeginTransaction` RPC                                |
-| `tracing:ydb:query.commit`      | tracing | `{ sessionId, nodeId, txId }` — one `CommitTransaction` RPC                                    |
-| `tracing:ydb:query.rollback`    | tracing | `{ sessionId, nodeId, txId }` — one `RollbackTransaction` RPC (fire-and-forget)                |
-
-`stage` is `'standalone'` for single-shot queries, `'tx'` for queries inside a transaction body, and `'do'` reserved for the future `sql.do(...)` runner.
+| Channel                         | Type    | Extra fields beyond `{ driver }`                                                                |
+| ------------------------------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `tracing:ydb:query.execute`     | tracing | `{ text, sessionId, nodeId, idempotent, isolation }` — one `ExecuteQuery` RPC                   |
+| `tracing:ydb:query.transaction` | tracing | `{ isolation, idempotent }` — from `tx.begin` to `commit`/`rollback`, including the retry loop  |
+| `tracing:ydb:query.begin`       | tracing | `{ sessionId, nodeId, isolation }` — one `BeginTransaction` RPC                                 |
+| `tracing:ydb:query.commit`      | tracing | `{ sessionId, nodeId, txId }` — one `CommitTransaction` RPC                                     |
+| `tracing:ydb:query.rollback`    | tracing | `{ sessionId, nodeId, txId }` — one `RollbackTransaction` RPC (fire-and-forget)                 |
 
 #### Session pool
 
-| Channel                       | Type    | Payload                                                            |
-| ----------------------------- | ------- | ------------------------------------------------------------------ |
-| `tracing:ydb:session.acquire` | tracing | `{ kind: 'query' \| 'transaction' }`                               |
-| `tracing:ydb:session.create`  | tracing | `{ liveSessions, maxSize, creating }` — only when the pool grows   |
-| `ydb:session.created`         | publish | `{ sessionId, nodeId }`                                            |
-| `ydb:session.closed`          | publish | `{ sessionId, nodeId, reason: 'evicted' \| 'pool_close', uptime }` |
+| Channel                              | Type    | Extra fields beyond `{ driver }`                                                                                  |
+| ------------------------------------ | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| `tracing:ydb:query.session.acquire`  | tracing | _(none)_ — wraps each session-lease acquisition                                                                   |
+| `tracing:ydb:query.session.create`   | tracing | _(none)_ — wraps `CreateSession` RPC + first `AttachStream` message                                               |
+| `tracing:ydb:query.session.delete`   | tracing | `{ sessionId, nodeId, reason, uptime }` — wraps the background `DeleteSession` RPC                                |
+| `ydb:query.session.pool.opened`      | publish | `{ maxSize, minSize, maxWaiters }` — once per pool, config snapshot                                               |
+| `ydb:query.session.pool.closed`      | publish | _(none)_                                                                                                          |
+| `ydb:query.session.created`          | publish | `{ sessionId, nodeId }`                                                                                           |
+| `ydb:query.session.closed`           | publish | `{ sessionId, nodeId, reason, uptime }` (ms) — see reasons below                                                  |
+| `ydb:query.session.acquired`         | publish | `{ sessionId, nodeId }` — lease handed to a caller                                                                |
+| `ydb:query.session.released`         | publish | `{ sessionId, nodeId }` — caller dropped the lease (paired with `acquired`)                                       |
+| `ydb:query.session.acquire.failed`   | publish | `{ error }` — `acquire()` rejected (pool full, timeout, pool closed)                                              |
+| `ydb:query.session.waiter.enqueued`  | publish | _(none)_ — a caller started waiting because the pool is saturated                                                 |
+| `ydb:query.session.waiter.dequeued`  | publish | _(none)_ — waiter resolved, rejected, or was aborted                                                              |
 
-`session.closed` fires **once** per session lifecycle. `reason` distinguishes server-side teardown (`evicted` — attach stream died, e.g. session expired or was dropped by the server) from explicit pool shutdown (`pool_close` — emitted for every session still tracked by the pool when `pool.close()` runs).
+`reason` (`SessionCloseReason`) is one of: `'pool_close'` (pool tear-down), `'attach_failed'` (initial AttachStream rejected — session never lived), `'stream_closed'` (attach stream ended cleanly, e.g. server-side TTL), `'stream_error'` (attach stream errored mid-flight). Sessions are pool-owned; there is no user-driven close. Carried both on the plain `session.closed` event and inside the `session.delete` tracing ctx.
+
+`pool.opened.minSize` is reported even though the JS pool does not eagerly warm sessions today — the option exists for parity with other YDB SDKs and for future warm-up logic.
 
 ### Retry hierarchy
 
@@ -210,7 +220,7 @@ Retry-loop spans (`tracing:ydb:retry.run`, `tracing:ydb:retry.attempt`, `ydb:ret
 ydb.query.transaction
 └─ ydb.retry.run
    ├─ ydb.retry.attempt #1
-   │  ├─ ydb.session.acquire
+   │  ├─ ydb.query.session.acquire
    │  ├─ ydb.query.begin
    │  ├─ ydb.query.execute   (SELECT ...)
    │  └─ ydb.query.commit            ← or ydb.query.rollback on body throw
@@ -218,7 +228,7 @@ ydb.query.transaction
       ...
 ```
 
-`query.begin` / `query.commit` / `query.rollback` each wrap exactly one server RPC. Use them for "begin/commit/rollback latency" and "rollback rate" metrics; `query.execute` is reserved for `ExecuteQuery` only. Rollback is fire-and-forget — its `start` always fires, but `asyncEnd` may land after the surrounding `query.transaction.error`.
+`query.begin` / `query.commit` / `query.rollback` each wrap exactly one server RPC. Use them for "begin/commit/rollback latency" and "rollback rate" metrics; `query.execute` is reserved for `ExecuteQuery` only. Rollback is fire-and-forget — its `start` always fires, but `asyncEnd` may land after the surrounding `query.transaction.error`. The same fire-and-forget pattern applies to `query.session.delete` (sent in the background when a session leaves the pool).
 
 ### Subscribing
 
@@ -230,12 +240,12 @@ tracingChannel('tracing:ydb:query.execute').subscribe({
     span.start({
       name: 'ydb.query.execute',
       attributes: {
-        'db.system': 'ydb',
-        'db.statement': ctx.text,
-        'db.ydb.session_id': ctx.sessionId,
-        'db.ydb.node_id': String(ctx.nodeId),
-        'db.ydb.isolation': ctx.isolation,
-        'db.ydb.stage': ctx.stage,
+        'db.system.name': 'ydb',
+        'db.namespace': ctx.driver.database,
+        'db.query.text': ctx.text,
+        'ydb.session.id': ctx.sessionId,
+        'ydb.node.id': Number(ctx.nodeId),
+        'ydb.isolation': ctx.isolation,
       },
     })
   },
@@ -248,8 +258,9 @@ tracingChannel('tracing:ydb:query.execute').subscribe({
   },
 })
 
-channel('ydb:session.closed').subscribe((msg) => {
-  metrics.sessionLifetime.record(msg.uptime, { reason: msg.reason })
+channel('ydb:query.session.closed').subscribe((msg) => {
+  // msg.uptime is in ms; convert to seconds when feeding OTel histograms.
+  metrics.sessionLifetime.record(msg.uptime / 1000, { reason: msg.reason })
 })
 ```
 
@@ -259,7 +270,7 @@ channel('ydb:session.closed').subscribe((msg) => {
 
 ### Stability
 
-Channel names, payload field names, and the `stage` / `reason` / `kind` enums follow semantic versioning. Adding new optional fields or new enum values is a minor change; renaming or removing fields is a major change.
+Channel names, payload field names, and the `reason` (`SessionCloseReason`) enum follow semantic versioning. Adding new optional fields or new enum values is a minor change; renaming or removing fields is a major change.
 
 ## Development
 

--- a/packages/query/src/diagnostics.test.ts
+++ b/packages/query/src/diagnostics.test.ts
@@ -258,6 +258,7 @@ test('traces tracing:ydb:query.session.delete with reason=pool_close on pool.clo
 	// fires so the test exercises the full tracingChannel lifecycle, not
 	// just the start hook.
 	for (let i = 0; i < 50 && trace.asyncEnd.length === 0; i++) {
+		// oxlint-disable-next-line no-await-in-loop -- polling, sequential by design
 		await new Promise((r) => setImmediate(r))
 	}
 

--- a/packages/query/src/diagnostics.test.ts
+++ b/packages/query/src/diagnostics.test.ts
@@ -125,11 +125,11 @@ afterEach(async () => {
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
-test('publishes ydb:session.created with sessionId and nodeId after pool.acquire()', async () => {
+test('publishes ydb:query.session.created with sessionId and nodeId after pool.acquire()', async () => {
 	srv = await startServer()
 	pool = new SessionPool(srv.driver, { maxSize: 1 })
 
-	using created = collect('ydb:session.created')
+	using created = collect('ydb:query.session.created')
 
 	let lease = await pool.acquire()
 	lease[Symbol.dispose]()
@@ -141,7 +141,7 @@ test('publishes ydb:session.created with sessionId and nodeId after pool.acquire
 	})
 })
 
-test('publishes ydb:session.closed with reason=evicted when the server kills the attach stream', async () => {
+test('publishes ydb:query.session.closed with reason=stream_closed when the server kills the attach stream', async () => {
 	srv = await startServer()
 	pool = new SessionPool(srv.driver, { maxSize: 1 })
 
@@ -149,7 +149,7 @@ test('publishes ydb:session.closed with reason=evicted when the server kills the
 	let sessionId = lease.id
 	lease[Symbol.dispose]()
 
-	using closed = collect('ydb:session.closed')
+	using closed = collect('ydb:query.session.closed')
 
 	srv.breakSession(sessionId)
 	// Give the attach-stream abort time to propagate.
@@ -158,11 +158,11 @@ test('publishes ydb:session.closed with reason=evicted when the server kills the
 	expect(closed.payloads).toHaveLength(1)
 	expect(closed.payloads[0]).toMatchObject({
 		sessionId,
-		reason: 'evicted',
+		reason: 'stream_closed',
 	})
 })
 
-test('publishes ydb:session.closed with reason=pool_close once per session on pool.close()', async () => {
+test('publishes ydb:query.session.closed with reason=pool_close once per session on pool.close()', async () => {
 	srv = await startServer()
 	pool = new SessionPool(srv.driver, { maxSize: 2 })
 
@@ -172,7 +172,7 @@ test('publishes ydb:session.closed with reason=pool_close once per session on po
 	a[Symbol.dispose]()
 	b[Symbol.dispose]()
 
-	using closed = collect('ydb:session.closed')
+	using closed = collect('ydb:query.session.closed')
 
 	await pool.close()
 	pool = undefined
@@ -190,19 +190,19 @@ test('publishes ydb:session.closed with reason=pool_close once per session on po
 	}
 })
 
-test('release of a checked-out session after pool.close() fires ydb:session.closed exactly once', async () => {
+test('release of a checked-out session after pool.close() fires ydb:query.session.closed exactly once', async () => {
 	srv = await startServer()
 	pool = new SessionPool(srv.driver, { maxSize: 1 })
 
 	// Hold the session — do not release it before close().
 	let lease = await pool.acquire()
 
-	using closed = collect('ydb:session.closed')
+	using closed = collect('ydb:query.session.closed')
 
 	// Race: pool.close() flips this.closed and awaits in-flight creates.
 	// While that promise pends, drop the lease so release() takes the
 	// closed-pool branch, which calls session.close() and would re-fire
-	// `evicted` through the eviction listener if it were still attached.
+	// the stream_* reason through the eviction listener if it were still attached.
 	let closing = pool.close()
 	lease[Symbol.dispose]()
 	await closing
@@ -212,25 +212,78 @@ test('release of a checked-out session after pool.close() fires ydb:session.clos
 	expect(closed.payloads[0]).toMatchObject({ reason: 'pool_close' })
 })
 
-test('traces tracing:ydb:session.create with liveSessions/maxSize/creating context', async () => {
+test('traces tracing:ydb:query.session.create with driver identity', async () => {
 	srv = await startServer()
 	pool = new SessionPool(srv.driver, { maxSize: 1 })
 
-	using trace = collectTrace('tracing:ydb:session.create')
+	using trace = collectTrace('tracing:ydb:query.session.create')
 
 	let lease = await pool.acquire()
 	lease[Symbol.dispose]()
 
 	expect(trace.start.length).toBeGreaterThanOrEqual(1)
 	expect(trace.asyncEnd.length).toBeGreaterThanOrEqual(1)
-	expect(trace.start[0]).toMatchObject({
-		liveSessions: 0,
-		maxSize: 1,
-		creating: 0,
+	expect(trace.start[0]).toMatchObject({ driver: { database: '/local' } })
+})
+
+test('publishes ydb:query.session.pool.opened once with config snapshot', async () => {
+	srv = await startServer()
+
+	using opened = collect('ydb:query.session.pool.opened')
+
+	pool = new SessionPool(srv.driver, { maxSize: 7, minSize: 2 })
+
+	expect(opened.payloads).toHaveLength(1)
+	expect(opened.payloads[0]).toMatchObject({
+		driver: { database: '/local' },
+		maxSize: 7,
+		minSize: 2,
 	})
 })
 
-test('traces tracing:ydb:session.acquire with kind=query', async () => {
+test('traces tracing:ydb:query.session.delete with reason=pool_close on pool.close()', async () => {
+	srv = await startServer()
+	let p = new SessionPool(srv.driver, { maxSize: 1 })
+
+	let lease = await p.acquire()
+	let sessionId = lease.id
+	lease[Symbol.dispose]()
+
+	using trace = collectTrace('tracing:ydb:query.session.delete')
+
+	await p.close()
+
+	// pool.close() does not await the per-session DeleteSession RPC — its
+	// promise resolves on a later microtask. Wait until the asyncEnd hook
+	// fires so the test exercises the full tracingChannel lifecycle, not
+	// just the start hook.
+	for (let i = 0; i < 50 && trace.asyncEnd.length === 0; i++) {
+		await new Promise((r) => setImmediate(r))
+	}
+
+	expect(trace.start.length).toBe(1)
+	expect(trace.asyncEnd.length).toBe(1)
+	expect(trace.start[0]).toMatchObject({
+		driver: { database: '/local' },
+		sessionId,
+		reason: 'pool_close',
+	})
+	expect((trace.start[0] as { uptime: number }).uptime).toBeGreaterThanOrEqual(0)
+})
+
+test('publishes ydb:query.session.pool.closed on close', async () => {
+	srv = await startServer()
+	let p = new SessionPool(srv.driver, { maxSize: 1 })
+
+	using closed = collect('ydb:query.session.pool.closed')
+
+	await p.close()
+
+	expect(closed.payloads).toHaveLength(1)
+	expect(closed.payloads[0]).toMatchObject({ driver: { database: '/local' } })
+})
+
+test('traces tracing:ydb:query.session.acquire with driver identity', async () => {
 	srv = await startServer()
 	pool = new SessionPool(srv.driver, { maxSize: 1 })
 
@@ -238,17 +291,15 @@ test('traces tracing:ydb:session.acquire with kind=query', async () => {
 	let warm = await pool.acquire()
 	warm[Symbol.dispose]()
 
-	using trace = collectTrace('tracing:ydb:session.acquire')
+	using trace = collectTrace('tracing:ydb:query.session.acquire')
 
-	// Drive the channel through the public sessionAcquireCh export by
-	// importing it via the same pool surface.
 	let { sessionAcquireCh } = await import('./session-pool.ts')
 	let lease = await sessionAcquireCh.tracePromise(() => pool!.acquire(), {
-		kind: 'query',
+		driver: srv.driver.identity,
 	})
 	lease[Symbol.dispose]()
 
 	expect(trace.start.length).toBeGreaterThanOrEqual(1)
 	expect(trace.asyncEnd.length).toBeGreaterThanOrEqual(1)
-	expect(trace.start[0]).toMatchObject({ kind: 'query' })
+	expect(trace.start[0]).toMatchObject({ driver: { database: '/local' } })
 })

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -4,7 +4,7 @@ import { tracingChannel } from 'node:diagnostics_channel'
 import { linkSignals } from '@ydbjs/abortable'
 import { StatusIds_StatusCode } from '@ydbjs/api/operation'
 import { QueryServiceDefinition } from '@ydbjs/api/query'
-import type { Driver } from '@ydbjs/core'
+import type { Driver, DriverIdentity } from '@ydbjs/core'
 import { CommitError, YDBError } from '@ydbjs/error'
 import {
 	type RetryConfig,
@@ -21,20 +21,29 @@ import { UnsafeString, identifier, unsafe, yql } from './yql.js'
 import { SessionPool, type SessionPoolOptions, sessionAcquireCh } from './session-pool.js'
 
 type TransactionContext = {
+	driver: DriverIdentity
 	isolation: string
 	idempotent: boolean
 }
 
-let transactionCh = tracingChannel<TransactionContext, TransactionContext>(
-	'tracing:ydb:query.transaction'
-)
+type TxControlContext = {
+	driver: DriverIdentity
+	sessionId: string
+	nodeId: bigint
+	txId: string
+}
 
-type TxBeginContext = { sessionId: string; nodeId: bigint; isolation: string }
-type TxControlContext = { sessionId: string; nodeId: bigint; txId: string }
+type TxBeginContext = {
+	driver: DriverIdentity
+	nodeId: bigint
+	sessionId: string
+	isolation: string
+}
 
-let txBeginCh = tracingChannel<TxBeginContext, TxBeginContext>('tracing:ydb:query.begin')
-let txCommitCh = tracingChannel<TxControlContext, TxControlContext>('tracing:ydb:query.commit')
-let txRollbackCh = tracingChannel<TxControlContext, TxControlContext>('tracing:ydb:query.rollback')
+let txBeginCh = tracingChannel<TxBeginContext>('tracing:ydb:query.begin')
+let txCommitCh = tracingChannel<TxControlContext>('tracing:ydb:query.commit')
+let txRollbackCh = tracingChannel<TxControlContext>('tracing:ydb:query.rollback')
+let transactionCh = tracingChannel<TransactionContext>('tracing:ydb:query.transaction')
 
 let dbg = loggers.query
 
@@ -207,7 +216,7 @@ export function query(driver: Driver, options?: QueryOptions): QueryClient {
 
 		let acquireSession = (signal: AbortSignal) =>
 			sessionAcquireCh.tracePromise(() => sessionPool.acquire(signal), {
-				kind: 'transaction',
+				driver: driver.identity,
 			})
 
 		let runAttempt = async (retrySignal: AbortSignal) => {
@@ -244,7 +253,12 @@ export function query(driver: Driver, options?: QueryOptions): QueryClient {
 						},
 						{ signal }
 					),
-				{ sessionId: session.id, nodeId: session.nodeId, isolation: options.isolation! }
+				{
+					driver: driver.identity,
+					nodeId: session.nodeId,
+					sessionId: session.id,
+					isolation: options.isolation!,
+				}
 			)
 			if (beginTransactionResult.status !== StatusIds_StatusCode.SUCCESS) {
 				dbg.log('failed to begin transaction, status: %d', beginTransactionResult.status)
@@ -302,6 +316,7 @@ export function query(driver: Driver, options?: QueryOptions): QueryClient {
 							{ signal }
 						),
 					{
+						driver: driver.identity,
 						sessionId: session.id,
 						nodeId: session.nodeId,
 						txId,
@@ -349,6 +364,7 @@ export function query(driver: Driver, options?: QueryOptions): QueryClient {
 								txId: rollbackTxId,
 							}),
 						{
+							driver: driver.identity,
 							sessionId: session.id,
 							nodeId: session.nodeId,
 							txId: rollbackTxId,
@@ -399,6 +415,7 @@ export function query(driver: Driver, options?: QueryOptions): QueryClient {
 		}
 
 		return transactionCh.tracePromise(() => retry(retryConfig, runAttempt), {
+			driver: driver.identity,
 			isolation: options.isolation!,
 			idempotent,
 		})

--- a/packages/query/src/query.ts
+++ b/packages/query/src/query.ts
@@ -13,7 +13,7 @@ import {
 	TransactionControlSchema,
 } from '@ydbjs/api/query'
 import { type TypedValue, TypedValueSchema } from '@ydbjs/api/value'
-import type { Driver } from '@ydbjs/core'
+import type { Driver, DriverIdentity } from '@ydbjs/core'
 import { loggers } from '@ydbjs/debug'
 import { YDBError } from '@ydbjs/error'
 import {
@@ -31,22 +31,13 @@ import { ctx } from './ctx.js'
 import { linkSignals } from '@ydbjs/abortable'
 import { type SessionPool, sessionAcquireCh } from './session-pool.js'
 
-/**
- * Where this query was issued from. Lets subscribers split latency by
- * shape:
- *   - 'standalone' — single-shot `sql\`...\`` outside any transaction.
- *   - 'tx'         — inside a `sql.begin()` / `sql.transaction()` body.
- *   - 'do'         — reserved for the future `sql.do(...)` runner.
- */
-type QueryStage = 'standalone' | 'tx' | 'do'
-
 type QueryExecuteContext = {
+	driver: DriverIdentity
 	text: string
 	sessionId: string
 	nodeId: bigint
 	idempotent: boolean
 	isolation: string
-	stage: QueryStage
 }
 
 let executeQueryCh = tracingChannel<QueryExecuteContext, QueryExecuteContext>(
@@ -190,8 +181,6 @@ export class Query<T extends any[] = unknown[]>
 
 		await this.#driver.ready(linkedSignal.signal)
 
-		let stage: QueryStage = txSession ? 'tx' : 'standalone'
-
 		let runAttempt = async (retrySignal: AbortSignal) => {
 			// Transaction-owned session stays pinned; out-of-transaction
 			// attempts always get a fresh lease — no cross-attempt reuse.
@@ -199,7 +188,7 @@ export class Query<T extends any[] = unknown[]>
 				? undefined
 				: await sessionAcquireCh.tracePromise(
 						() => this.#sessionPool.acquire(retrySignal),
-						{ kind: 'query' }
+						{ driver: this.#driver.identity }
 					)
 			let session = txSession ?? sessionLease!.session
 			let attemptSessionId = session.id
@@ -260,12 +249,12 @@ export class Query<T extends any[] = unknown[]>
 			}
 
 			let executeCtx: QueryExecuteContext = {
+				driver: this.#driver.identity,
 				text: this.text,
 				sessionId: attemptSessionId,
 				nodeId: attemptNodeId,
 				idempotent: this.#idempotent,
 				isolation: this.#isolation,
-				stage,
 			}
 
 			return await executeQueryCh.tracePromise(async () => {
@@ -359,9 +348,7 @@ export class Query<T extends any[] = unknown[]>
 		// `transactionId` after a server-side abort cannot recover the
 		// transaction. Skip the retry wrapper entirely; the tx retries the
 		// whole body if it needs to.
-		this.#promise = (
-			txSession ? runAttempt(linkedSignal.signal) : retry(retryConfig, runAttempt)
-		)
+		this.#promise = (txSession ? runAttempt(linkedSignal.signal) : retry(retryConfig, runAttempt))
 			.then((results) => {
 				if (this.#stats) {
 					this.emit('stats', this.#stats)

--- a/packages/query/src/session-pool.test.ts
+++ b/packages/query/src/session-pool.test.ts
@@ -303,9 +303,11 @@ test('claim() releases on dispose so the next caller succeeds', async () => {
 		// scope holds the slot
 	}
 
-	// previous claim disposed — a fresh claim must succeed
-	let again = session.claim()
-	again[Symbol.dispose]()
+	// previous claim disposed — a fresh claim must succeed (would throw SessionBusyError otherwise)
+	expect(() => {
+		let again = session.claim()
+		again[Symbol.dispose]()
+	}).not.toThrow()
 	session.close('pool_close')
 })
 
@@ -315,11 +317,13 @@ test('claim() dispose is idempotent', async () => {
 
 	let held = session.claim()
 	held[Symbol.dispose]()
-	held[Symbol.dispose]() // second dispose is a no-op
+	expect(() => held[Symbol.dispose]()).not.toThrow() // second dispose is a no-op
 
 	// the slot must still be free
-	let again = session.claim()
-	again[Symbol.dispose]()
+	expect(() => {
+		let again = session.claim()
+		again[Symbol.dispose]()
+	}).not.toThrow()
 	session.close('pool_close')
 })
 

--- a/packages/query/src/session-pool.test.ts
+++ b/packages/query/src/session-pool.test.ts
@@ -275,7 +275,7 @@ test('Session.open aborts the attach stream when the caller signal fires mid-wai
 	// SUCCESS message was already received before we aborted — in that
 	// race we simply verify that either resolution cleans up.
 	await opening.then(
-		(session) => session.close(),
+		(session) => session.close('pool_close'),
 		() => {}
 	)
 	expect(srv.attachCalls).toHaveLength(1)
@@ -290,7 +290,7 @@ test('claim() throws SessionBusyError on a second concurrent caller', async () =
 		expect(() => session.claim()).toThrow(SessionBusyError)
 	} finally {
 		first[Symbol.dispose]()
-		session.close()
+		session.close('pool_close')
 	}
 })
 
@@ -306,7 +306,7 @@ test('claim() releases on dispose so the next caller succeeds', async () => {
 	// previous claim disposed — a fresh claim must succeed
 	let again = session.claim()
 	again[Symbol.dispose]()
-	session.close()
+	session.close('pool_close')
 })
 
 test('claim() dispose is idempotent', async () => {
@@ -320,5 +320,96 @@ test('claim() dispose is idempotent', async () => {
 	// the slot must still be free
 	let again = session.claim()
 	again[Symbol.dispose]()
-	session.close()
+	session.close('pool_close')
+})
+
+// ── warm-up to minSize ─────────────────────────────────────────────────────
+
+test('warms the pool up to minSize on construction', async () => {
+	srv = await startQueryServer()
+	pool = new SessionPool(srv.driver, { maxSize: 5, minSize: 3 })
+
+	await until(() => pool!.stats.total === 3, 1000)
+
+	expect(pool.stats.total).toBe(3)
+	expect(pool.stats.idle).toBe(3)
+	expect(pool.stats.busy).toBe(0)
+	expect(srv.createCount).toBe(3)
+})
+
+test('does not warm any sessions when minSize defaults to 0', async () => {
+	srv = await startQueryServer()
+	pool = new SessionPool(srv.driver, { maxSize: 5 })
+
+	// Give the event loop a chance — if warm-up were misfiring, creates
+	// would have started by now.
+	await new Promise((r) => setTimeout(r, 50))
+
+	expect(pool.stats.total).toBe(0)
+	expect(pool.stats.creating).toBe(0)
+	expect(srv.createCount).toBe(0)
+})
+
+test('throws RangeError when minSize exceeds maxSize', async () => {
+	srv = await startQueryServer()
+
+	expect(() => new SessionPool(srv!.driver, { maxSize: 2, minSize: 5 })).toThrow(RangeError)
+})
+
+test('refills to minSize after a session is evicted by the server', async () => {
+	srv = await startQueryServer()
+	pool = new SessionPool(srv.driver, { maxSize: 5, minSize: 2 })
+
+	await until(() => pool!.stats.total === 2, 1000)
+	let createsBeforeEviction = srv.createCount
+	let killed = srv.attachCalls[0]
+
+	// Server tears down the attach stream → Session.#runMonitor flips it
+	// broken → pool eviction listener removes from #all → refill kicks in.
+	srv.breakSession(killed)
+
+	await until(() => srv!.createCount > createsBeforeEviction, 2000)
+	await until(() => pool!.stats.total === 2, 2000)
+
+	expect(pool.stats.total).toBe(2)
+	expect(srv.createCount).toBe(createsBeforeEviction + 1)
+})
+
+test('hands a warming session to a waiter when warm-up holds all capacity', async () => {
+	srv = await startQueryServer()
+	let release = srv.holdCreateSession()
+
+	pool = new SessionPool(srv.driver, { maxSize: 2, minSize: 2 })
+
+	// Both create slots are taken by held warm-ups; acquire() must queue
+	// rather than spawn a third create.
+	let acquired = pool.acquire()
+	await until(() => pool!.stats.waiting === 1, 500)
+
+	release()
+
+	let lease = await acquired
+	expect(lease).toBeInstanceOf(SessionLease)
+	expect(pool.stats.waiting).toBe(0)
+	// Two creates total — the waiter received a warm-up session via
+	// #growAndPark's handoff path, no extra grow was issued.
+	expect(srv.createCount).toBe(2)
+})
+
+test('pool.close() during warm-up settles without hanging', async () => {
+	srv = await startQueryServer()
+	srv.holdCreateSession() // hold indefinitely; never released
+
+	pool = new SessionPool(srv.driver, { maxSize: 5, minSize: 5 })
+
+	// All five warm-up creates are blocked on the server. close() must
+	// abort them through the linked close signal and resolve quickly.
+	await Promise.race([
+		pool.close(),
+		new Promise((_, reject) =>
+			setTimeout(() => reject(new Error('pool.close() hung during warm-up')), 2000)
+		),
+	])
+
+	expect(pool.closed).toBe(true)
 })

--- a/packages/query/src/session-pool.ts
+++ b/packages/query/src/session-pool.ts
@@ -5,10 +5,10 @@
  *   - Single source of truth: #all (Set). Idle is a derived LIFO stack.
  *   - Idle is LIFO for cache warmth (server-side plan cache).
  *   - Busy has no explicit marker — it's "in #all but not in #available".
- *   - No background sweeper. Dead sessions are evicted lazily on acquire.
+ *   - No background sweeper. Dead sessions are dropped lazily on acquire.
  *   - Waiters have a hard cap (maxSize * 8) — caller gets fast failure
  *     under thundering-herd rather than unbounded queue growth.
- *   - An evicted session opens a slot; we proactively refill for waiters.
+ *   - A dropped session opens a slot; we proactively refill for waiters.
  *   - close() is atomic w.r.t. in-flight creates: we own their abort
  *     controllers, cancel them on close, and allSettle before returning.
  *
@@ -24,25 +24,20 @@
 import { channel as dc, tracingChannel } from 'node:diagnostics_channel'
 
 import { linkSignals } from '@ydbjs/abortable'
-import type { Driver } from '@ydbjs/core'
+import type { Driver, DriverIdentity } from '@ydbjs/core'
 import { loggers } from '@ydbjs/debug'
-import { Session } from './session.js'
+import { Session, type SessionCloseReason } from './session.js'
 
-/** Reasons a session left the pool. See `ydb:session.closed`. */
-type SessionClosedReason = 'evicted' | 'pool_close'
+type SessionAcquireCtx = { driver: DriverIdentity }
+type SessionCreateCtx = { driver: DriverIdentity }
 
-/** Call-site classifier for `tracing:ydb:session.acquire`. */
-type SessionAcquireKind = 'query' | 'transaction'
+let sessionCreateCh = tracingChannel<SessionCreateCtx, SessionCreateCtx>(
+	'tracing:ydb:query.session.create'
+)
 
-export let sessionAcquireCh = tracingChannel<
-	{ kind: SessionAcquireKind },
-	{ kind: SessionAcquireKind }
->('tracing:ydb:session.acquire')
-
-let sessionCreateCh = tracingChannel<
-	{ liveSessions: number; maxSize: number; creating: number },
-	{ liveSessions: number; maxSize: number; creating: number }
->('tracing:ydb:session.create')
+export let sessionAcquireCh = tracingChannel<SessionAcquireCtx, SessionAcquireCtx>(
+	'tracing:ydb:query.session.acquire'
+)
 
 let dbg = loggers.query.extend('pool2')
 
@@ -63,12 +58,19 @@ export class SessionPoolFullError extends Error {
 export type SessionPoolOptions = {
 	/** Hard cap on simultaneously-live sessions (idle + busy + creating). */
 	maxSize?: number
+	/**
+	 * Soft floor reported as `ydb.query.session.min` for dashboard parity
+	 * with other YDB SDKs. The JS pool does not eagerly warm sessions up to
+	 * this number. Default 0.
+	 */
+	minSize?: number
 	/** Multiplier over maxSize for the wait queue. Default 8. */
 	waitQueueFactor?: number
 }
 
 let DEFAULTS = {
 	maxSize: 50,
+	minSize: 0,
 	waitQueueFactor: 8,
 } satisfies Required<SessionPoolOptions>
 
@@ -131,6 +133,7 @@ export class SessionLease implements Disposable {
 export class SessionPool implements AsyncDisposable {
 	#driver: Driver
 	#maxSize: number
+	#minSize: number
 	#maxWaiters: number
 
 	#all = new Set<Session>()
@@ -139,16 +142,31 @@ export class SessionPool implements AsyncDisposable {
 	#creates = new Set<Promise<unknown>>()
 	#close = new AbortController()
 
-	// Per-session metadata used by `ydb:session.closed`. Held weakly so a
-	// session removed from #all without going through #publishClosed (defence
-	// in depth) doesn't keep its createdAt entry alive.
-	#createdAt = new WeakMap<Session, number>()
 	#evictionHandlers = new WeakMap<Session, () => void>()
 
 	constructor(driver: Driver, options: SessionPoolOptions = {}) {
 		this.#driver = driver
 		this.#maxSize = options.maxSize ?? DEFAULTS.maxSize
+		this.#minSize = options.minSize ?? DEFAULTS.minSize
 		this.#maxWaiters = this.#maxSize * (options.waitQueueFactor ?? DEFAULTS.waitQueueFactor)
+
+		if (this.#minSize > this.#maxSize) {
+			throw new RangeError(
+				`minSize (${this.#minSize}) cannot exceed maxSize (${this.#maxSize})`
+			)
+		}
+
+		// Single config snapshot for this pool. Metrics subscribers anchor
+		// their per-pool ObservableGauges here; per-session events deliberately
+		// do not repeat config.
+		dc('ydb:query.session.pool.opened').publish({
+			driver: this.#driver.identity,
+			maxSize: this.#maxSize,
+			minSize: this.#minSize,
+			maxWaiters: this.#maxWaiters,
+		})
+
+		this.#refillToMinSize()
 	}
 
 	get closed(): boolean {
@@ -163,20 +181,53 @@ export class SessionPool implements AsyncDisposable {
 			creating: this.#creates.size,
 			waiting: this.#waiters.length,
 			maxSize: this.#maxSize,
+			minSize: this.#minSize,
 		}
 	}
 
 	async acquire(signal?: AbortSignal): Promise<SessionLease> {
-		let session = await this.#acquireSession(signal)
-		return new SessionLease(this, session)
+		try {
+			let session = await this.#acquireSession(signal)
+
+			dc('ydb:query.session.acquired').publish({
+				driver: this.#driver.identity,
+				nodeId: session.nodeId,
+				sessionId: session.id,
+			})
+
+			return new SessionLease(this, session)
+		} catch (error) {
+			// Caller cancellation isn't a pool-side failure — the request was
+			// withdrawn before we could serve it. Skip the failed event so the
+			// `acquire.failures` counter stays a pool-health signal rather than
+			// a count of upstream-cancelled requests. Pool-internal aborts
+			// (pool.close, full queue, timeout we picked) still publish.
+			if (!signal?.aborted) {
+				dc('ydb:query.session.acquire.failed').publish({
+					driver: this.#driver.identity,
+					error,
+				})
+			}
+
+			throw error
+		}
 	}
 
 	release(session: Session): void {
+		// Pairs with `ydb:query.session.acquired`: exactly one release per
+		// lease, whatever path the session takes afterwards.
+		dc('ydb:query.session.released').publish({
+			driver: this.#driver.identity,
+			nodeId: session.nodeId,
+			sessionId: session.id,
+		})
+
 		// Session died while someone was using it. The eviction listener
-		// already popped it from #all and published `closed{evicted}`; just
-		// fire DeleteSession in the background.
+		// already popped it from #all and published `closed{stream_*}`. The
+		// server has either killed the session itself (stream_closed) or the
+		// stream errored — either way the server-side TTL reaps it, so no
+		// extra DeleteSession RPC is required from us.
 		if (!session.alive || !this.#all.has(session)) {
-			session.close()
 			return
 		}
 
@@ -185,11 +236,13 @@ export class SessionPool implements AsyncDisposable {
 			// sessions get a `pool_close` event so subscribers see one event
 			// per session lifecycle regardless of timing. Detach the eviction
 			// listener first — session.close() aborts the signal, which would
-			// otherwise re-fire `closed{evicted}` for the same session.
+			// otherwise re-fire `closed{stream_*}` for the same session.
 			this.#detachEviction(session)
 			this.#publishClosed(session, 'pool_close')
 			this.#all.delete(session)
-			session.close()
+
+			session.close('pool_close')
+
 			return
 		}
 
@@ -199,6 +252,11 @@ export class SessionPool implements AsyncDisposable {
 		let waiter = this.#waiters.shift()
 		if (waiter) {
 			waiter.detach()
+
+			dc('ydb:query.session.waiter.dequeued').publish({
+				driver: this.#driver.identity,
+			})
+
 			waiter.resolve(session)
 			return
 		}
@@ -214,6 +272,11 @@ export class SessionPool implements AsyncDisposable {
 		let waiters = this.#waiters.splice(0)
 		for (let w of waiters) {
 			w.detach()
+
+			dc('ydb:query.session.waiter.dequeued').publish({
+				driver: this.#driver.identity,
+			})
+
 			w.reject(new SessionPoolClosedError())
 		}
 
@@ -227,12 +290,14 @@ export class SessionPool implements AsyncDisposable {
 		this.#available.length = 0
 		// close() is sync + fire-and-forget — no need to await each RPC.
 		// Detach the eviction listener BEFORE close() so we don't double-fire
-		// `closed{evicted}` for sessions that the pool itself is tearing down.
+		// `closed{stream_*}` for sessions that the pool itself is tearing down.
 		for (let s of sessions) {
 			this.#detachEviction(s)
 			this.#publishClosed(s, 'pool_close')
-			s.close()
+			s.close('pool_close')
 		}
+		// Pairs with `pool.opened`; tells subscribers to drop per-pool state.
+		dc('ydb:query.session.pool.closed').publish({ driver: this.#driver.identity })
 		dbg.log('pool closed (%d sessions)', sessions.length)
 	}
 
@@ -268,11 +333,7 @@ export class SessionPool implements AsyncDisposable {
 		// many concurrent creates fan out.
 		using linked = linkSignals(signal, this.#close.signal)
 
-		let createCtx = {
-			liveSessions: this.#all.size,
-			maxSize: this.#maxSize,
-			creating: this.#creates.size,
-		}
+		let createCtx: SessionCreateCtx = { driver: this.#driver.identity }
 		let promise = sessionCreateCh.tracePromise(
 			() => Session.open(this.#driver, linked.signal),
 			createCtx
@@ -284,14 +345,14 @@ export class SessionPool implements AsyncDisposable {
 
 			// The pool closed while we were creating. Dispose it, don't leak.
 			if (this.closed) {
-				session.close()
+				session.close('pool_close')
 				throw new SessionPoolClosedError()
 			}
 
 			this.#all.add(session)
-			this.#createdAt.set(session, Date.now())
 			this.#bindEviction(session)
-			dc('ydb:session.created').publish({
+			dc('ydb:query.session.created').publish({
+				driver: this.#driver.identity,
 				sessionId: session.id,
 				nodeId: session.nodeId,
 			})
@@ -307,9 +368,18 @@ export class SessionPool implements AsyncDisposable {
 			this.#all.delete(session)
 			let idx = this.#available.indexOf(session)
 			if (idx !== -1) this.#available.splice(idx, 1)
-			dbg.log('evicted session %s', session.id)
-			this.#publishClosed(session, 'evicted')
+			// Session.#markBroken set closeReason before aborting the signal;
+			// fall back to stream_closed only as a defensive default if a
+			// future code path aborts the signal without going through
+			// markBroken (today nothing does).
+			let reason = session.closeReason ?? 'stream_closed'
+			dbg.log('session %s left the pool (%s)', session.id, reason)
+			this.#publishClosed(session, reason)
+			// Order matters: waiters first (the freed capacity belongs to
+			// whoever was already queued), then top up to minSize if the
+			// slot is still empty.
 			this.#pumpWaitersAfterEviction()
+			this.#refillToMinSize()
 		}
 		this.#evictionHandlers.set(session, handler)
 		session.signal.addEventListener('abort', handler, { once: true })
@@ -319,7 +389,7 @@ export class SessionPool implements AsyncDisposable {
 	 * Detach the eviction listener bound by #bindEviction. Used by close()
 	 * to avoid a double `closed` event when the pool itself tears down a
 	 * session (which abort() would otherwise reflect back through the
-	 * eviction listener).
+	 * eviction listener with reason=stream_*).
 	 */
 	#detachEviction(session: Session): void {
 		let handler = this.#evictionHandlers.get(session)
@@ -328,15 +398,13 @@ export class SessionPool implements AsyncDisposable {
 		session.signal.removeEventListener('abort', handler)
 	}
 
-	#publishClosed(session: Session, reason: SessionClosedReason): void {
-		let createdAt = this.#createdAt.get(session)
-		let uptime = createdAt ? Date.now() - createdAt : 0
-		this.#createdAt.delete(session)
-		dc('ydb:session.closed').publish({
+	#publishClosed(session: Session, reason: SessionCloseReason): void {
+		dc('ydb:query.session.closed').publish({
+			driver: this.#driver.identity,
 			sessionId: session.id,
 			nodeId: session.nodeId,
 			reason,
-			uptime,
+			uptime: Date.now() - session.createdAt,
 		})
 	}
 
@@ -353,10 +421,59 @@ export class SessionPool implements AsyncDisposable {
 
 		let waiter = this.#waiters.shift()!
 		waiter.detach()
+		dc('ydb:query.session.waiter.dequeued').publish({ driver: this.#driver.identity })
 		this.#grow().then(
 			(s) => waiter.resolve(s),
 			(e) => waiter.reject(e instanceof Error ? e : new Error(String(e)))
 		)
+	}
+
+	/**
+	 * Brings (live + in-flight creates) up to minSize. Called from the
+	 * constructor and after every eviction. Idempotent: computes the deficit
+	 * each time, so over-calling is harmless. Each grow runs concurrently
+	 * via a detached `#growAndPark`; the outer call returns immediately.
+	 */
+	#refillToMinSize(): void {
+		if (this.closed) return
+		let deficit = this.#minSize - (this.#all.size + this.#creates.size)
+		for (let i = 0; i < deficit; i++) {
+			void this.#growAndPark()
+		}
+	}
+
+	/**
+	 * Grow once, then park the result: hand to a queued waiter if any,
+	 * otherwise drop into `#available` for the next acquire().
+	 *
+	 * Errors are swallowed by design — warm-up is best-effort. A failed
+	 * background create does not crash the app; the next acquire() or the
+	 * next eviction-triggered refill will try again. `SessionPoolClosedError`
+	 * is expected on shutdown (the linked close signal aborts pending
+	 * creates).
+	 */
+	async #growAndPark(): Promise<void> {
+		let session: Session
+		try {
+			session = await this.#grow()
+		} catch (err) {
+			dbg.log('warm-up grow failed: %O', err)
+			return
+		}
+
+		if (this.closed) return // #grow already disposed it under this.closed
+
+		let waiter = this.#waiters.shift()
+		if (waiter) {
+			waiter.detach()
+			dc('ydb:query.session.waiter.dequeued').publish({
+				driver: this.#driver.identity,
+			})
+			waiter.resolve(session)
+			return
+		}
+
+		this.#available.push(session)
 	}
 
 	#enqueue(signal?: AbortSignal): Promise<Session> {
@@ -365,10 +482,14 @@ export class SessionPool implements AsyncDisposable {
 		}
 
 		let { promise, resolve, reject } = Promise.withResolvers<Session>()
+		let driver = this.#driver.identity
 
 		let onAbort = () => {
 			let idx = this.#waiters.findIndex((w) => w.resolve === resolve)
-			if (idx !== -1) this.#waiters.splice(idx, 1)
+			if (idx !== -1) {
+				this.#waiters.splice(idx, 1)
+				dc('ydb:query.session.waiter.dequeued').publish({ driver })
+			}
 			reject(signal!.reason ?? new Error('aborted'))
 		}
 
@@ -377,6 +498,7 @@ export class SessionPool implements AsyncDisposable {
 		if (signal) signal.addEventListener('abort', onAbort, { once: true })
 
 		this.#waiters.push({ resolve, reject, detach })
+		dc('ydb:query.session.waiter.enqueued').publish({ driver })
 		return promise
 	}
 }

--- a/packages/query/src/session.ts
+++ b/packages/query/src/session.ts
@@ -10,19 +10,57 @@
  * before the error propagates to the caller. No leaks.
  */
 
+import { tracingChannel } from 'node:diagnostics_channel'
+
 import { StatusIds_StatusCode } from '@ydbjs/api/operation'
 import { QueryServiceDefinition, type SessionState } from '@ydbjs/api/query'
-import type { Driver } from '@ydbjs/core'
+import type { Driver, DriverIdentity } from '@ydbjs/core'
 import { loggers } from '@ydbjs/debug'
 import { YDBError } from '@ydbjs/error'
+
+/**
+ * Why a session left the server. Carried on
+ * `tracing:ydb:query.session.delete` and `ydb:query.session.closed`.
+ *
+ * Only three real causes exist; `stream_closed` and `stream_error` split the
+ * post-attach death by whether the server closed cleanly or the stream
+ * errored, which subscribers care about for alerting.
+ *
+ *   - 'pool_close'    — pool is tearing down; we tell the server.
+ *   - 'attach_failed' — initial AttachStream rejected; session never lived.
+ *   - 'stream_closed' — attach stream ended cleanly (server-side timeout / drain).
+ *   - 'stream_error' — attach stream errored mid-flight.
+ *
+ * No `user_close` — users do not manage sessions. No `evicted` /
+ * `release_dead` — those were pool-side observations of stream death, the
+ * underlying `stream_*` reason now propagates through.
+ */
+export type SessionCloseReason =
+	| 'pool_close'
+	| 'attach_failed'
+	| 'stream_closed'
+	| 'stream_error'
+
+type SessionDeleteCtx = {
+	driver: DriverIdentity
+	sessionId: string
+	nodeId: bigint
+	reason: SessionCloseReason
+	/** ms */
+	uptime: number
+}
+
+export let sessionDeleteCh = tracingChannel<SessionDeleteCtx, SessionDeleteCtx>(
+	'tracing:ydb:query.session.delete'
+)
 
 let dbg = loggers.query.extend('session')
 
 export class SessionAbortedError extends Error {
 	readonly sessionId: string
-	readonly reason: 'stream-closed' | 'stream-error' | 'deleted' | 'pool-closed'
+	readonly reason: SessionCloseReason
 
-	constructor(sessionId: string, reason: SessionAbortedError['reason']) {
+	constructor(sessionId: string, reason: SessionCloseReason) {
 		super(`session ${sessionId} aborted: ${reason}`)
 		this.name = 'SessionAbortedError'
 		this.sessionId = sessionId
@@ -51,12 +89,14 @@ export class SessionBusyError extends Error {
 export class Session {
 	readonly id: string
 	readonly nodeId: bigint
+	readonly createdAt: number = Date.now()
 	lastUsedAt: number = Date.now()
 
 	#driver: Driver
 	#life = new AbortController()
 	#attach = new AbortController()
 	#closing = false
+	#closeReason: SessionCloseReason | undefined
 	// In-flight RPCs on this session. YDB sessions are single-threaded, so
 	// this counter must never exceed 1. `claim()` throws SessionBusyError on
 	// the second concurrent caller.
@@ -75,6 +115,17 @@ export class Session {
 
 	get alive(): boolean {
 		return !this.#life.signal.aborted
+	}
+
+	/**
+	 * The reason this session was closed, set by `#markBroken` (stream monitor
+	 * or pool tear-down). Stays `undefined` while the session is alive.
+	 * Pool subscribers read it from the eviction listener so the published
+	 * `session.closed` event reflects the underlying cause, not the pool's
+	 * view of it.
+	 */
+	get closeReason(): SessionCloseReason | undefined {
+		return this.#closeReason
 	}
 
 	/**
@@ -118,7 +169,7 @@ export class Session {
 		} catch (err) {
 			dbg.log('attach failed for %s, firing DeleteSession in background', session.id)
 			session.#attach.abort() // defensive: ensure stream is torn down
-			session.#deleteOnServer() // fire-and-forget
+			session.#deleteOnServer('attach_failed') // fire-and-forget
 			throw err
 		}
 	}
@@ -166,48 +217,57 @@ export class Session {
 	 * underlying gRPC call — no dangling stream.
 	 */
 	async #runMonitor(stream: AsyncIterable<SessionState>): Promise<void> {
-		let reason: SessionAbortedError['reason'] = 'stream-closed'
+		let reason: SessionCloseReason = 'stream_closed'
 		try {
 			for await (let msg of stream) {
 				if (msg.status !== StatusIds_StatusCode.SUCCESS) {
-					reason = 'stream-error'
+					reason = 'stream_error'
 					break
 				}
 			}
 		} catch {
-			reason = 'stream-error'
+			reason = 'stream_error'
 		} finally {
 			this.#markBroken(reason)
 		}
 	}
 
-	#markBroken(reason: SessionAbortedError['reason']): void {
+	#markBroken(reason: SessionCloseReason): void {
 		if (this.#life.signal.aborted) return
+		this.#closeReason = reason
 		this.#life.abort(new SessionAbortedError(this.id, reason))
 		this.#attach.abort()
 		dbg.log('session %s marked broken (%s)', this.id, reason)
 	}
 
-	/** Fire-and-forget DeleteSession. Server TTL is the ultimate backstop. */
-	#deleteOnServer(): void {
+	// Fire-and-forget RPC, traced for subscribers. Server TTL cleans up if
+	// the call is lost.
+	#deleteOnServer(reason: SessionCloseReason): void {
 		let client = this.#driver.createClient(QueryServiceDefinition, this.nodeId)
-		client.deleteSession({ sessionId: this.id }).catch((err) => {
-			dbg.log('deleteSession for %s failed: %O', this.id, err)
-		})
+		let ctx: SessionDeleteCtx = {
+			driver: this.#driver.identity,
+			sessionId: this.id,
+			nodeId: this.nodeId,
+			reason,
+			uptime: Date.now() - this.createdAt,
+		}
+		sessionDeleteCh
+			.tracePromise(() => client.deleteSession({ sessionId: this.id }), ctx)
+			.catch((err) => {
+				dbg.log('deleteSession for %s failed: %O', this.id, err)
+			})
 	}
 
 	/**
 	 * Synchronous shutdown: flip state, fire DeleteSession in the
-	 * background. Callers never wait on the RPC.
+	 * background. Callers never wait on the RPC. Reason is required —
+	 * the pool always knows why it's tearing a session down, and there's
+	 * no sensible default in the absence of `user_close`.
 	 */
-	close(): void {
+	close(reason: SessionCloseReason): void {
 		if (this.#closing) return
 		this.#closing = true
-		if (this.alive) this.#deleteOnServer()
-		this.#markBroken('deleted')
-	}
-
-	[Symbol.dispose](): void {
-		this.close()
+		if (this.alive) this.#deleteOnServer(reason)
+		this.#markBroken(reason)
 	}
 }

--- a/packages/retry/README.md
+++ b/packages/retry/README.md
@@ -198,15 +198,31 @@ Every code path that uses `retry()` — driver discovery, query execution, trans
 
 ### Channels
 
-| Channel                     | Type    | Payload                                                                             |
-| --------------------------- | ------- | ----------------------------------------------------------------------------------- |
-| `tracing:ydb:retry.run`     | tracing | `{ idempotent: boolean }` — whole retry loop                                        |
-| `tracing:ydb:retry.attempt` | tracing | `{ attempt: number, idempotent: boolean }` — a single attempt (including the first) |
-| `ydb:retry.exhausted`       | publish | `{ attempts: number, totalDuration: number, lastError: unknown }` — see below       |
+| Channel                       | Type    | Payload                                                                                                                  |
+| ----------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `tracing:ydb:retry.run`       | tracing | `{ idempotent: boolean, outcome?: RetryOutcome }` — whole retry loop. `outcome` is set on the ctx before resolve / throw. |
+| `tracing:ydb:retry.attempt`   | tracing | `{ attempt: number, idempotent: boolean }` — a single attempt (including the first)                                      |
+| `ydb:retry.attempt.completed` | publish | `{ attempt: number, idempotent: boolean, outcome: RetryOutcome }` — emitted once per attempt with its outcome            |
+| `ydb:retry.exhausted`         | publish | `{ attempts: number, totalDuration: number, lastError: unknown }` — ms. See below.                                       |
+
+```ts
+type RetryOutcome = 'success' | 'retried' | 'non_retryable' | 'exhausted'
+```
 
 `retry.attempt` is published once per attempt starting from `attempt: 1`. Because `tracingChannel.tracePromise` wraps every attempt, `tracing:ydb:retry.attempt.error` fires for **every** failed attempt — both the ones that will be retried and the final one that exits the loop. The final attempt's failure additionally surfaces on `tracing:ydb:retry.run.error`.
 
+`ydb:retry.attempt.completed` is the metrics-friendly companion: it fires exactly once per attempt regardless of success or failure, with an `outcome` tag suited for a `Counter`. Use it instead of subscribing to both `attempt.asyncEnd` and `attempt.error` when all you want is a count.
+
 `ydb:retry.exhausted` fires when the retry policy itself gives up — either the budget ran out or the predicate returned `false`. It does **not** fire when the loop exits via `AbortError` or `TimeoutError`: those are rethrown immediately as caller-driven cancellations. Subscribers tracking "retry budget exhausted" should not expect this event for cancellations or timeouts; use `tracing:ydb:retry.run.error` for the broader "retry loop failed" signal.
+
+For end-to-end retry duration with outcome dimensions, read `outcome` off the `retry.run` ctx on `asyncEnd` / `error`:
+
+```ts
+tracingChannel('tracing:ydb:retry.run').subscribe({
+  asyncEnd(ctx) { histogram.record(elapsed, { outcome: ctx.outcome }) },
+  error(ctx)    { histogram.record(elapsed, { outcome: ctx.outcome }) },
+})
+```
 
 ### Subscribing
 

--- a/packages/retry/README.md
+++ b/packages/retry/README.md
@@ -198,12 +198,12 @@ Every code path that uses `retry()` — driver discovery, query execution, trans
 
 ### Channels
 
-| Channel                       | Type    | Payload                                                                                                                  |
-| ----------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `tracing:ydb:retry.run`       | tracing | `{ idempotent: boolean, outcome?: RetryOutcome }` — whole retry loop. `outcome` is set on the ctx before resolve / throw. |
-| `tracing:ydb:retry.attempt`   | tracing | `{ attempt: number, idempotent: boolean }` — a single attempt (including the first)                                      |
-| `ydb:retry.attempt.completed` | publish | `{ attempt: number, idempotent: boolean, outcome: RetryOutcome }` — emitted once per attempt with its outcome            |
-| `ydb:retry.exhausted`         | publish | `{ attempts: number, totalDuration: number, lastError: unknown }` — ms. See below.                                       |
+| Channel                       | Type    | Payload                                                                                                                                                                                         |
+| ----------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tracing:ydb:retry.run`       | tracing | `{ idempotent: boolean, outcome?: RetryOutcome }` — whole retry loop. `outcome` is set on the ctx before resolve / throw.                                                                       |
+| `tracing:ydb:retry.attempt`   | tracing | `{ attempt: number, idempotent: boolean, backoffMs: number }` — a single attempt (including the first); `backoffMs` is the wait actually observed before this attempt (`0` for `attempt === 1`) |
+| `ydb:retry.attempt.completed` | publish | `{ attempt: number, idempotent: boolean, outcome: RetryOutcome }` — emitted once per attempt with its outcome                                                                                   |
+| `ydb:retry.exhausted`         | publish | `{ attempts: number, totalDuration: number, lastError: unknown }` — ms. See below.                                                                                                              |
 
 ```ts
 type RetryOutcome = 'success' | 'retried' | 'non_retryable' | 'exhausted'
@@ -219,8 +219,12 @@ For end-to-end retry duration with outcome dimensions, read `outcome` off the `r
 
 ```ts
 tracingChannel('tracing:ydb:retry.run').subscribe({
-  asyncEnd(ctx) { histogram.record(elapsed, { outcome: ctx.outcome }) },
-  error(ctx)    { histogram.record(elapsed, { outcome: ctx.outcome }) },
+  asyncEnd(ctx) {
+    histogram.record(elapsed, { outcome: ctx.outcome })
+  },
+  error(ctx) {
+    histogram.record(elapsed, { outcome: ctx.outcome })
+  },
 })
 ```
 

--- a/packages/retry/src/diagnostics.test.ts
+++ b/packages/retry/src/diagnostics.test.ts
@@ -93,6 +93,29 @@ test('publishes tracing:ydb:retry.attempt once per attempt with monotonic number
 	expect(trace.error).toHaveLength(2)
 })
 
+test('tracing:ydb:retry.attempt ctx carries backoffMs (0 for first, >0 after a delayed retry)', async () => {
+	using trace = collectTrace('tracing:ydb:retry.attempt')
+
+	let calls = 0
+	await retry(
+		// strategy: 25ms — first failure waits ~25ms before the second attempt
+		{ retry: true, budget: 5, strategy: 25, idempotent: false },
+		async () => {
+			calls++
+			if (calls < 2) throw new Error('again')
+			return 'ok'
+		}
+	)
+
+	expect(trace.start).toHaveLength(2)
+	let [first, second] = trace.start as Array<{ attempt: number; backoffMs: number }>
+	expect(first.attempt).toBe(1)
+	expect(first.backoffMs).toBe(0)
+	expect(second.attempt).toBe(2)
+	expect(second.backoffMs).toBeGreaterThan(0)
+	expect(second.backoffMs).toBeLessThanOrEqual(25)
+})
+
 // ── retry.exhausted ──────────────────────────────────────────────────────────
 
 test('publishes ydb:retry.exhausted with attempts, duration and lastError when budget runs out', async () => {
@@ -147,11 +170,7 @@ test('emits attempt.completed sequence: retried, retried, success', async () => 
 	})
 
 	expect(completed.payloads).toHaveLength(3)
-	expect(completed.payloads.map((p: any) => p.outcome)).toEqual([
-		'retried',
-		'retried',
-		'success',
-	])
+	expect(completed.payloads.map((p: any) => p.outcome)).toEqual(['retried', 'retried', 'success'])
 })
 
 test('emits attempt.completed with outcome=exhausted when budget runs out', async () => {

--- a/packages/retry/src/diagnostics.test.ts
+++ b/packages/retry/src/diagnostics.test.ts
@@ -120,3 +120,87 @@ test('skips ydb:retry.exhausted when the call succeeds', async () => {
 
 	expect(exhausted.payloads).toHaveLength(0)
 })
+
+// ── retry.attempt.completed ──────────────────────────────────────────────────
+
+test('emits attempt.completed with outcome=success on first-try success', async () => {
+	using completed = collect('ydb:retry.attempt.completed')
+
+	await retry({ idempotent: true }, async () => 'ok')
+
+	expect(completed.payloads).toHaveLength(1)
+	expect(completed.payloads[0]).toMatchObject({
+		attempt: 1,
+		idempotent: true,
+		outcome: 'success',
+	})
+})
+
+test('emits attempt.completed sequence: retried, retried, success', async () => {
+	using completed = collect('ydb:retry.attempt.completed')
+
+	let calls = 0
+	await retry({ retry: true, budget: 5, strategy: 0, idempotent: false }, async () => {
+		calls++
+		if (calls < 3) throw new Error('again')
+		return 'ok'
+	})
+
+	expect(completed.payloads).toHaveLength(3)
+	expect(completed.payloads.map((p: any) => p.outcome)).toEqual([
+		'retried',
+		'retried',
+		'success',
+	])
+})
+
+test('emits attempt.completed with outcome=exhausted when budget runs out', async () => {
+	using completed = collect('ydb:retry.attempt.completed')
+
+	await expect(
+		retry({ retry: true, budget: 2, strategy: 0, idempotent: true }, () => {
+			throw new Error('fail')
+		})
+	).rejects.toThrow('fail')
+
+	expect(completed.payloads).toHaveLength(2)
+	expect(completed.payloads.map((p: any) => p.outcome)).toEqual(['retried', 'exhausted'])
+})
+
+test('emits attempt.completed with outcome=non_retryable on first non-retryable error', async () => {
+	using completed = collect('ydb:retry.attempt.completed')
+
+	await expect(
+		retry({ retry: false, budget: 5, idempotent: true }, () => {
+			throw new Error('nope')
+		})
+	).rejects.toThrow('nope')
+
+	expect(completed.payloads).toHaveLength(1)
+	expect(completed.payloads[0]).toMatchObject({
+		attempt: 1,
+		outcome: 'non_retryable',
+	})
+})
+
+test('tracing:ydb:retry.run.asyncEnd carries outcome=success when the call resolves', async () => {
+	using trace = collectTrace('tracing:ydb:retry.run')
+
+	await retry({ idempotent: true }, async () => 'ok')
+
+	expect(trace.asyncEnd).toHaveLength(1)
+	expect(trace.asyncEnd[0]).toMatchObject({ outcome: 'success' })
+})
+
+test('tracing:ydb:retry.run.error carries outcome=exhausted when budget runs out', async () => {
+	using trace = collectTrace('tracing:ydb:retry.run')
+
+	await expect(
+		retry({ retry: true, budget: 1, strategy: 0, idempotent: false }, () => {
+			throw new Error('fail')
+		})
+	).rejects.toThrow('fail')
+
+	expect(trace.error).toHaveLength(1)
+	expect(trace.error[0]).toMatchObject({ outcome: 'exhausted' })
+})

--- a/packages/retry/src/diagnostics.test.ts
+++ b/packages/retry/src/diagnostics.test.ts
@@ -93,7 +93,7 @@ test('publishes tracing:ydb:retry.attempt once per attempt with monotonic number
 	expect(trace.error).toHaveLength(2)
 })
 
-test('tracing:ydb:retry.attempt ctx carries backoffMs (0 for first, >0 after a delayed retry)', async () => {
+test('publishes tracing:ydb:retry.attempt with backoffMs (0 for first, >0 after a delayed retry)', async () => {
 	using trace = collectTrace('tracing:ydb:retry.attempt')
 
 	let calls = 0

--- a/packages/retry/src/index.ts
+++ b/packages/retry/src/index.ts
@@ -11,13 +11,22 @@ import type { RetryConfig } from './config.js'
 import type { RetryContext } from './context.js'
 import { type RetryStrategy, backoff, fixed } from './strategy.js'
 
-let retryRunCh = tracingChannel<{ idempotent: boolean }, { idempotent: boolean }>(
-	'tracing:ydb:retry.run'
-)
-let retryAttemptCh = tracingChannel<
-	{ attempt: number; idempotent: boolean },
-	{ attempt: number; idempotent: boolean }
->('tracing:ydb:retry.attempt')
+/**
+ * Per-attempt outcome:
+ *   - `success`       — resolved
+ *   - `retried`       — retryable failure, budget remains
+ *   - `non_retryable` — policy refuses to retry
+ *   - `exhausted`     — retryable failure with no budget left
+ *
+ * Same type tags whole-run outcomes, except `retried` (a run terminates).
+ */
+export type RetryOutcome = 'success' | 'retried' | 'non_retryable' | 'exhausted'
+
+type RetryRunCtx = { idempotent: boolean; outcome?: RetryOutcome }
+type RetryAttemptCtx = { attempt: number; idempotent: boolean }
+
+let retryRunCh = tracingChannel<RetryRunCtx, RetryRunCtx>('tracing:ydb:retry.run')
+let retryAttemptCh = tracingChannel<RetryAttemptCtx, RetryAttemptCtx>('tracing:ydb:retry.attempt')
 
 export * from './config.js'
 export * from './context.js'
@@ -35,12 +44,16 @@ export async function retry<R>(
 	fn: (signal: AbortSignal) => R | Promise<R>
 ): Promise<R> {
 	let idempotent = cfg.idempotent ?? false
-	return retryRunCh.tracePromise(() => runLoop(cfg, fn), { idempotent })
+	// runLoop mutates `runCtx.outcome` before settling so the asyncEnd
+	// subscriber reads the final outcome off the same ctx object.
+	let runCtx: RetryRunCtx = { idempotent }
+	return retryRunCh.tracePromise(() => runLoop(cfg, fn, runCtx), runCtx)
 }
 
 async function runLoop<R>(
 	cfg: RetryConfig,
-	fn: (signal: AbortSignal) => R | Promise<R>
+	fn: (signal: AbortSignal) => R | Promise<R>,
+	runCtx: RetryRunCtx
 ): Promise<R> {
 	let config = Object.assign({}, defaultRetryConfig, cfg)
 	let idempotent = cfg.idempotent ?? false
@@ -70,6 +83,12 @@ async function runLoop<R>(
 			)
 
 			dbg.log('attempt %d: success', attemptNumber)
+			dc('ydb:retry.attempt.completed').publish({
+				attempt: attemptNumber,
+				idempotent,
+				outcome: 'success' satisfies RetryOutcome,
+			})
+			runCtx.outcome = 'success'
 			return result
 		} catch (error) {
 			ctx.error = error
@@ -77,11 +96,23 @@ async function runLoop<R>(
 
 			if (error instanceof Error && error.name === 'AbortError') {
 				dbg.log('attempt %d: abort error, not retryable', ctx.attempt)
+				dc('ydb:retry.attempt.completed').publish({
+					attempt: attemptNumber,
+					idempotent,
+					outcome: 'non_retryable' satisfies RetryOutcome,
+				})
+				runCtx.outcome = 'non_retryable'
 				throw error
 			}
 
 			if (error instanceof Error && error.name === 'TimeoutError') {
 				dbg.log('attempt %d: timeout error, not retryable', ctx.attempt)
+				dc('ydb:retry.attempt.completed').publish({
+					attempt: attemptNumber,
+					idempotent,
+					outcome: 'non_retryable' satisfies RetryOutcome,
+				})
+				runCtx.outcome = 'non_retryable'
 				throw error
 			}
 
@@ -94,8 +125,21 @@ async function runLoop<R>(
 
 			if (!willRetry || ctx.attempt >= budget) {
 				dbg.log('attempt %d: not retrying, error: %O', ctx.attempt, error)
+				let outcome: RetryOutcome = !willRetry ? 'non_retryable' : 'exhausted'
+				dc('ydb:retry.attempt.completed').publish({
+					attempt: attemptNumber,
+					idempotent,
+					outcome,
+				})
+				runCtx.outcome = outcome
 				break
 			}
+
+			dc('ydb:retry.attempt.completed').publish({
+				attempt: attemptNumber,
+				idempotent,
+				outcome: 'retried' satisfies RetryOutcome,
+			})
 
 			let delay: number
 			if (typeof config.strategy === 'number') {

--- a/packages/retry/src/index.ts
+++ b/packages/retry/src/index.ts
@@ -23,7 +23,12 @@ import { type RetryStrategy, backoff, fixed } from './strategy.js'
 export type RetryOutcome = 'success' | 'retried' | 'non_retryable' | 'exhausted'
 
 type RetryRunCtx = { idempotent: boolean; outcome?: RetryOutcome }
-type RetryAttemptCtx = { attempt: number; idempotent: boolean }
+/**
+ * `backoffMs` is the actual wait observed before this attempt started,
+ * accounting for time already spent on the previous failed attempt.
+ * Always `0` for `attempt === 1` (no preceding wait).
+ */
+type RetryAttemptCtx = { attempt: number; idempotent: boolean; backoffMs: number }
 
 let retryRunCh = tracingChannel<RetryRunCtx, RetryRunCtx>('tracing:ydb:retry.run')
 let retryAttemptCh = tracingChannel<RetryAttemptCtx, RetryAttemptCtx>('tracing:ydb:retry.attempt')
@@ -61,6 +66,10 @@ async function runLoop<R>(
 	let started = performance.now()
 
 	let budget: number
+	// Backoff waited before the NEXT attempt — surfaced on the
+	// retry.attempt ctx so the consumer can stamp `ydb.retry.backoff` on
+	// the corresponding span. `0` for the first attempt.
+	let pendingBackoffMs = 0
 	while (
 		ctx.attempt <
 		(budget = typeof config.budget === 'number' ? config.budget : config.budget!(ctx, config))
@@ -79,7 +88,7 @@ async function runLoop<R>(
 			// oxlint-disable-next-line no-await-in-loop
 			let result = await retryAttemptCh.tracePromise(
 				() => abortable(signal, Promise.resolve(fn(signal))),
-				{ attempt: attemptNumber, idempotent }
+				{ attempt: attemptNumber, idempotent, backoffMs: pendingBackoffMs }
 			)
 
 			dbg.log('attempt %d: success', attemptNumber)
@@ -149,6 +158,7 @@ async function runLoop<R>(
 			}
 
 			let remaining = Math.max(delay - (Date.now() - start), 0)
+			pendingBackoffMs = remaining
 			if (!remaining) {
 				dbg.log('attempt %d: no delay before next retry', ctx.attempt)
 				continue

--- a/packages/telemetry/.gitignore
+++ b/packages/telemetry/.gitignore
@@ -1,0 +1,2 @@
+.turbo
+dist

--- a/packages/telemetry/.npmignore
+++ b/packages/telemetry/.npmignore
@@ -1,0 +1,9 @@
+/.turbo
+
+/src
+/tests
+/plugins
+/coverage
+
+/*.yaml
+/*.json

--- a/packages/telemetry/CHANGELOG.md
+++ b/packages/telemetry/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @ydbjs/telemetry

--- a/packages/telemetry/CHANGELOG.md
+++ b/packages/telemetry/CHANGELOG.md
@@ -1,1 +1,103 @@
 # @ydbjs/telemetry
+
+## 6.0.0
+
+### Major Changes
+
+- Initial release. OpenTelemetry instrumentation for the YDB JavaScript SDK.
+
+  The package subscribes to `node:diagnostics_channel` events published by
+  `@ydbjs/core`, `@ydbjs/query`, `@ydbjs/auth`, and `@ydbjs/retry`, and
+  emits OpenTelemetry **spans** and **metrics** through the SDK's standard
+  `TracerProvider` and `MeterProvider`. No monkey-patching — all
+  instrumentation flows through diagnostics channels. Producers use
+  `tracingChannel.tracePromise`, which short-circuits when no one is
+  listening, so the package is zero-cost when disabled.
+
+  **Lifecycle.** `YdbInstrumentation` extends `InstrumentationBase`, so it
+  is compatible with `registerInstrumentations()` from
+  `@opentelemetry/instrumentation`. A `register()` sugar is also exported,
+  plus a `@ydbjs/telemetry/register` entry for
+  `node --import @ydbjs/telemetry/register`.
+
+  **Multi-driver attribution.** Every span and every metric data point
+  carries `db.namespace`, `server.address`, and `server.port` from the
+  publishing driver's `DriverIdentity` (stamped at publish-time by
+  `@ydbjs/core`).
+
+  **Time units.** Diagnostics-channel payloads stay in **milliseconds**
+  (Node convention — `performance.now()`, `Date.now()`); spans and metrics
+  are emitted in **seconds** (OTel canonical unit). The conversion lives
+  in this package; attribute keys never carry an `_ms` suffix.
+
+  **W3C trace context propagation.** Enabling the instrumentation installs
+  a gRPC client middleware (via `@ydbjs/core`'s `addClientMiddleware`) that
+  calls `propagation.inject(context.active(), metadata, …)` on every
+  outgoing YDB RPC. Default propagator is `traceparent` / `tracestate`;
+  set a different one globally via `propagation.setGlobalPropagator`.
+  `register()` must be called **before** `new Driver(...)` for the
+  middleware to apply — drivers compose the chain once at construction.
+
+  **Spans.** Wraps every leaf YDB operation with a CLIENT span carrying
+  `db.system.name=ydb`, `db.operation.name=<Service>.<Method>`, and
+  operation-specific attributes. Nesting follows the natural call graph:
+
+  ```
+  ydb.Transaction
+  └── ydb.RunWithRetry
+      └── ydb.Try
+          ├── ydb.AcquireSession              (opt-in, off by default)
+          ├── ydb.CreateSession               (on miss)
+          ├── ydb.ExecuteQuery
+          ├── ydb.BeginTransaction / Commit / Rollback
+          └── ydb.DeleteSession               (background, on session close)
+  ```
+
+  Plus `ydb.Discovery` (with connection-pool point-in-time events as
+  span events) and `ydb.TokenFetch` (only on real fetches — cache hits
+  don't open a span).
+
+  **Metrics.** Synchronous instruments:
+  - `db.client.operation.duration` (Histogram, `s`) — every leaf CLIENT
+    operation attempt, tagged with `db.operation.name`. Standard OTel
+    database semantic convention.
+  - `ydb.driver.connection.pessimizations` (Counter)
+  - `ydb.query.session.create.duration` (Histogram)
+  - `ydb.query.session.acquire.duration` (Histogram)
+  - `ydb.query.session.closed` (Counter, tagged with
+    `ydb.session.close.reason` ∈ `{pool_close, attach_failed,
+stream_closed, stream_error}`)
+  - `ydb.query.session.acquire.failures` (Counter, tagged with
+    `error.type`)
+  - `ydb.auth.token.fetch.duration` (Histogram)
+  - `ydb.auth.token.fetch.failures` (Counter)
+  - `ydb.auth.token.refreshes` (Counter)
+  - `ydb.auth.token.expirations` (Counter)
+  - `ydb.retry.attempts` (Counter, tagged with `ydb.retry.outcome` ∈
+    `{success, retried, non_retryable, exhausted}`)
+  - `ydb.retry.duration` (Histogram, end-to-end loop including backoffs)
+
+  Observable instruments fed by a per-`DriverIdentity` state registry:
+  - `ydb.driver.connection.count` (`ObservableUpDownCounter`, tagged with
+    `ydb.connection.state` ∈ `{live, pessimized}`)
+  - `ydb.query.session.count` (`ObservableUpDownCounter`, tagged with
+    `ydb.session.state` ∈ `{idle, acquired, creating}`)
+  - `ydb.query.session.acquire.pending` (`ObservableUpDownCounter`)
+  - `ydb.query.session.max` / `ydb.query.session.min` (`ObservableGauge`)
+
+  All histograms ship with explicit bucket boundaries via OTel `advice`
+  so the out-of-the-box distribution is usable without configuration —
+  the SDK default (`[0, 5, 10, 25, …, 10000]`, ms-oriented) would collapse
+  every `unit: 's'` recording into the first slot.
+
+  **Configuration.** Two package-specific knobs; everything else is
+  controlled at the OTel SDK level (Sampler / View / Resource / Exporter):
+  - `captureQueryText` (default `false`) — include the raw YQL text as
+    `db.query.text`. Off by default because query text may carry PII.
+  - `emitAcquireSessionSpan` (default `false`) — emit `ydb.AcquireSession`
+    spans. Off by default; warm-pool acquires are sub-ms and only add
+    noise. Turn on to debug session-pool starvation.
+
+  See `packages/telemetry/README.md` for the full attribute and metric
+  catalogue, plus recipes for Sampler / View / Resource / OTLP exporter
+  wiring.

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -20,6 +20,10 @@ OpenTelemetry instrumentation for the YDB JavaScript SDK. Subscribes to
 - Standard `enable()` / `disable()` lifecycle via `InstrumentationBase`.
   Compatible with `registerInstrumentations()` from
   `@opentelemetry/instrumentation`.
+- W3C trace context propagation — `register()` installs a gRPC client
+  middleware that carries `traceparent` / `tracestate` (and any other
+  propagator registered via `propagation.setGlobalPropagator`) into
+  outgoing YDB calls. See [Propagation to YDB](#propagation-to-ydb) below.
 
 ## Installation
 
@@ -300,13 +304,13 @@ out-of-the-box distribution is usable without configuration. The OTel SDK
 default (designed for milliseconds: `[0, 5, 10, 25, …, 10000]`) buckets all
 sub-second YDB ops into the first slot, which is why we override.
 
-| Histogram                            | Boundaries (seconds)                                                                                               | Why                                                                                                          |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| `db.client.operation.duration`       | `0.0005, 0.001, 0.0025, 0.005, 0.0075, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, 30, 60` | Dense middle (1ms–1s) covers warm-cache reads + typical Execute; tail extends to overload-backoff territory. |
-| `ydb.query.session.create.duration`  | `0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10`                                                          | CreateSession + first AttachStream message — typically tens of ms, capped well below operation timeouts.     |
-| `ydb.query.session.acquire.duration` | `0.0001, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5`                                                                 | Warm-pool acquires are sub-millisecond; high tail only signals pool starvation.                              |
-| `ydb.auth.token.fetch.duration`      | `0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30`                                                                    | IAM/JWT round-trip; 30s tail matches typical request timeouts.                                               |
-| `ydb.retry.duration`                 | `0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30, 60, 300`                                                                      | End-to-end loop including backoffs — overload-induced retry sequences can stretch to minutes.                |
+| Histogram                            | Boundaries (seconds)                                                                                               | Why                                                                                                                                                                                                                        |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `db.client.operation.duration`       | `0.0005, 0.001, 0.0025, 0.005, 0.0075, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, 30, 60` | Dense middle (1ms–1s) covers warm-cache reads + typical Execute; tail extends to overload-backoff territory.                                                                                                               |
+| `ydb.query.session.create.duration`  | `0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10`                                                          | CreateSession + first AttachStream message — typically tens of ms, capped well below operation timeouts.                                                                                                                   |
+| `ydb.query.session.acquire.duration` | `0.0001, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2.5, 5, 10, 30`                                                    | Warm-pool acquires are sub-millisecond. When the pool has capacity but no idle session, an acquire wraps a full `session.create`, so the upper tail must cover create's tail (10s) plus a 30s slot for genuine starvation. |
+| `ydb.auth.token.fetch.duration`      | `0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30`                                                                    | IAM/JWT round-trip; 30s tail matches typical request timeouts.                                                                                                                                                             |
+| `ydb.retry.duration`                 | `0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30, 60, 300`                                                                      | End-to-end loop including backoffs — overload-induced retry sequences can stretch to minutes.                                                                                                                              |
 
 Override per-histogram in your OTel SDK config with a `View`:
 
@@ -358,12 +362,70 @@ Parent-child relationships between nested spans (e.g.
 channel body, so `disable()` cleanly tears down the binding without orphaning
 state.
 
+## Propagation to YDB
+
+`register()` installs a gRPC client middleware into `@ydbjs/core` (via
+`addClientMiddleware` — a small public hook exported from `@ydbjs/core`).
+On every outgoing RPC it calls
+`propagation.inject(context.active(), metadata, …)`, serialising the active
+OTel context into gRPC metadata using whichever propagator is globally
+registered. With no SDK registered the global propagator is a no-op.
+
+**Order of operations matters.** Drivers compose the middleware chain
+**once** at construction time, so `register()` must run **before**
+`new Driver(...)`. Matches OTel's `NodeSDK.start()` pattern.
+
+```ts
+sdk.start()                 // 1. OTel SDK
+register({ /* … */ })       // 2. @ydbjs/telemetry
+let driver = new Driver(…)  // 3. YDB driver — picks up the middleware
+```
+
+Default propagator is W3C `traceparent` / `tracestate`. Override with any
+other format by setting it before `register()`:
+
+```ts
+import { propagation } from '@opentelemetry/api'
+import { W3CTraceContextPropagator } from '@opentelemetry/core'
+
+// NodeSDK registers the W3C propagator by default; only set this manually
+// if you want a different format (e.g. B3, AWS X-Amzn).
+propagation.setGlobalPropagator(new W3CTraceContextPropagator())
+```
+
+**For propagation to actually carry your trace id, the YDB call must run
+inside an active OTel context.** The typical pattern: wrap the call in your
+own span.
+
+```ts
+import { trace } from '@opentelemetry/api'
+
+let tracer = trace.getTracer('my-app')
+
+await tracer.startActiveSpan('checkout', async (span) => {
+  try {
+    let rows = await sql`SELECT * FROM orders WHERE id = ${orderId}`
+    // Inside `startActiveSpan` callback, `context.active()` carries the new
+    // span — the propagator middleware emits a matching `traceparent`.
+  } finally {
+    span.end()
+  }
+})
+```
+
+> **Note.** `@ydbjs/telemetry`'s own internal spans (`ydb.Query.ExecuteQuery`,
+> `ydb.AcquireSession`, …) are created via the global `TracerProvider` but
+> are **not** activated in OTel's `ContextManager` — they live in a private
+> `AsyncLocalStorage` used only for parent-child linkage between sibling
+> SDK spans. So a `SELECT` issued **without** a user-created outer span will
+> still produce a `ydb.Query.ExecuteQuery` span locally, but the
+> `traceparent` sent to YDB will carry no trace id. Wrap YDB calls in your
+> own span (or in any other OTel-instrumented work) to get end-to-end
+> propagation.
+
 ## Non-goals (this version)
 
 - Structured logs are out of scope. Producers already emit driver / auth /
   session lifecycle events on dc; a separate logs subscriber will land later.
-- Cross-process trace context propagation. The instrumentation operates
-  inside the SDK boundary; trace context for outgoing gRPC calls is handled
-  by the user's OTel SDK setup.
 - See the "Deferred" subsection of [Metrics](#metrics) for instruments that
   need new producer events.

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -1,0 +1,202 @@
+# @ydbjs/telemetry
+
+OpenTelemetry instrumentation for the YDB JavaScript SDK. Subscribes to
+`node:diagnostics_channel` events emitted by `@ydbjs/core`, `@ydbjs/query`,
+`@ydbjs/auth`, and `@ydbjs/retry`, and converts them into OTel **spans** and
+**metrics**.
+
+## Features
+
+- Zero-cost when no subscriber is attached — producers use
+  `tracingChannel.tracePromise` which short-circuits if no one listens.
+- No monkey-patching. All instrumentation flows through
+  `node:diagnostics_channel`.
+- Multi-driver attribution out of the box — every span and every metric data
+  point carries `db.namespace`, `server.address`, and `server.port` from the
+  publishing driver's identity (`@ydbjs/core` stamps it at publish-time).
+- Time unit conversion handled here: dc payloads stay in **milliseconds**
+  (Node.js convention); spans and metrics are emitted in **seconds** (OTel
+  canonical unit). Attribute keys never carry an `_ms` suffix.
+- Standard `enable()` / `disable()` lifecycle via `InstrumentationBase`.
+  Compatible with `registerInstrumentations()` from
+  `@opentelemetry/instrumentation`.
+
+## Installation
+
+```sh
+npm install @ydbjs/telemetry
+```
+
+## Usage
+
+### Programmatic
+
+```ts
+import { NodeSDK } from '@opentelemetry/sdk-node'
+import { register } from '@ydbjs/telemetry'
+
+let sdk = new NodeSDK({ /* exporter, resource, ... */ })
+sdk.start()
+
+let instrumentation = register({
+	captureQueryText: false,
+	emitAcquireSessionSpan: false,
+})
+
+// Later, on shutdown:
+instrumentation.disable()
+await sdk.shutdown()
+```
+
+### Auto-registration
+
+```sh
+node --import @opentelemetry/sdk-node/register \
+     --import @ydbjs/telemetry/register \
+     your-app.js
+```
+
+The OTel SDK must be initialised before `@ydbjs/telemetry/register` runs, so
+the global tracer provider is already in place when subscribers attach.
+
+## Configuration
+
+| Option | Default | Description |
+|---|---|---|
+| `captureQueryText` | `false` | Include the raw YQL text as `db.query.text`. Disabled by default — query text may contain PII. |
+| `emitAcquireSessionSpan` | `false` | Emit `ydb.AcquireSession` spans. Off by default — session acquisition is almost always instant (warm pool hit). Turn on to debug session-pool starvation. |
+
+To drop other spans (e.g. `ydb.Try`, `ydb.Transaction`) or skip orphan
+root traces, configure your OpenTelemetry SDK's sampler — it applies
+uniformly across every instrumentation, not just this one.
+
+## Spans
+
+`db.operation.name` is service-prefixed (`Query.ExecuteQuery`,
+`Discovery.ListEndpoints`, …) so traces stay unambiguous when the Table
+service gets instrumented next to Query.
+
+| Span name             | Channel                              | Kind     | Specific attributes                                                                                                                   |
+| --------------------- | ------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `ydb.Discovery`       | `tracing:ydb:driver.discovery`       | CLIENT   | `db.operation.name="Discovery.ListEndpoints"` + (on `discovery.completed`) `ydb.discovery.{added,removed,total}_count`, `ydb.discovery.duration` |
+| `ydb.Transaction`     | `tracing:ydb:query.transaction`      | CLIENT   | `ydb.isolation`, `ydb.idempotent`                                                                                                     |
+| `ydb.Begin`           | `tracing:ydb:query.begin`            | CLIENT   | `db.operation.name="Query.BeginTransaction"`, `ydb.session.id`, `ydb.node.id`, `ydb.isolation`                                        |
+| `ydb.ExecuteQuery`    | `tracing:ydb:query.execute`          | CLIENT   | `db.operation.name="Query.ExecuteQuery"`, `db.query.text`? (opt-in), `ydb.session.id`, `ydb.node.id`, `ydb.idempotent`, `ydb.isolation` |
+| `ydb.Commit`          | `tracing:ydb:query.commit`           | CLIENT   | `db.operation.name="Query.CommitTransaction"`, `ydb.session.id`, `ydb.node.id`, `ydb.transaction.id`                                  |
+| `ydb.Rollback`        | `tracing:ydb:query.rollback`         | CLIENT   | `db.operation.name="Query.RollbackTransaction"`, `ydb.session.id`, `ydb.node.id`, `ydb.transaction.id`                                |
+| `ydb.CreateSession`   | `tracing:ydb:query.session.create`   | CLIENT   | `db.operation.name="Query.CreateSession"`                                                                                             |
+| `ydb.DeleteSession`   | `tracing:ydb:query.session.delete`   | CLIENT   | `db.operation.name="Query.DeleteSession"`, `ydb.session.id`, `ydb.node.id`, `ydb.session.close.reason`, `ydb.session.uptime`          |
+| `ydb.AcquireSession`  | `tracing:ydb:query.session.acquire`  | INTERNAL | _(opt-in via `emitAcquireSessionSpan`)_                                                                                               |
+| `ydb.RunWithRetry`    | `tracing:ydb:retry.run`              | INTERNAL | `ydb.idempotent` + (on `retry.exhausted`) `ydb.retry.attempts_total`, `ydb.retry.total_duration`                                      |
+| `ydb.Try`             | `tracing:ydb:retry.attempt`          | INTERNAL | `ydb.retry.attempt`, `ydb.idempotent`                                                                                                 |
+| `ydb.TokenFetch`      | `tracing:ydb:auth.token.fetch`       | INTERNAL | `ydb.auth.provider`                                                                                                                   |
+
+Identity attributes (`db.system.name="ydb"`, `db.namespace`, `server.address`,
+`server.port`) flow through the channel payload — producers stamp them at
+publish-time, so no AsyncLocalStorage wrapping is required on the producer
+side. On error, every span additionally carries `db.response.status_code`
+(when the server returned a YDB status) and `error.type` ∈
+{`ydb_error`, `transport_error`, `<Error.name>`, `unknown`}.
+
+### Span events (point-in-time)
+
+When a connection-pool event fires while a tracing channel span is active
+(typically a `ydb.Discovery` span during a discovery round), it is recorded
+as a `span.addEvent`. When no span is active, the event is dropped by the
+traces pipeline — the metrics pipeline picks it up regardless.
+
+| Event name                              | Channel                              | Attributes                                                                            |
+| --------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------- |
+| `ydb.driver.connection.added`           | `ydb:driver.connection.added`        | `ydb.node.id`, `ydb.node.dc`, `network.peer.address`                                  |
+| `ydb.driver.connection.pessimized`     | `ydb:driver.connection.pessimized`   | `… + ydb.driver.connection.pessimization.until` (unix seconds)                        |
+| `ydb.driver.connection.unpessimized`   | `ydb:driver.connection.unpessimized` | `… + ydb.driver.connection.pessimization.duration` (seconds)                          |
+| `ydb.driver.connection.retired`        | `ydb:driver.connection.retired`      | `… + ydb.driver.connection.retire.reason`                                             |
+| `ydb.driver.connection.removed`        | `ydb:driver.connection.removed`      | `… + ydb.driver.connection.remove.reason`                                             |
+
+## Metrics
+
+The pipeline registers OTel instruments via the package's own `Meter`. All
+data points carry the identity attributes above (when the source ctx /
+payload includes a driver — most channels do).
+
+### Synchronous instruments
+
+| Instrument                              | Kind      | Unit          | Tags (beyond identity)                                                | Source                                                                                                                       |
+| --------------------------------------- | --------- | ------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `db.client.operation.duration`          | Histogram | `s`           | `db.operation.name`, `error.type`?                                    | every leaf CLIENT tracing channel: `query.{execute,begin,commit,rollback,session.create,session.delete}` and `driver.discovery`. Auth token fetch is its own INTERNAL span recorded by `ydb.auth.token.fetch.duration` below — not a database operation. Uses the OTel-standard metric so off-the-shelf db dashboards work. |
+| `ydb.driver.connection.pessimizations`  | Counter   | `{event}`     | _(none)_                                                              | `ydb:driver.connection.pessimized`                                                                                           |
+| `ydb.query.session.create.duration`     | Histogram | `s`           | _(none)_                                                              | `tracing:ydb:query.session.create.asyncEnd`                                                                                  |
+| `ydb.query.session.acquire.duration`    | Histogram | `s`           | _(none)_                                                              | `tracing:ydb:query.session.acquire.asyncEnd`                                                                                 |
+| `ydb.query.session.closed`              | Counter   | `{session}`   | `ydb.session.close.reason`                                            | `ydb:query.session.closed`                                                                                                   |
+| `ydb.query.session.acquire.failures`    | Counter   | `{failure}`   | `error.type`                                                          | `ydb:query.session.acquire.failed` (caller-aborted acquires are not published, so they do not count as failures)             |
+| `ydb.auth.token.fetch.duration`         | Histogram | `s`           | `ydb.auth.provider`, `error.type`?                                    | `tracing:ydb:auth.token.fetch.asyncEnd` / `.error`                                                                           |
+| `ydb.auth.token.fetch.failures`         | Counter   | `{failure}`   | `ydb.auth.provider`, `error.type`                                     | `ydb:auth.provider.failed`                                                                                                   |
+| `ydb.auth.token.expirations`            | Counter   | `{expiration}`| `ydb.auth.provider`                                                   | `ydb:auth.token.expired`                                                                                                     |
+| `ydb.retry.attempts`                    | Counter   | `{attempt}`   | `ydb.idempotent`, `ydb.retry.outcome` ∈ {success, retried, exhausted, non_retryable} | `ydb:retry.attempt.completed`                                                                                                |
+| `ydb.retry.duration`                    | Histogram | `s`           | `ydb.idempotent`, `ydb.retry.outcome`                                 | `tracing:ydb:retry.run.asyncEnd` / `.error` (end-to-end, including backoffs)                                                 |
+
+### Observable instruments
+
+State for these is reconstructed from lifecycle events in two per-driver
+registries (`ConnectionPoolRegistry` for the gRPC connection pool,
+`SessionPoolRegistry` for the query session pool). Late-attaching subscribers
+(those registered after a driver is already `ready`) miss the initial state —
+that's an explicit trade-off vs. introducing a "snapshot" channel. Register
+telemetry at process start (the standard pattern) to avoid the gap.
+
+| Instrument                            | Kind                       | Unit           | Tags                                                       | State updated by                                                                                                |
+| ------------------------------------- | -------------------------- | -------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `ydb.driver.connection.count`         | ObservableUpDownCounter    | `{connection}` | `ydb.connection.state` ∈ {`live`, `pessimized`}            | `ydb:driver.connection.{added,pessimized,unpessimized,retired,removed}`; entry deleted on `ydb:driver.closed`   |
+| `ydb.query.session.count`             | ObservableUpDownCounter    | `{session}`    | `ydb.session.state` ∈ {`idle`, `acquired`, `creating`}     | `ydb:query.session.{created,closed,acquired,released}` + hooks on `tracing:ydb:query.session.create`            |
+| `ydb.query.session.acquire.pending`   | ObservableUpDownCounter    | `{request}`    | _(identity only)_                                          | `ydb:query.session.waiter.{enqueued,dequeued}`                                                                  |
+| `ydb.query.session.max`               | ObservableGauge            | `{session}`    | _(identity only)_                                          | `ydb:query.session.pool.opened` snapshot                                                                        |
+| `ydb.query.session.min`               | ObservableGauge            | `{session}`    | _(identity only)_                                          | `ydb:query.session.pool.opened` snapshot                                                                        |
+
+### Cardinality budget
+
+All tag values are bounded and safe to ingest at high request rates:
+
+- `db.operation.name` — 10 fixed strings (Query.*, Discovery.ListEndpoints, Auth.TokenFetch)
+- `ydb.session.close.reason` — 4 strings (`pool_close`, `attach_failed`, `stream_closed`, `stream_error`)
+- `ydb.retry.outcome` — 4 strings
+- `ydb.connection.state` — 2 strings
+- `ydb.auth.provider` — bounded by the credential providers configured in the process
+- identity tags (`db.namespace`, `server.address`, `server.port`) — bounded by the deployment
+
+Tags **never** set on metrics (always unbounded, OK for spans only):
+`ydb.session.id`, `ydb.transaction.id`, `db.query.text`.
+
+### Deferred (planned)
+
+Awaiting new producer-side events / channels — these instruments are NOT
+emitted in this version:
+
+- `ydb.driver.connection.count` state breakdown into `{idle, busy}` — needs new events for "connection routed to RPC" / "returned to pool"
+
+## How it works
+
+The SDK publishes structured events to `node:diagnostics_channel` topics
+named `tracing:ydb:*` (operations with a duration) and `ydb:*` (point-in-time
+or summary events).
+
+For each `tracing:ydb:*` channel, `@ydbjs/telemetry` subscribes a bundle of
+handlers (`start`, `asyncEnd`, `error`) that create, finalise, or fail an OTel
+span keyed by the channel's `ctx` object (held in a `WeakMap` so leaks are
+bounded by GC).
+
+Parent-child relationships between nested spans (e.g.
+`ydb.Transaction → ydb.ExecuteQuery`) propagate through a private
+`AsyncLocalStorage` bound to each scope channel via
+`tracingChannel.start.bindStore`. Node manages the ALS frame around the
+channel body, so `disable()` cleanly tears down the binding without orphaning
+state.
+
+## Non-goals (this version)
+
+- Structured logs are out of scope. Producers already emit driver / auth /
+  session lifecycle events on dc; a separate logs subscriber will land later.
+- Cross-process trace context propagation. The instrumentation operates
+  inside the SDK boundary; trace context for outgoing gRPC calls is handled
+  by the user's OTel SDK setup.
+- See the "Deferred" subsection of [Metrics](#metrics) for instruments that
+  need new producer events.

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -72,6 +72,137 @@ To drop other spans (e.g. `ydb.Try`, `ydb.Transaction`) or skip orphan
 root traces, configure your OpenTelemetry SDK's sampler — it applies
 uniformly across every instrumentation, not just this one.
 
+## Customising emitted telemetry
+
+`@ydbjs/telemetry` is an `InstrumentationBase` subclass, so it integrates
+with the standard OTel pipeline. The two options above are the only knobs
+specific to this package; everything else is configured at the SDK level
+and applies uniformly across all instrumentations.
+
+| Knob                                                           | Controlled by                         | Example use case                                |
+| -------------------------------------------------------------- | ------------------------------------- | ----------------------------------------------- |
+| Span sampling rate / drop specific spans                       | OTel `Sampler`                        | Sample 1% of traces, or drop `ydb.Try`          |
+| Histogram bucket layout, metric tag pruning, rename            | OTel `View`                           | Switch `ydb.retry.duration` to explicit buckets |
+| `service.name`, `deployment.environment`, custom resource tags | OTel `Resource`                       | Attribute traces to the right service           |
+| Choose / configure exporter                                    | OTel `SpanProcessor` + `MetricReader` | OTLP, Jaeger, Prometheus, console               |
+| Periodic export interval                                       | `PeriodicExportingMetricReader`       | Trade freshness vs. ingestion cost              |
+| Disable instrumentation at runtime                             | `instrumentation.disable()`           | Pause telemetry in tests                        |
+
+### Drop noisy spans with a sampler
+
+`ydb.Try` and `ydb.Transaction` are wrapper spans — useful for retry
+debugging but noise on a high-RPS service. A small custom sampler
+combined with `ParentBasedSampler` keeps the rest of the tree intact:
+
+```ts
+import {
+  ParentBasedSampler,
+  type Sampler,
+  SamplingDecision,
+  TraceIdRatioBasedSampler,
+} from '@opentelemetry/sdk-trace-base'
+
+let DROPPED = new Set(['ydb.Try', 'ydb.Transaction'])
+
+let dropWrappers: Sampler = {
+  shouldSample(_ctx, _traceId, name) {
+    return DROPPED.has(name)
+      ? { decision: SamplingDecision.NOT_RECORD }
+      : { decision: SamplingDecision.RECORD_AND_SAMPLED }
+  },
+  toString: () => 'DropWrapperSpans',
+}
+
+new NodeSDK({
+  sampler: new ParentBasedSampler({ root: dropWrappers }),
+  // ...
+})
+```
+
+### Customise histogram buckets via View
+
+```ts
+import { ExplicitBucketHistogramAggregation, View } from '@opentelemetry/sdk-metrics'
+
+new NodeSDK({
+  views: [
+    new View({
+      instrumentName: 'ydb.retry.duration',
+      aggregation: new ExplicitBucketHistogramAggregation([0.01, 0.05, 0.1, 0.5, 1, 5, 30]),
+    }),
+    // Drop the `ydb.idempotent` tag from retry counters if you don't need it
+    new View({ instrumentName: 'ydb.retry.attempts', attributeKeys: ['ydb.retry.outcome'] }),
+  ],
+})
+```
+
+### Identify the service in exported telemetry
+
+```ts
+import { resourceFromAttributes } from '@opentelemetry/resources'
+import {
+  ATTR_DEPLOYMENT_ENVIRONMENT_NAME,
+  ATTR_SERVICE_NAME,
+  ATTR_SERVICE_VERSION,
+} from '@opentelemetry/semantic-conventions/incubating'
+
+new NodeSDK({
+  resource: resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: 'orders-api',
+    [ATTR_SERVICE_VERSION]: process.env.GIT_SHA,
+    [ATTR_DEPLOYMENT_ENVIRONMENT_NAME]: 'production',
+  }),
+})
+```
+
+Identity attributes the SDK emits per request (`db.namespace`,
+`server.address`, `server.port`) come from the YDB driver and are
+orthogonal to resource attributes.
+
+### Wire an OTLP exporter (traces + metrics)
+
+```ts
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http'
+import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics'
+
+new NodeSDK({
+  traceExporter: new OTLPTraceExporter({ url: 'http://collector:4318/v1/traces' }),
+  metricReader: new PeriodicExportingMetricReader({
+    exporter: new OTLPMetricExporter({ url: 'http://collector:4318/v1/metrics' }),
+    exportIntervalMillis: 10_000,
+  }),
+})
+```
+
+### Graceful shutdown
+
+```ts
+let instrumentation = register({ captureQueryText: false, emitAcquireSessionSpan: false })
+
+async function shutdown() {
+  instrumentation.disable() // 1. stop publishing into the OTel SDK
+  await sdk.shutdown() // 2. flush exporters
+}
+process.on('SIGTERM', shutdown)
+```
+
+### What you cannot configure here
+
+The following are part of the package's semconv contract — change them via
+a PR, not configuration:
+
+- Which `node:diagnostics_channel` topics the pipeline subscribes to.
+- Span names (`ydb.ExecuteQuery`, `ydb.Try`, …) and the `db.operation.name` mapping.
+- Metric instrument names (`db.client.operation.duration`, `ydb.retry.attempts`, …).
+- Attribute key names (`ydb.session.id`, `ydb.retry.outcome`, …).
+- Synchronous-handler error policy: thrown exceptions inside our subscribers are swallowed and logged via OTel's `DiagLogger`, never re-thrown into the SDK call site.
+
+If you want a custom subscriber alongside ours — e.g. a structured-log sink —
+subscribe to `node:diagnostics_channel` directly. The producer's channel
+surface is documented in each package's README (`@ydbjs/core`,
+`@ydbjs/query`, `@ydbjs/retry`, `@ydbjs/auth`).
+
 ## Spans
 
 `db.operation.name` is service-prefixed (`Query.ExecuteQuery`,

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -293,6 +293,32 @@ telemetry at process start (the standard pattern) to avoid the gap.
 | `ydb.query.session.max`             | ObservableGauge         | `{session}`    | _(identity only)_                                      | `ydb:query.session.pool.opened` snapshot                                                                      |
 | `ydb.query.session.min`             | ObservableGauge         | `{session}`    | _(identity only)_                                      | `ydb:query.session.pool.opened` snapshot                                                                      |
 
+### Histogram bucket defaults
+
+Every histogram is registered with `advice.explicitBucketBoundaries` so the
+out-of-the-box distribution is usable without configuration. The OTel SDK
+default (designed for milliseconds: `[0, 5, 10, 25, …, 10000]`) buckets all
+sub-second YDB ops into the first slot, which is why we override.
+
+| Histogram                            | Boundaries (seconds)                                                                                               | Why                                                                                                          |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `db.client.operation.duration`       | `0.0005, 0.001, 0.0025, 0.005, 0.0075, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, 30, 60` | Dense middle (1ms–1s) covers warm-cache reads + typical Execute; tail extends to overload-backoff territory. |
+| `ydb.query.session.create.duration`  | `0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10`                                                          | CreateSession + first AttachStream message — typically tens of ms, capped well below operation timeouts.     |
+| `ydb.query.session.acquire.duration` | `0.0001, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5`                                                                 | Warm-pool acquires are sub-millisecond; high tail only signals pool starvation.                              |
+| `ydb.auth.token.fetch.duration`      | `0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30`                                                                    | IAM/JWT round-trip; 30s tail matches typical request timeouts.                                               |
+| `ydb.retry.duration`                 | `0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30, 60, 300`                                                                      | End-to-end loop including backoffs — overload-induced retry sequences can stretch to minutes.                |
+
+Override per-histogram in your OTel SDK config with a `View`:
+
+```ts
+new View({
+  instrumentName: 'db.client.operation.duration',
+  aggregation: new ExplicitBucketHistogramAggregation([
+    /* your boundaries */
+  ]),
+})
+```
+
 ### Cardinality budget
 
 All tag values are bounded and safe to ingest at high request rates:

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -100,6 +100,13 @@ side. On error, every span additionally carries `db.response.status_code`
 (when the server returned a YDB status) and `error.type` ∈
 {`ydb_error`, `transport_error`, `<Error.name>`, `unknown`}.
 
+`ydb.TokenFetch` is only emitted when a credential provider actually goes to
+the network for a token — every provider (`static`, `metadata`,
+`yc-service-account`) short-circuits cache hits **before** wrapping the
+fetch in `tracingChannel.tracePromise`, so a warm cache never produces a
+span. Opportunistic background refreshes do produce one (they perform real
+IO), as a root span if no caller-side trace is active.
+
 ### Span events (point-in-time)
 
 When a connection-pool event fires while a tracing channel span is active
@@ -133,6 +140,7 @@ payload includes a driver — most channels do).
 | `ydb.query.session.acquire.failures`   | Counter   | `{failure}`    | `error.type`                                                                         | `ydb:query.session.acquire.failed` (caller-aborted acquires are not published, so they do not count as failures)                                                                                                                                                                                                            |
 | `ydb.auth.token.fetch.duration`        | Histogram | `s`            | `ydb.auth.provider`, `error.type`?                                                   | `tracing:ydb:auth.token.fetch.asyncEnd` / `.error`                                                                                                                                                                                                                                                                          |
 | `ydb.auth.token.fetch.failures`        | Counter   | `{failure}`    | `ydb.auth.provider`, `error.type`                                                    | `ydb:auth.provider.failed`                                                                                                                                                                                                                                                                                                  |
+| `ydb.auth.token.refreshes`             | Counter   | `{refresh}`    | `ydb.auth.provider`                                                                  | `ydb:auth.token.refreshed` — successful refreshes only; direct rate signal complementing the `fetch.duration` histogram                                                                                                                                                                                                     |
 | `ydb.auth.token.expirations`           | Counter   | `{expiration}` | `ydb.auth.provider`                                                                  | `ydb:auth.token.expired`                                                                                                                                                                                                                                                                                                    |
 | `ydb.retry.attempts`                   | Counter   | `{attempt}`    | `ydb.idempotent`, `ydb.retry.outcome` ∈ {success, retried, exhausted, non_retryable} | `ydb:retry.attempt.completed`                                                                                                                                                                                                                                                                                               |
 | `ydb.retry.duration`                   | Histogram | `s`            | `ydb.idempotent`, `ydb.retry.outcome`                                                | `tracing:ydb:retry.run.asyncEnd` / `.error` (end-to-end, including backoffs)                                                                                                                                                                                                                                                |

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -35,12 +35,14 @@ npm install @ydbjs/telemetry
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import { register } from '@ydbjs/telemetry'
 
-let sdk = new NodeSDK({ /* exporter, resource, ... */ })
+let sdk = new NodeSDK({
+  /* exporter, resource, ... */
+})
 sdk.start()
 
 let instrumentation = register({
-	captureQueryText: false,
-	emitAcquireSessionSpan: false,
+  captureQueryText: false,
+  emitAcquireSessionSpan: false,
 })
 
 // Later, on shutdown:
@@ -61,9 +63,9 @@ the global tracer provider is already in place when subscribers attach.
 
 ## Configuration
 
-| Option | Default | Description |
-|---|---|---|
-| `captureQueryText` | `false` | Include the raw YQL text as `db.query.text`. Disabled by default — query text may contain PII. |
+| Option                   | Default | Description                                                                                                                                               |
+| ------------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `captureQueryText`       | `false` | Include the raw YQL text as `db.query.text`. Disabled by default — query text may contain PII.                                                            |
 | `emitAcquireSessionSpan` | `false` | Emit `ydb.AcquireSession` spans. Off by default — session acquisition is almost always instant (warm pool hit). Turn on to debug session-pool starvation. |
 
 To drop other spans (e.g. `ydb.Try`, `ydb.Transaction`) or skip orphan
@@ -76,20 +78,20 @@ uniformly across every instrumentation, not just this one.
 `Discovery.ListEndpoints`, …) so traces stay unambiguous when the Table
 service gets instrumented next to Query.
 
-| Span name             | Channel                              | Kind     | Specific attributes                                                                                                                   |
-| --------------------- | ------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `ydb.Discovery`       | `tracing:ydb:driver.discovery`       | CLIENT   | `db.operation.name="Discovery.ListEndpoints"` + (on `discovery.completed`) `ydb.discovery.{added,removed,total}_count`, `ydb.discovery.duration` |
-| `ydb.Transaction`     | `tracing:ydb:query.transaction`      | CLIENT   | `ydb.isolation`, `ydb.idempotent`                                                                                                     |
-| `ydb.Begin`           | `tracing:ydb:query.begin`            | CLIENT   | `db.operation.name="Query.BeginTransaction"`, `ydb.session.id`, `ydb.node.id`, `ydb.isolation`                                        |
-| `ydb.ExecuteQuery`    | `tracing:ydb:query.execute`          | CLIENT   | `db.operation.name="Query.ExecuteQuery"`, `db.query.text`? (opt-in), `ydb.session.id`, `ydb.node.id`, `ydb.idempotent`, `ydb.isolation` |
-| `ydb.Commit`          | `tracing:ydb:query.commit`           | CLIENT   | `db.operation.name="Query.CommitTransaction"`, `ydb.session.id`, `ydb.node.id`, `ydb.transaction.id`                                  |
-| `ydb.Rollback`        | `tracing:ydb:query.rollback`         | CLIENT   | `db.operation.name="Query.RollbackTransaction"`, `ydb.session.id`, `ydb.node.id`, `ydb.transaction.id`                                |
-| `ydb.CreateSession`   | `tracing:ydb:query.session.create`   | CLIENT   | `db.operation.name="Query.CreateSession"`                                                                                             |
-| `ydb.DeleteSession`   | `tracing:ydb:query.session.delete`   | CLIENT   | `db.operation.name="Query.DeleteSession"`, `ydb.session.id`, `ydb.node.id`, `ydb.session.close.reason`, `ydb.session.uptime`          |
-| `ydb.AcquireSession`  | `tracing:ydb:query.session.acquire`  | INTERNAL | _(opt-in via `emitAcquireSessionSpan`)_                                                                                               |
-| `ydb.RunWithRetry`    | `tracing:ydb:retry.run`              | INTERNAL | `ydb.idempotent` + (on `retry.exhausted`) `ydb.retry.attempts_total`, `ydb.retry.total_duration`                                      |
-| `ydb.Try`             | `tracing:ydb:retry.attempt`          | INTERNAL | `ydb.retry.attempt`, `ydb.idempotent`                                                                                                 |
-| `ydb.TokenFetch`      | `tracing:ydb:auth.token.fetch`       | INTERNAL | `ydb.auth.provider`                                                                                                                   |
+| Span name            | Channel                             | Kind     | Specific attributes                                                                                                                              |
+| -------------------- | ----------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ydb.Discovery`      | `tracing:ydb:driver.discovery`      | CLIENT   | `db.operation.name="Discovery.ListEndpoints"` + (on `discovery.completed`) `ydb.discovery.{added,removed,total}_count`, `ydb.discovery.duration` |
+| `ydb.Transaction`    | `tracing:ydb:query.transaction`     | CLIENT   | `ydb.isolation`, `ydb.idempotent`                                                                                                                |
+| `ydb.Begin`          | `tracing:ydb:query.begin`           | CLIENT   | `db.operation.name="Query.BeginTransaction"`, `ydb.session.id`, `ydb.node.id`, `ydb.isolation`                                                   |
+| `ydb.ExecuteQuery`   | `tracing:ydb:query.execute`         | CLIENT   | `db.operation.name="Query.ExecuteQuery"`, `db.query.text`? (opt-in), `ydb.session.id`, `ydb.node.id`, `ydb.idempotent`, `ydb.isolation`          |
+| `ydb.Commit`         | `tracing:ydb:query.commit`          | CLIENT   | `db.operation.name="Query.CommitTransaction"`, `ydb.session.id`, `ydb.node.id`, `ydb.transaction.id`                                             |
+| `ydb.Rollback`       | `tracing:ydb:query.rollback`        | CLIENT   | `db.operation.name="Query.RollbackTransaction"`, `ydb.session.id`, `ydb.node.id`, `ydb.transaction.id`                                           |
+| `ydb.CreateSession`  | `tracing:ydb:query.session.create`  | CLIENT   | `db.operation.name="Query.CreateSession"`                                                                                                        |
+| `ydb.DeleteSession`  | `tracing:ydb:query.session.delete`  | CLIENT   | `db.operation.name="Query.DeleteSession"`, `ydb.session.id`, `ydb.node.id`, `ydb.session.close.reason`, `ydb.session.uptime`                     |
+| `ydb.AcquireSession` | `tracing:ydb:query.session.acquire` | INTERNAL | _(opt-in via `emitAcquireSessionSpan`)_                                                                                                          |
+| `ydb.RunWithRetry`   | `tracing:ydb:retry.run`             | INTERNAL | `ydb.idempotent` + (on `retry.exhausted`) `ydb.retry.attempts_total`, `ydb.retry.total_duration`                                                 |
+| `ydb.Try`            | `tracing:ydb:retry.attempt`         | INTERNAL | `ydb.retry.attempt`, `ydb.idempotent`, `ydb.retry.backoff` (seconds; `0` for attempt 1)                                                          |
+| `ydb.TokenFetch`     | `tracing:ydb:auth.token.fetch`      | INTERNAL | `ydb.auth.provider`                                                                                                                              |
 
 Identity attributes (`db.system.name="ydb"`, `db.namespace`, `server.address`,
 `server.port`) flow through the channel payload — producers stamp them at
@@ -105,13 +107,13 @@ When a connection-pool event fires while a tracing channel span is active
 as a `span.addEvent`. When no span is active, the event is dropped by the
 traces pipeline — the metrics pipeline picks it up regardless.
 
-| Event name                              | Channel                              | Attributes                                                                            |
-| --------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------- |
-| `ydb.driver.connection.added`           | `ydb:driver.connection.added`        | `ydb.node.id`, `ydb.node.dc`, `network.peer.address`                                  |
-| `ydb.driver.connection.pessimized`     | `ydb:driver.connection.pessimized`   | `… + ydb.driver.connection.pessimization.until` (unix seconds)                        |
-| `ydb.driver.connection.unpessimized`   | `ydb:driver.connection.unpessimized` | `… + ydb.driver.connection.pessimization.duration` (seconds)                          |
-| `ydb.driver.connection.retired`        | `ydb:driver.connection.retired`      | `… + ydb.driver.connection.retire.reason`                                             |
-| `ydb.driver.connection.removed`        | `ydb:driver.connection.removed`      | `… + ydb.driver.connection.remove.reason`                                             |
+| Event name                           | Channel                              | Attributes                                                     |
+| ------------------------------------ | ------------------------------------ | -------------------------------------------------------------- |
+| `ydb.driver.connection.added`        | `ydb:driver.connection.added`        | `ydb.node.id`, `ydb.node.dc`, `network.peer.address`           |
+| `ydb.driver.connection.pessimized`   | `ydb:driver.connection.pessimized`   | `… + ydb.driver.connection.pessimization.until` (unix seconds) |
+| `ydb.driver.connection.unpessimized` | `ydb:driver.connection.unpessimized` | `… + ydb.driver.connection.pessimization.duration` (seconds)   |
+| `ydb.driver.connection.retired`      | `ydb:driver.connection.retired`      | `… + ydb.driver.connection.retire.reason`                      |
+| `ydb.driver.connection.removed`      | `ydb:driver.connection.removed`      | `… + ydb.driver.connection.remove.reason`                      |
 
 ## Metrics
 
@@ -121,19 +123,19 @@ payload includes a driver — most channels do).
 
 ### Synchronous instruments
 
-| Instrument                              | Kind      | Unit          | Tags (beyond identity)                                                | Source                                                                                                                       |
-| --------------------------------------- | --------- | ------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `db.client.operation.duration`          | Histogram | `s`           | `db.operation.name`, `error.type`?                                    | every leaf CLIENT tracing channel: `query.{execute,begin,commit,rollback,session.create,session.delete}` and `driver.discovery`. Auth token fetch is its own INTERNAL span recorded by `ydb.auth.token.fetch.duration` below — not a database operation. Uses the OTel-standard metric so off-the-shelf db dashboards work. |
-| `ydb.driver.connection.pessimizations`  | Counter   | `{event}`     | _(none)_                                                              | `ydb:driver.connection.pessimized`                                                                                           |
-| `ydb.query.session.create.duration`     | Histogram | `s`           | _(none)_                                                              | `tracing:ydb:query.session.create.asyncEnd`                                                                                  |
-| `ydb.query.session.acquire.duration`    | Histogram | `s`           | _(none)_                                                              | `tracing:ydb:query.session.acquire.asyncEnd`                                                                                 |
-| `ydb.query.session.closed`              | Counter   | `{session}`   | `ydb.session.close.reason`                                            | `ydb:query.session.closed`                                                                                                   |
-| `ydb.query.session.acquire.failures`    | Counter   | `{failure}`   | `error.type`                                                          | `ydb:query.session.acquire.failed` (caller-aborted acquires are not published, so they do not count as failures)             |
-| `ydb.auth.token.fetch.duration`         | Histogram | `s`           | `ydb.auth.provider`, `error.type`?                                    | `tracing:ydb:auth.token.fetch.asyncEnd` / `.error`                                                                           |
-| `ydb.auth.token.fetch.failures`         | Counter   | `{failure}`   | `ydb.auth.provider`, `error.type`                                     | `ydb:auth.provider.failed`                                                                                                   |
-| `ydb.auth.token.expirations`            | Counter   | `{expiration}`| `ydb.auth.provider`                                                   | `ydb:auth.token.expired`                                                                                                     |
-| `ydb.retry.attempts`                    | Counter   | `{attempt}`   | `ydb.idempotent`, `ydb.retry.outcome` ∈ {success, retried, exhausted, non_retryable} | `ydb:retry.attempt.completed`                                                                                                |
-| `ydb.retry.duration`                    | Histogram | `s`           | `ydb.idempotent`, `ydb.retry.outcome`                                 | `tracing:ydb:retry.run.asyncEnd` / `.error` (end-to-end, including backoffs)                                                 |
+| Instrument                             | Kind      | Unit           | Tags (beyond identity)                                                               | Source                                                                                                                                                                                                                                                                                                                      |
+| -------------------------------------- | --------- | -------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `db.client.operation.duration`         | Histogram | `s`            | `db.operation.name`, `error.type`?                                                   | every leaf CLIENT tracing channel: `query.{execute,begin,commit,rollback,session.create,session.delete}` and `driver.discovery`. Auth token fetch is its own INTERNAL span recorded by `ydb.auth.token.fetch.duration` below — not a database operation. Uses the OTel-standard metric so off-the-shelf db dashboards work. |
+| `ydb.driver.connection.pessimizations` | Counter   | `{event}`      | _(none)_                                                                             | `ydb:driver.connection.pessimized`                                                                                                                                                                                                                                                                                          |
+| `ydb.query.session.create.duration`    | Histogram | `s`            | _(none)_                                                                             | `tracing:ydb:query.session.create.asyncEnd`                                                                                                                                                                                                                                                                                 |
+| `ydb.query.session.acquire.duration`   | Histogram | `s`            | _(none)_                                                                             | `tracing:ydb:query.session.acquire.asyncEnd`                                                                                                                                                                                                                                                                                |
+| `ydb.query.session.closed`             | Counter   | `{session}`    | `ydb.session.close.reason`                                                           | `ydb:query.session.closed`                                                                                                                                                                                                                                                                                                  |
+| `ydb.query.session.acquire.failures`   | Counter   | `{failure}`    | `error.type`                                                                         | `ydb:query.session.acquire.failed` (caller-aborted acquires are not published, so they do not count as failures)                                                                                                                                                                                                            |
+| `ydb.auth.token.fetch.duration`        | Histogram | `s`            | `ydb.auth.provider`, `error.type`?                                                   | `tracing:ydb:auth.token.fetch.asyncEnd` / `.error`                                                                                                                                                                                                                                                                          |
+| `ydb.auth.token.fetch.failures`        | Counter   | `{failure}`    | `ydb.auth.provider`, `error.type`                                                    | `ydb:auth.provider.failed`                                                                                                                                                                                                                                                                                                  |
+| `ydb.auth.token.expirations`           | Counter   | `{expiration}` | `ydb.auth.provider`                                                                  | `ydb:auth.token.expired`                                                                                                                                                                                                                                                                                                    |
+| `ydb.retry.attempts`                   | Counter   | `{attempt}`    | `ydb.idempotent`, `ydb.retry.outcome` ∈ {success, retried, exhausted, non_retryable} | `ydb:retry.attempt.completed`                                                                                                                                                                                                                                                                                               |
+| `ydb.retry.duration`                   | Histogram | `s`            | `ydb.idempotent`, `ydb.retry.outcome`                                                | `tracing:ydb:retry.run.asyncEnd` / `.error` (end-to-end, including backoffs)                                                                                                                                                                                                                                                |
 
 ### Observable instruments
 
@@ -144,19 +146,19 @@ registries (`ConnectionPoolRegistry` for the gRPC connection pool,
 that's an explicit trade-off vs. introducing a "snapshot" channel. Register
 telemetry at process start (the standard pattern) to avoid the gap.
 
-| Instrument                            | Kind                       | Unit           | Tags                                                       | State updated by                                                                                                |
-| ------------------------------------- | -------------------------- | -------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `ydb.driver.connection.count`         | ObservableUpDownCounter    | `{connection}` | `ydb.connection.state` ∈ {`live`, `pessimized`}            | `ydb:driver.connection.{added,pessimized,unpessimized,retired,removed}`; entry deleted on `ydb:driver.closed`   |
-| `ydb.query.session.count`             | ObservableUpDownCounter    | `{session}`    | `ydb.session.state` ∈ {`idle`, `acquired`, `creating`}     | `ydb:query.session.{created,closed,acquired,released}` + hooks on `tracing:ydb:query.session.create`            |
-| `ydb.query.session.acquire.pending`   | ObservableUpDownCounter    | `{request}`    | _(identity only)_                                          | `ydb:query.session.waiter.{enqueued,dequeued}`                                                                  |
-| `ydb.query.session.max`               | ObservableGauge            | `{session}`    | _(identity only)_                                          | `ydb:query.session.pool.opened` snapshot                                                                        |
-| `ydb.query.session.min`               | ObservableGauge            | `{session}`    | _(identity only)_                                          | `ydb:query.session.pool.opened` snapshot                                                                        |
+| Instrument                          | Kind                    | Unit           | Tags                                                   | State updated by                                                                                              |
+| ----------------------------------- | ----------------------- | -------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `ydb.driver.connection.count`       | ObservableUpDownCounter | `{connection}` | `ydb.connection.state` ∈ {`live`, `pessimized`}        | `ydb:driver.connection.{added,pessimized,unpessimized,retired,removed}`; entry deleted on `ydb:driver.closed` |
+| `ydb.query.session.count`           | ObservableUpDownCounter | `{session}`    | `ydb.session.state` ∈ {`idle`, `acquired`, `creating`} | `ydb:query.session.{created,closed,acquired,released}` + hooks on `tracing:ydb:query.session.create`          |
+| `ydb.query.session.acquire.pending` | ObservableUpDownCounter | `{request}`    | _(identity only)_                                      | `ydb:query.session.waiter.{enqueued,dequeued}`                                                                |
+| `ydb.query.session.max`             | ObservableGauge         | `{session}`    | _(identity only)_                                      | `ydb:query.session.pool.opened` snapshot                                                                      |
+| `ydb.query.session.min`             | ObservableGauge         | `{session}`    | _(identity only)_                                      | `ydb:query.session.pool.opened` snapshot                                                                      |
 
 ### Cardinality budget
 
 All tag values are bounded and safe to ingest at high request rates:
 
-- `db.operation.name` — 10 fixed strings (Query.*, Discovery.ListEndpoints, Auth.TokenFetch)
+- `db.operation.name` — 10 fixed strings (Query.\*, Discovery.ListEndpoints, Auth.TokenFetch)
 - `ydb.session.close.reason` — 4 strings (`pool_close`, `attach_failed`, `stream_closed`, `stream_error`)
 - `ydb.retry.outcome` — 4 strings
 - `ydb.connection.state` — 2 strings

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,0 +1,69 @@
+{
+	"name": "@ydbjs/telemetry",
+	"version": "0.1.0",
+	"description": "OpenTelemetry tracing for YDB JavaScript SDK. Subscribes to ydbjs diagnostics channels and emits OTel spans.",
+	"keywords": [
+		"opentelemetry",
+		"otel",
+		"telemetry",
+		"tracing",
+		"ydb"
+	],
+	"homepage": "https://github.com/ydb-platform/ydb-js-sdk#readme",
+	"bugs": {
+		"url": "https://github.com/ydb-platform/ydb-js-sdk/issues"
+	},
+	"license": "Apache-2.0",
+	"author": "YDB Team <team@ydb.tech> (https://ydb.tech)",
+	"contributors": [
+		"Vladislav Polyakov <me@polrk.com>"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/ydb-platform/ydb-js-sdk.git",
+		"directory": "packages/telemetry"
+	},
+	"files": [
+		"dist",
+		"README.md",
+		"CHANGELOG.md"
+	],
+	"type": "module",
+	"sideEffects": false,
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": "./dist/index.js",
+		"./register": "./dist/register.js"
+	},
+	"publishConfig": {
+		"access": "public",
+		"registry": "https://registry.npmjs.org/"
+	},
+	"scripts": {
+		"clean": "rm -rf dist",
+		"build": "tsc",
+		"test": "vitest --run",
+		"attw": "attw --pack --profile esm-only"
+	},
+	"dependencies": {
+		"@opentelemetry/api": "^1.9.0",
+		"@opentelemetry/instrumentation": "^0.57.0",
+		"@opentelemetry/semantic-conventions": "^1.32.0",
+		"@ydbjs/api": "^6.0.0",
+		"@ydbjs/core": "^6.0.0",
+		"@ydbjs/error": "^6.0.0",
+		"nice-grpc": "^2.1.13"
+	},
+	"devDependencies": {
+		"@opentelemetry/sdk-metrics": "^2.7.0",
+		"@opentelemetry/sdk-trace-base": "^2.0.0",
+		"@opentelemetry/sdk-trace-node": "^2.0.0",
+		"@types/debug": "^4.1.12"
+	},
+	"engines": {
+		"node": ">=20.19.0",
+		"npm": ">=10"
+	},
+	"engineStrict": true
+}

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ydbjs/telemetry",
-	"version": "0.1.0",
+	"version": "6.0.0",
 	"description": "OpenTelemetry tracing for YDB JavaScript SDK. Subscribes to ydbjs diagnostics channels and emits OTel spans.",
 	"keywords": [
 		"opentelemetry",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -56,6 +56,8 @@
 		"nice-grpc": "^2.1.13"
 	},
 	"devDependencies": {
+		"@opentelemetry/context-async-hooks": "^2.7.1",
+		"@opentelemetry/core": "^2.7.0",
 		"@opentelemetry/sdk-metrics": "^2.7.0",
 		"@opentelemetry/sdk-trace-base": "^2.0.0",
 		"@opentelemetry/sdk-trace-node": "^2.0.0",

--- a/packages/telemetry/src/channels.ts
+++ b/packages/telemetry/src/channels.ts
@@ -5,6 +5,7 @@ import {
 	ATTR_NETWORK_PEER_ADDRESS,
 } from '@opentelemetry/semantic-conventions'
 
+import { leafOperation } from './operations.js'
 import {
 	ATTR_YDB_AUTH_PROVIDER,
 	ATTR_YDB_DISCOVERY_ADDED_COUNT,
@@ -53,21 +54,27 @@ export type ChannelTableOptions = {
 	emitAcquireSessionSpan: boolean
 }
 
-/**
- * `db.operation.name` is service-qualified (`Query.ExecuteQuery`) so the
- * Table service can later coexist with Query without ambiguity — both
- * expose `BeginTransaction` etc.
- */
+// Build a CLIENT-leaf row. `channel` and `span` come from the canonical
+// `LEAF_OPERATIONS` table, and `ATTR_DB_OPERATION_NAME` is prefilled from
+// the same entry, so adding a new operation only requires editing
+// `operations.ts`. `extra` contributes the per-row payload attributes.
+function leafRow<T>(channel: string, extra?: (ctx: T) => Attributes): TracingChannelEntry {
+	let op = leafOperation(channel)
+	let attrs = (ctx: T): Attributes => ({
+		[ATTR_DB_OPERATION_NAME]: op.operation,
+		...(extra?.(ctx) ?? {}),
+	})
+	return {
+		channel: op.channel,
+		span: op.span,
+		kind: SpanKind.CLIENT,
+		attrs: attrs as (ctx: never) => Attributes,
+	}
+}
+
 export function buildTracingChannels(opts: ChannelTableOptions): TracingChannelEntry[] {
 	let table: TracingChannelEntry[] = [
-		{
-			channel: 'tracing:ydb:driver.discovery',
-			span: 'ydb.Discovery',
-			kind: SpanKind.CLIENT,
-			attrs: () => ({
-				[ATTR_DB_OPERATION_NAME]: 'Discovery.ListEndpoints',
-			}),
-		},
+		leafRow('tracing:ydb:driver.discovery'),
 		{
 			channel: 'tracing:ydb:retry.run',
 			span: 'ydb.RunWithRetry',
@@ -94,80 +101,57 @@ export function buildTracingChannels(opts: ChannelTableOptions): TracingChannelE
 				[ATTR_YDB_IDEMPOTENT]: ctx.idempotent,
 			}),
 		},
-		{
-			channel: 'tracing:ydb:query.begin',
-			span: 'ydb.Begin',
-			kind: SpanKind.CLIENT,
-			attrs: (ctx: { sessionId: string; nodeId: bigint; isolation: string }) => ({
-				[ATTR_DB_OPERATION_NAME]: 'Query.BeginTransaction',
+		leafRow(
+			'tracing:ydb:query.begin',
+			(ctx: { sessionId: string; nodeId: bigint; isolation: string }) => ({
 				[ATTR_YDB_SESSION_ID]: ctx.sessionId,
 				[ATTR_YDB_NODE_ID]: Number(ctx.nodeId),
 				[ATTR_YDB_ISOLATION]: ctx.isolation,
-			}),
-		},
-		{
-			channel: 'tracing:ydb:query.execute',
-			span: 'ydb.ExecuteQuery',
-			kind: SpanKind.CLIENT,
-			attrs: (ctx: {
+			})
+		),
+		leafRow(
+			'tracing:ydb:query.execute',
+			(ctx: {
 				text: string
 				sessionId: string
 				nodeId: bigint
 				idempotent: boolean
 				isolation: string
 			}) => ({
-				[ATTR_DB_OPERATION_NAME]: 'Query.ExecuteQuery',
-				[ATTR_DB_QUERY_TEXT]: opts.captureQueryText ? ctx.text : undefined,
 				[ATTR_YDB_SESSION_ID]: ctx.sessionId,
 				[ATTR_YDB_NODE_ID]: Number(ctx.nodeId),
 				[ATTR_YDB_IDEMPOTENT]: ctx.idempotent,
 				[ATTR_YDB_ISOLATION]: ctx.isolation,
-			}),
-		},
-		{
-			channel: 'tracing:ydb:query.commit',
-			span: 'ydb.Commit',
-			kind: SpanKind.CLIENT,
-			attrs: (ctx: { sessionId: string; nodeId: bigint; txId: string }) => ({
-				[ATTR_DB_OPERATION_NAME]: 'Query.CommitTransaction',
+				...(opts.captureQueryText ? { [ATTR_DB_QUERY_TEXT]: ctx.text } : {}),
+			})
+		),
+		leafRow(
+			'tracing:ydb:query.commit',
+			(ctx: { sessionId: string; nodeId: bigint; txId: string }) => ({
 				[ATTR_YDB_SESSION_ID]: ctx.sessionId,
 				[ATTR_YDB_NODE_ID]: Number(ctx.nodeId),
 				[ATTR_YDB_TRANSACTION_ID]: ctx.txId,
-			}),
-		},
-		{
-			channel: 'tracing:ydb:query.rollback',
-			span: 'ydb.Rollback',
-			kind: SpanKind.CLIENT,
-			attrs: (ctx: { sessionId: string; nodeId: bigint; txId: string }) => ({
-				[ATTR_DB_OPERATION_NAME]: 'Query.RollbackTransaction',
+			})
+		),
+		leafRow(
+			'tracing:ydb:query.rollback',
+			(ctx: { sessionId: string; nodeId: bigint; txId: string }) => ({
 				[ATTR_YDB_SESSION_ID]: ctx.sessionId,
 				[ATTR_YDB_NODE_ID]: Number(ctx.nodeId),
 				[ATTR_YDB_TRANSACTION_ID]: ctx.txId,
-			}),
-		},
-		{
-			channel: 'tracing:ydb:query.session.create',
-			span: 'ydb.CreateSession',
-			kind: SpanKind.CLIENT,
-			attrs: () => ({
-				[ATTR_DB_OPERATION_NAME]: 'Query.CreateSession',
-			}),
-		},
-		{
-			channel: 'tracing:ydb:query.session.delete',
-			span: 'ydb.DeleteSession',
-			kind: SpanKind.CLIENT,
-			attrs: (ctx: { sessionId: string; nodeId: bigint; reason: string; uptime: number }) => ({
-				[ATTR_DB_OPERATION_NAME]: 'Query.DeleteSession',
+			})
+		),
+		leafRow('tracing:ydb:query.session.create'),
+		leafRow(
+			'tracing:ydb:query.session.delete',
+			(ctx: { sessionId: string; nodeId: bigint; reason: string; uptime: number }) => ({
 				[ATTR_YDB_SESSION_ID]: ctx.sessionId,
 				[ATTR_YDB_NODE_ID]: Number(ctx.nodeId),
 				[ATTR_YDB_SESSION_CLOSE_REASON]: ctx.reason,
-				// Durations on the dc bus are in ms (Node convention); OTel
-				// expects seconds. All `/ 1000` below sit at that boundary.
+				// `uptime` arrives in ms (dc-bus convention); OTel expects seconds.
 				[ATTR_YDB_SESSION_UPTIME]: ctx.uptime / 1000,
-			}),
-		},
+			})
+		),
 		{
 			channel: 'tracing:ydb:auth.token.fetch',
 			span: 'ydb.TokenFetch',

--- a/packages/telemetry/src/channels.ts
+++ b/packages/telemetry/src/channels.ts
@@ -22,6 +22,7 @@ import {
 	ATTR_YDB_NODE_ID,
 	ATTR_YDB_RETRY_ATTEMPT,
 	ATTR_YDB_RETRY_ATTEMPTS_TOTAL,
+	ATTR_YDB_RETRY_BACKOFF,
 	ATTR_YDB_RETRY_TOTAL_DURATION,
 	ATTR_YDB_SESSION_CLOSE_REASON,
 	ATTR_YDB_SESSION_ID,
@@ -87,9 +88,11 @@ export function buildTracingChannels(opts: ChannelTableOptions): TracingChannelE
 			channel: 'tracing:ydb:retry.attempt',
 			span: 'ydb.Try',
 			kind: SpanKind.INTERNAL,
-			attrs: (ctx: { attempt: number; idempotent: boolean }) => ({
+			attrs: (ctx: { attempt: number; idempotent: boolean; backoffMs: number }) => ({
 				[ATTR_YDB_RETRY_ATTEMPT]: ctx.attempt,
 				[ATTR_YDB_IDEMPOTENT]: ctx.idempotent,
+				// ms on the dc bus, seconds on OTel.
+				[ATTR_YDB_RETRY_BACKOFF]: ctx.backoffMs / 1000,
 			}),
 		},
 		{

--- a/packages/telemetry/src/channels.ts
+++ b/packages/telemetry/src/channels.ts
@@ -1,0 +1,292 @@
+import { type Attributes, type Span, SpanKind } from '@opentelemetry/api'
+import {
+	ATTR_DB_OPERATION_NAME,
+	ATTR_DB_QUERY_TEXT,
+	ATTR_NETWORK_PEER_ADDRESS,
+} from '@opentelemetry/semantic-conventions'
+
+import {
+	ATTR_YDB_AUTH_PROVIDER,
+	ATTR_YDB_DISCOVERY_ADDED_COUNT,
+	ATTR_YDB_DISCOVERY_DURATION,
+	ATTR_YDB_DISCOVERY_REMOVED_COUNT,
+	ATTR_YDB_DISCOVERY_TOTAL_COUNT,
+	ATTR_YDB_DRIVER_CONNECTION_PESSIMIZATION_DURATION,
+	ATTR_YDB_DRIVER_CONNECTION_PESSIMIZATION_UNTIL,
+	ATTR_YDB_DRIVER_CONNECTION_REMOVE_REASON,
+	ATTR_YDB_DRIVER_CONNECTION_RETIRE_REASON,
+	ATTR_YDB_IDEMPOTENT,
+	ATTR_YDB_ISOLATION,
+	ATTR_YDB_NODE_DC,
+	ATTR_YDB_NODE_ID,
+	ATTR_YDB_RETRY_ATTEMPT,
+	ATTR_YDB_RETRY_ATTEMPTS_TOTAL,
+	ATTR_YDB_RETRY_TOTAL_DURATION,
+	ATTR_YDB_SESSION_CLOSE_REASON,
+	ATTR_YDB_SESSION_ID,
+	ATTR_YDB_SESSION_UPTIME,
+	ATTR_YDB_TRANSACTION_ID,
+	EVENT_YDB_DRIVER_CONNECTION_ADDED,
+	EVENT_YDB_DRIVER_CONNECTION_PESSIMIZED,
+	EVENT_YDB_DRIVER_CONNECTION_REMOVED,
+	EVENT_YDB_DRIVER_CONNECTION_RETIRED,
+	EVENT_YDB_DRIVER_CONNECTION_UNPESSIMIZED,
+} from './semconv/index.js'
+
+// `ctx: never` makes every row's stricter `(ctx: T) => Attributes` assignable
+// to this signature; the trace pipeline narrows it via `ctx as never` at the
+// call site, keeping `any` out of the public type.
+export type TracingChannelEntry = {
+	channel: string
+	span: string
+	kind: SpanKind
+	attrs?: (ctx: never) => Attributes
+}
+
+export type EventChannelEntry = {
+	channel: string
+	apply: (msg: never, span: Span) => void
+}
+
+export type ChannelTableOptions = {
+	captureQueryText: boolean
+	emitAcquireSessionSpan: boolean
+}
+
+/**
+ * `db.operation.name` is service-qualified (`Query.ExecuteQuery`) so the
+ * Table service can later coexist with Query without ambiguity — both
+ * expose `BeginTransaction` etc.
+ */
+export function buildTracingChannels(opts: ChannelTableOptions): TracingChannelEntry[] {
+	let table: TracingChannelEntry[] = [
+		{
+			channel: 'tracing:ydb:driver.discovery',
+			span: 'ydb.Discovery',
+			kind: SpanKind.CLIENT,
+			attrs: () => ({
+				[ATTR_DB_OPERATION_NAME]: 'Discovery.ListEndpoints',
+			}),
+		},
+		{
+			channel: 'tracing:ydb:retry.run',
+			span: 'ydb.RunWithRetry',
+			kind: SpanKind.INTERNAL,
+			attrs: (ctx: { idempotent: boolean }) => ({
+				[ATTR_YDB_IDEMPOTENT]: ctx.idempotent,
+			}),
+		},
+		{
+			channel: 'tracing:ydb:retry.attempt',
+			span: 'ydb.Try',
+			kind: SpanKind.INTERNAL,
+			attrs: (ctx: { attempt: number; idempotent: boolean }) => ({
+				[ATTR_YDB_RETRY_ATTEMPT]: ctx.attempt,
+				[ATTR_YDB_IDEMPOTENT]: ctx.idempotent,
+			}),
+		},
+		{
+			channel: 'tracing:ydb:query.transaction',
+			span: 'ydb.Transaction',
+			kind: SpanKind.CLIENT,
+			attrs: (ctx: { isolation: string; idempotent: boolean }) => ({
+				[ATTR_YDB_ISOLATION]: ctx.isolation,
+				[ATTR_YDB_IDEMPOTENT]: ctx.idempotent,
+			}),
+		},
+		{
+			channel: 'tracing:ydb:query.begin',
+			span: 'ydb.Begin',
+			kind: SpanKind.CLIENT,
+			attrs: (ctx: { sessionId: string; nodeId: bigint; isolation: string }) => ({
+				[ATTR_DB_OPERATION_NAME]: 'Query.BeginTransaction',
+				[ATTR_YDB_SESSION_ID]: ctx.sessionId,
+				[ATTR_YDB_NODE_ID]: Number(ctx.nodeId),
+				[ATTR_YDB_ISOLATION]: ctx.isolation,
+			}),
+		},
+		{
+			channel: 'tracing:ydb:query.execute',
+			span: 'ydb.ExecuteQuery',
+			kind: SpanKind.CLIENT,
+			attrs: (ctx: {
+				text: string
+				sessionId: string
+				nodeId: bigint
+				idempotent: boolean
+				isolation: string
+			}) => ({
+				[ATTR_DB_OPERATION_NAME]: 'Query.ExecuteQuery',
+				[ATTR_DB_QUERY_TEXT]: opts.captureQueryText ? ctx.text : undefined,
+				[ATTR_YDB_SESSION_ID]: ctx.sessionId,
+				[ATTR_YDB_NODE_ID]: Number(ctx.nodeId),
+				[ATTR_YDB_IDEMPOTENT]: ctx.idempotent,
+				[ATTR_YDB_ISOLATION]: ctx.isolation,
+			}),
+		},
+		{
+			channel: 'tracing:ydb:query.commit',
+			span: 'ydb.Commit',
+			kind: SpanKind.CLIENT,
+			attrs: (ctx: { sessionId: string; nodeId: bigint; txId: string }) => ({
+				[ATTR_DB_OPERATION_NAME]: 'Query.CommitTransaction',
+				[ATTR_YDB_SESSION_ID]: ctx.sessionId,
+				[ATTR_YDB_NODE_ID]: Number(ctx.nodeId),
+				[ATTR_YDB_TRANSACTION_ID]: ctx.txId,
+			}),
+		},
+		{
+			channel: 'tracing:ydb:query.rollback',
+			span: 'ydb.Rollback',
+			kind: SpanKind.CLIENT,
+			attrs: (ctx: { sessionId: string; nodeId: bigint; txId: string }) => ({
+				[ATTR_DB_OPERATION_NAME]: 'Query.RollbackTransaction',
+				[ATTR_YDB_SESSION_ID]: ctx.sessionId,
+				[ATTR_YDB_NODE_ID]: Number(ctx.nodeId),
+				[ATTR_YDB_TRANSACTION_ID]: ctx.txId,
+			}),
+		},
+		{
+			channel: 'tracing:ydb:query.session.create',
+			span: 'ydb.CreateSession',
+			kind: SpanKind.CLIENT,
+			attrs: () => ({
+				[ATTR_DB_OPERATION_NAME]: 'Query.CreateSession',
+			}),
+		},
+		{
+			channel: 'tracing:ydb:query.session.delete',
+			span: 'ydb.DeleteSession',
+			kind: SpanKind.CLIENT,
+			attrs: (ctx: { sessionId: string; nodeId: bigint; reason: string; uptime: number }) => ({
+				[ATTR_DB_OPERATION_NAME]: 'Query.DeleteSession',
+				[ATTR_YDB_SESSION_ID]: ctx.sessionId,
+				[ATTR_YDB_NODE_ID]: Number(ctx.nodeId),
+				[ATTR_YDB_SESSION_CLOSE_REASON]: ctx.reason,
+				// Durations on the dc bus are in ms (Node convention); OTel
+				// expects seconds. All `/ 1000` below sit at that boundary.
+				[ATTR_YDB_SESSION_UPTIME]: ctx.uptime / 1000,
+			}),
+		},
+		{
+			channel: 'tracing:ydb:auth.token.fetch',
+			span: 'ydb.TokenFetch',
+			kind: SpanKind.INTERNAL,
+			attrs: (ctx: { provider: string }) => ({
+				[ATTR_YDB_AUTH_PROVIDER]: ctx.provider,
+			}),
+		},
+	]
+
+	if (opts.emitAcquireSessionSpan) {
+		table.push({
+			channel: 'tracing:ydb:query.session.acquire',
+			span: 'ydb.AcquireSession',
+			kind: SpanKind.INTERNAL,
+		})
+	}
+
+	return table
+}
+
+// Rows that attach data to whichever span is currently active. "Summary"
+// payloads set attributes (discovery / retry totals); "point-in-time"
+// payloads become `span.addEvent`. Events fired with no active span are
+// dropped silently — that is the intended behaviour, since these channels
+// also feed metrics independently of any trace.
+export let EVENT_CHANNELS: EventChannelEntry[] = [
+	{
+		channel: 'ydb:driver.discovery.completed',
+		apply: (
+			msg: {
+				addedCount: number
+				removedCount: number
+				totalCount: number
+				duration: number
+			},
+			span
+		) => {
+			span.setAttributes({
+				[ATTR_YDB_DISCOVERY_ADDED_COUNT]: msg.addedCount,
+				[ATTR_YDB_DISCOVERY_REMOVED_COUNT]: msg.removedCount,
+				[ATTR_YDB_DISCOVERY_TOTAL_COUNT]: msg.totalCount,
+				[ATTR_YDB_DISCOVERY_DURATION]: msg.duration / 1000,
+			})
+		},
+	},
+	{
+		channel: 'ydb:retry.exhausted',
+		apply: (msg: { attempts: number; totalDuration: number }, span) => {
+			span.setAttributes({
+				[ATTR_YDB_RETRY_ATTEMPTS_TOTAL]: msg.attempts,
+				[ATTR_YDB_RETRY_TOTAL_DURATION]: msg.totalDuration / 1000,
+			})
+		},
+	},
+	{
+		channel: 'ydb:driver.connection.added',
+		apply: (msg: { nodeId: bigint; address: string; location: string }, span) => {
+			span.addEvent(EVENT_YDB_DRIVER_CONNECTION_ADDED, {
+				[ATTR_YDB_NODE_ID]: Number(msg.nodeId),
+				[ATTR_YDB_NODE_DC]: msg.location,
+				[ATTR_NETWORK_PEER_ADDRESS]: msg.address,
+			})
+		},
+	},
+	{
+		channel: 'ydb:driver.connection.pessimized',
+		apply: (
+			msg: { nodeId: bigint; address: string; location: string; until: number },
+			span
+		) => {
+			span.addEvent(EVENT_YDB_DRIVER_CONNECTION_PESSIMIZED, {
+				[ATTR_YDB_NODE_ID]: Number(msg.nodeId),
+				[ATTR_YDB_NODE_DC]: msg.location,
+				[ATTR_NETWORK_PEER_ADDRESS]: msg.address,
+				[ATTR_YDB_DRIVER_CONNECTION_PESSIMIZATION_UNTIL]: msg.until / 1000,
+			})
+		},
+	},
+	{
+		channel: 'ydb:driver.connection.unpessimized',
+		apply: (
+			msg: { nodeId: bigint; address: string; location: string; duration: number },
+			span
+		) => {
+			span.addEvent(EVENT_YDB_DRIVER_CONNECTION_UNPESSIMIZED, {
+				[ATTR_YDB_NODE_ID]: Number(msg.nodeId),
+				[ATTR_YDB_NODE_DC]: msg.location,
+				[ATTR_NETWORK_PEER_ADDRESS]: msg.address,
+				[ATTR_YDB_DRIVER_CONNECTION_PESSIMIZATION_DURATION]: msg.duration / 1000,
+			})
+		},
+	},
+	{
+		channel: 'ydb:driver.connection.retired',
+		apply: (
+			msg: { nodeId: bigint; address: string; location: string; reason: string },
+			span
+		) => {
+			span.addEvent(EVENT_YDB_DRIVER_CONNECTION_RETIRED, {
+				[ATTR_YDB_NODE_ID]: Number(msg.nodeId),
+				[ATTR_YDB_NODE_DC]: msg.location,
+				[ATTR_NETWORK_PEER_ADDRESS]: msg.address,
+				[ATTR_YDB_DRIVER_CONNECTION_RETIRE_REASON]: msg.reason,
+			})
+		},
+	},
+	{
+		channel: 'ydb:driver.connection.removed',
+		apply: (
+			msg: { nodeId: bigint; address: string; location: string; reason: string },
+			span
+		) => {
+			span.addEvent(EVENT_YDB_DRIVER_CONNECTION_REMOVED, {
+				[ATTR_YDB_NODE_ID]: Number(msg.nodeId),
+				[ATTR_YDB_NODE_DC]: msg.location,
+				[ATTR_NETWORK_PEER_ADDRESS]: msg.address,
+				[ATTR_YDB_DRIVER_CONNECTION_REMOVE_REASON]: msg.reason,
+			})
+		},
+	},
+]

--- a/packages/telemetry/src/channels.ts
+++ b/packages/telemetry/src/channels.ts
@@ -122,7 +122,10 @@ export function buildTracingChannels(opts: ChannelTableOptions): TracingChannelE
 				[ATTR_YDB_NODE_ID]: Number(ctx.nodeId),
 				[ATTR_YDB_IDEMPOTENT]: ctx.idempotent,
 				[ATTR_YDB_ISOLATION]: ctx.isolation,
-				...(opts.captureQueryText ? { [ATTR_DB_QUERY_TEXT]: ctx.text } : {}),
+				// Undefined attribute values are dropped by the OTel SDK; this is
+				// the hot path so we avoid the extra `{}` literal that a
+				// conditional spread would allocate every call.
+				[ATTR_DB_QUERY_TEXT]: opts.captureQueryText ? ctx.text : undefined,
 			})
 		),
 		leafRow(

--- a/packages/telemetry/src/context.ts
+++ b/packages/telemetry/src/context.ts
@@ -1,0 +1,16 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+import type { Span } from '@opentelemetry/api'
+
+/**
+ * Active subscriber span, propagated across async continuations via
+ * `tracingChannel.bindStore`. We keep our own ALS instead of reusing
+ * OTel's context because channel handlers are discrete events — there's no
+ * function for `context.with(ctx, fn)` to wrap, and `enterWith` isn't part
+ * of OTel's public API.
+ */
+export let spanStorage = new AsyncLocalStorage<Span>()
+
+export function getActiveSubscriberSpan(): Span | undefined {
+	return spanStorage.getStore()
+}

--- a/packages/telemetry/src/context.ts
+++ b/packages/telemetry/src/context.ts
@@ -8,8 +8,12 @@ import type { Span } from '@opentelemetry/api'
  * OTel's context because channel handlers are discrete events — there's no
  * function for `context.with(ctx, fn)` to wrap, and `enterWith` isn't part
  * of OTel's public API.
+ *
+ * Stored value is `Span | undefined` because the bindStore transform may
+ * return `undefined` when span creation throws — children then transparently
+ * fall back to `context.active()` instead of seeing a poisoned parent.
  */
-export let spanStorage = new AsyncLocalStorage<Span>()
+export let spanStorage = new AsyncLocalStorage<Span | undefined>()
 
 export function getActiveSubscriberSpan(): Span | undefined {
 	return spanStorage.getStore()

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -1,0 +1,17 @@
+import { YdbInstrumentation, type YdbInstrumentationConfig } from './instrumentation.js'
+
+export { recordErrorAttributes } from './semconv/index.js'
+export { getActiveSubscriberSpan } from './context.js'
+export { YdbInstrumentation, type YdbInstrumentationConfig } from './instrumentation.js'
+
+/**
+ * Sugar over `new YdbInstrumentation(opts).enable()` for one-shot
+ * registration. Use `registerInstrumentations()` from
+ * @opentelemetry/instrumentation if you want to wire several instrumentations
+ * together.
+ */
+export function register(opts?: YdbInstrumentationConfig): YdbInstrumentation {
+	let instrumentation = new YdbInstrumentation(opts)
+	instrumentation.enable()
+	return instrumentation
+}

--- a/packages/telemetry/src/instrumentation.ts
+++ b/packages/telemetry/src/instrumentation.ts
@@ -1,0 +1,62 @@
+import { InstrumentationBase, type InstrumentationConfig } from '@opentelemetry/instrumentation'
+
+import pkg from '../package.json' with { type: 'json' }
+
+import { YdbMetricsPipeline } from './metrics.js'
+import { YdbTracesPipeline } from './traces.js'
+
+export type YdbInstrumentationConfig = InstrumentationConfig & {
+	/**
+	 * Include raw query text as `db.query.text`. Default `false`.
+	 * Query text can carry PII (literals interpolated by the user), so the
+	 * safe default is to omit. Enable per environment when you control the
+	 * data flowing through.
+	 */
+	captureQueryText?: boolean
+	/**
+	 * Emit `ydb.AcquireSession` span. Default `false`.
+	 * Session acquisition is almost always instant (warm pool hit), so the
+	 * span is noise in 99% of traces. Turn on only when debugging session-
+	 * pool starvation.
+	 */
+	emitAcquireSessionSpan?: boolean
+}
+
+export class YdbInstrumentation extends InstrumentationBase<YdbInstrumentationConfig> {
+	#traces: YdbTracesPipeline | undefined
+	#metrics: YdbMetricsPipeline | undefined
+
+	constructor(config: YdbInstrumentationConfig = {}) {
+		// Defer `enable()` until our private fields are constructed —
+		// `InstrumentationBase` would otherwise call it from inside super().
+		super(pkg.name, pkg.version, { ...config, enabled: false })
+		if (config.enabled !== false) this.enable()
+	}
+
+	protected init(): undefined {
+		return undefined
+	}
+
+	override enable(): void {
+		super.enable()
+		if (this.#traces || this.#metrics) return
+
+		let cfg = this.getConfig()
+		this.#traces = new YdbTracesPipeline(this.tracer, this._diag, {
+			captureQueryText: cfg.captureQueryText ?? false,
+			emitAcquireSessionSpan: cfg.emitAcquireSessionSpan ?? false,
+		})
+		this.#traces.enable()
+
+		this.#metrics = new YdbMetricsPipeline(this.meter)
+		this.#metrics.enable()
+	}
+
+	override disable(): void {
+		super.disable()
+		this.#traces?.disable()
+		this.#traces = undefined
+		this.#metrics?.disable()
+		this.#metrics = undefined
+	}
+}

--- a/packages/telemetry/src/instrumentation.ts
+++ b/packages/telemetry/src/instrumentation.ts
@@ -1,8 +1,10 @@
 import { InstrumentationBase, type InstrumentationConfig } from '@opentelemetry/instrumentation'
+import { addClientMiddleware } from '@ydbjs/core'
 
 import pkg from '../package.json' with { type: 'json' }
 
 import { YdbMetricsPipeline } from './metrics.js'
+import { propagator } from './propagation.js'
 import { YdbTracesPipeline } from './traces.js'
 
 export type YdbInstrumentationConfig = InstrumentationConfig & {
@@ -25,6 +27,7 @@ export type YdbInstrumentationConfig = InstrumentationConfig & {
 export class YdbInstrumentation extends InstrumentationBase<YdbInstrumentationConfig> {
 	#traces: YdbTracesPipeline | undefined
 	#metrics: YdbMetricsPipeline | undefined
+	#propagatorHandle: Disposable | undefined
 
 	constructor(config: YdbInstrumentationConfig = {}) {
 		// Defer `enable()` until our private fields are constructed —
@@ -50,6 +53,8 @@ export class YdbInstrumentation extends InstrumentationBase<YdbInstrumentationCo
 
 		this.#metrics = new YdbMetricsPipeline(this.meter)
 		this.#metrics.enable()
+
+		this.#propagatorHandle = addClientMiddleware(propagator)
 	}
 
 	override disable(): void {
@@ -58,5 +63,7 @@ export class YdbInstrumentation extends InstrumentationBase<YdbInstrumentationCo
 		this.#traces = undefined
 		this.#metrics?.disable()
 		this.#metrics = undefined
+		this.#propagatorHandle?.[Symbol.dispose]()
+		this.#propagatorHandle = undefined
 	}
 }

--- a/packages/telemetry/src/metrics.ts
+++ b/packages/telemetry/src/metrics.ts
@@ -28,6 +28,7 @@ import {
 	METRIC_YDB_AUTH_TOKEN_EXPIRATIONS,
 	METRIC_YDB_AUTH_TOKEN_FETCH_DURATION,
 	METRIC_YDB_AUTH_TOKEN_FETCH_FAILURES,
+	METRIC_YDB_AUTH_TOKEN_REFRESHES,
 	METRIC_YDB_DRIVER_CONNECTION_COUNT,
 	METRIC_YDB_DRIVER_CONNECTION_PESSIMIZATIONS,
 	METRIC_YDB_QUERY_SESSION_ACQUIRE_DURATION,
@@ -74,6 +75,7 @@ export class YdbMetricsPipeline {
 	#sessionClosed!: Counter
 	#sessionAcquireFailures!: Counter
 	#authTokenFetchFailures!: Counter
+	#authTokenRefreshes!: Counter
 	#authTokenExpirations!: Counter
 	#retryAttempts!: Counter
 
@@ -167,6 +169,12 @@ export class YdbMetricsPipeline {
 				unit: '{failure}',
 			}
 		)
+		this.#authTokenRefreshes = this.#meter.createCounter(METRIC_YDB_AUTH_TOKEN_REFRESHES, {
+			description:
+				'Successful token refreshes. Direct rate signal; complements ' +
+				'ydb.auth.token.fetch.duration which records both successes and failures.',
+			unit: '{refresh}',
+		})
 		this.#authTokenExpirations = this.#meter.createCounter(METRIC_YDB_AUTH_TOKEN_EXPIRATIONS, {
 			description: 'Incidents where a stale (past hard expiry buffer) token was served.',
 			unit: '{expiration}',
@@ -509,6 +517,14 @@ export class YdbMetricsPipeline {
 		this.#subs.push(
 			this.#subPlain<{ provider: string }>('ydb:auth.token.expired', (msg) =>
 				this.#authTokenExpirations.add(1, {
+					...BASE_ATTRIBUTES,
+					[ATTR_YDB_AUTH_PROVIDER]: msg.provider,
+				})
+			)
+		)
+		this.#subs.push(
+			this.#subPlain<{ provider: string }>('ydb:auth.token.refreshed', (msg) =>
+				this.#authTokenRefreshes.add(1, {
 					...BASE_ATTRIBUTES,
 					[ATTR_YDB_AUTH_PROVIDER]: msg.provider,
 				})

--- a/packages/telemetry/src/metrics.ts
+++ b/packages/telemetry/src/metrics.ts
@@ -1,0 +1,541 @@
+import { channel as plainChannel, tracingChannel } from 'node:diagnostics_channel'
+
+import type {
+	BatchObservableResult,
+	Counter,
+	Histogram,
+	Meter,
+	MetricAttributes,
+	ObservableGauge,
+	ObservableUpDownCounter,
+} from '@opentelemetry/api'
+import {
+	ATTR_DB_NAMESPACE,
+	ATTR_DB_OPERATION_NAME,
+	ATTR_SERVER_ADDRESS,
+	ATTR_SERVER_PORT,
+} from '@opentelemetry/semantic-conventions'
+
+import type { DriverIdentity } from '@ydbjs/core'
+
+import { ConnectionPoolRegistry } from './state/connection-pool.js'
+import { SessionPoolRegistry } from './state/session-pool.js'
+import {
+	ATTR_YDB_AUTH_PROVIDER,
+	ATTR_YDB_CONNECTION_STATE,
+	ATTR_YDB_IDEMPOTENT,
+	ATTR_YDB_RETRY_OUTCOME,
+	ATTR_YDB_SESSION_CLOSE_REASON,
+	ATTR_YDB_SESSION_STATE,
+	BASE_ATTRIBUTES,
+	METRIC_DB_CLIENT_OPERATION_DURATION,
+	METRIC_YDB_AUTH_TOKEN_EXPIRATIONS,
+	METRIC_YDB_AUTH_TOKEN_FETCH_DURATION,
+	METRIC_YDB_AUTH_TOKEN_FETCH_FAILURES,
+	METRIC_YDB_DRIVER_CONNECTION_COUNT,
+	METRIC_YDB_DRIVER_CONNECTION_PESSIMIZATIONS,
+	METRIC_YDB_QUERY_SESSION_ACQUIRE_DURATION,
+	METRIC_YDB_QUERY_SESSION_ACQUIRE_FAILURES,
+	METRIC_YDB_QUERY_SESSION_ACQUIRE_PENDING,
+	METRIC_YDB_QUERY_SESSION_CLOSED,
+	METRIC_YDB_QUERY_SESSION_COUNT,
+	METRIC_YDB_QUERY_SESSION_CREATE_DURATION,
+	METRIC_YDB_QUERY_SESSION_MAX,
+	METRIC_YDB_QUERY_SESSION_MIN,
+	METRIC_YDB_RETRY_ATTEMPTS,
+	METRIC_YDB_RETRY_DURATION,
+	recordErrorAttributes,
+} from './semconv/index.js'
+
+function identityAttrs(driver: DriverIdentity | undefined): MetricAttributes {
+	if (!driver) return {}
+	let attrs: MetricAttributes = {
+		[ATTR_DB_NAMESPACE]: driver.database,
+		[ATTR_SERVER_ADDRESS]: driver.address,
+	}
+	if (driver.port !== undefined) attrs[ATTR_SERVER_PORT] = driver.port
+	return attrs
+}
+
+function baseFor(driver: DriverIdentity | undefined): MetricAttributes {
+	return { ...BASE_ATTRIBUTES, ...identityAttrs(driver) }
+}
+
+const LEAF_OPERATION_CHANNELS: ReadonlyArray<{ channel: string; operation: string }> = [
+	{ channel: 'tracing:ydb:driver.discovery', operation: 'Discovery.ListEndpoints' },
+	{ channel: 'tracing:ydb:query.begin', operation: 'Query.BeginTransaction' },
+	{ channel: 'tracing:ydb:query.execute', operation: 'Query.ExecuteQuery' },
+	{ channel: 'tracing:ydb:query.commit', operation: 'Query.CommitTransaction' },
+	{ channel: 'tracing:ydb:query.rollback', operation: 'Query.RollbackTransaction' },
+	{ channel: 'tracing:ydb:query.session.create', operation: 'Query.CreateSession' },
+	{ channel: 'tracing:ydb:query.session.delete', operation: 'Query.DeleteSession' },
+]
+
+type DurationCtx = { driver?: DriverIdentity }
+
+/**
+ * Metrics pipeline. Owns OTel instruments and subscribes `diagnostics_channel`
+ * events into them. State for observable instruments is split per domain —
+ * connection-pool vs session-pool — and is rebuilt from channel events only,
+ * never by reaching into pool internals. Late subscribers therefore miss the
+ * initial state of an already-running driver.
+ */
+export class YdbMetricsPipeline {
+	#meter: Meter
+	#connectionState = new ConnectionPoolRegistry()
+	#sessionState = new SessionPoolRegistry()
+	#subs: Disposable[] = []
+	#observableSubs: Disposable[] = []
+
+	#dbClientOperationDuration!: Histogram
+	#sessionCreateDuration!: Histogram
+	#sessionAcquireDuration!: Histogram
+	#authTokenFetchDuration!: Histogram
+	#retryDuration!: Histogram
+
+	#connectionPessimizations!: Counter
+	#sessionClosed!: Counter
+	#sessionAcquireFailures!: Counter
+	#authTokenFetchFailures!: Counter
+	#authTokenExpirations!: Counter
+	#retryAttempts!: Counter
+
+	#connectionCount!: ObservableUpDownCounter
+	#sessionCount!: ObservableUpDownCounter
+	#sessionAcquirePending!: ObservableUpDownCounter
+	#sessionMax!: ObservableGauge
+	#sessionMin!: ObservableGauge
+
+	constructor(meter: Meter) {
+		this.#meter = meter
+		this.#registerInstruments()
+	}
+
+	enable(): void {
+		if (this.#subs.length > 0) return
+		this.#subscribeLeafDurations()
+		this.#subscribeConnectionEvents()
+		this.#subscribeSessionEvents()
+		this.#subscribeAuthEvents()
+		this.#subscribeRetryEvents()
+		this.#registerObservableCallbacks()
+	}
+
+	disable(): void {
+		for (let s of this.#subs) s[Symbol.dispose]()
+		this.#subs.length = 0
+		for (let s of this.#observableSubs) s[Symbol.dispose]()
+		this.#observableSubs.length = 0
+	}
+
+	#registerInstruments(): void {
+		this.#dbClientOperationDuration = this.#meter.createHistogram(
+			METRIC_DB_CLIENT_OPERATION_DURATION,
+			{
+				description: 'Duration of each client-side YDB operation attempt.',
+				unit: 's',
+			}
+		)
+		this.#sessionCreateDuration = this.#meter.createHistogram(
+			METRIC_YDB_QUERY_SESSION_CREATE_DURATION,
+			{
+				description: 'Time to create a query session (CreateSession + AttachStream first message).',
+				unit: 's',
+			}
+		)
+		this.#sessionAcquireDuration = this.#meter.createHistogram(
+			METRIC_YDB_QUERY_SESSION_ACQUIRE_DURATION,
+			{
+				description: 'Time to acquire a session lease from the pool.',
+				unit: 's',
+			}
+		)
+		this.#authTokenFetchDuration = this.#meter.createHistogram(
+			METRIC_YDB_AUTH_TOKEN_FETCH_DURATION,
+			{
+				description: 'Duration of a token fetch / refresh.',
+				unit: 's',
+			}
+		)
+		this.#retryDuration = this.#meter.createHistogram(METRIC_YDB_RETRY_DURATION, {
+			description: 'End-to-end duration of a retry loop including backoffs.',
+			unit: 's',
+		})
+
+		this.#connectionPessimizations = this.#meter.createCounter(
+			METRIC_YDB_DRIVER_CONNECTION_PESSIMIZATIONS,
+			{
+				description: 'Count of connection pessimization events.',
+				unit: '{event}',
+			}
+		)
+		this.#sessionClosed = this.#meter.createCounter(METRIC_YDB_QUERY_SESSION_CLOSED, {
+			description: 'Count of session removals, tagged by close reason.',
+			unit: '{session}',
+		})
+		this.#sessionAcquireFailures = this.#meter.createCounter(
+			METRIC_YDB_QUERY_SESSION_ACQUIRE_FAILURES,
+			{
+				description:
+					'Failed session acquires (pool full / pool-internal timeout / pool closed), tagged by error.type. ' +
+					'Caller-aborted acquires are not counted as failures — see ydb:query.session.acquire.failed.',
+				unit: '{failure}',
+			}
+		)
+		this.#authTokenFetchFailures = this.#meter.createCounter(
+			METRIC_YDB_AUTH_TOKEN_FETCH_FAILURES,
+			{
+				description: 'Failed token fetch / refresh attempts.',
+				unit: '{failure}',
+			}
+		)
+		this.#authTokenExpirations = this.#meter.createCounter(METRIC_YDB_AUTH_TOKEN_EXPIRATIONS, {
+			description: 'Incidents where a stale (past hard expiry buffer) token was served.',
+			unit: '{expiration}',
+		})
+		this.#retryAttempts = this.#meter.createCounter(METRIC_YDB_RETRY_ATTEMPTS, {
+			description: 'Count of retry attempts tagged with outcome.',
+			unit: '{attempt}',
+		})
+
+		this.#connectionCount = this.#meter.createObservableUpDownCounter(
+			METRIC_YDB_DRIVER_CONNECTION_COUNT,
+			{
+				description: 'Current count of pooled gRPC connections, by state.',
+				unit: '{connection}',
+			}
+		)
+		this.#sessionCount = this.#meter.createObservableUpDownCounter(METRIC_YDB_QUERY_SESSION_COUNT, {
+			description: 'Current count of live query sessions in the pool, by state.',
+			unit: '{session}',
+		})
+		this.#sessionAcquirePending = this.#meter.createObservableUpDownCounter(
+			METRIC_YDB_QUERY_SESSION_ACQUIRE_PENDING,
+			{
+				description: 'Callers currently waiting for a session lease.',
+				unit: '{request}',
+			}
+		)
+		this.#sessionMax = this.#meter.createObservableGauge(METRIC_YDB_QUERY_SESSION_MAX, {
+			description: 'Configured maxSize of the session pool.',
+			unit: '{session}',
+		})
+		this.#sessionMin = this.#meter.createObservableGauge(METRIC_YDB_QUERY_SESSION_MIN, {
+			description: 'Configured minSize of the session pool.',
+			unit: '{session}',
+		})
+	}
+
+	#registerObservableCallbacks(): void {
+		let cb = (observable: BatchObservableResult) => {
+			for (let [driver, state] of this.#connectionState.connections()) {
+				let base = baseFor(driver)
+				observable.observe(this.#connectionCount, state.live, {
+					...base,
+					[ATTR_YDB_CONNECTION_STATE]: 'live',
+				})
+				observable.observe(this.#connectionCount, state.pessimized, {
+					...base,
+					[ATTR_YDB_CONNECTION_STATE]: 'pessimized',
+				})
+			}
+			for (let [driver, state] of this.#sessionState.sessions()) {
+				let base = baseFor(driver)
+				let idle = Math.max(0, state.total - state.acquired)
+				observable.observe(this.#sessionCount, idle, {
+					...base,
+					[ATTR_YDB_SESSION_STATE]: 'idle',
+				})
+				observable.observe(this.#sessionCount, state.acquired, {
+					...base,
+					[ATTR_YDB_SESSION_STATE]: 'acquired',
+				})
+				observable.observe(this.#sessionCount, state.creating, {
+					...base,
+					[ATTR_YDB_SESSION_STATE]: 'creating',
+				})
+				observable.observe(this.#sessionAcquirePending, state.waiters, base)
+				observable.observe(this.#sessionMax, state.maxSize, base)
+				observable.observe(this.#sessionMin, state.minSize, base)
+			}
+		}
+		this.#meter.addBatchObservableCallback(cb, [
+			this.#connectionCount,
+			this.#sessionCount,
+			this.#sessionAcquirePending,
+			this.#sessionMax,
+			this.#sessionMin,
+		])
+		this.#observableSubs.push({
+			[Symbol.dispose]: () => {
+				this.#meter.removeBatchObservableCallback(cb, [
+					this.#connectionCount,
+					this.#sessionCount,
+					this.#sessionAcquirePending,
+					this.#sessionMax,
+					this.#sessionMin,
+				])
+			},
+		})
+	}
+
+	#subPlain<T>(name: string, fn: (msg: T) => void): Disposable {
+		let ch = plainChannel(name)
+		let handler = (msg: unknown) => fn(msg as T)
+		ch.subscribe(handler)
+		return {
+			[Symbol.dispose]() {
+				ch.unsubscribe(handler)
+			},
+		}
+	}
+
+	#subDuration(
+		channelName: string,
+		instrument: Histogram,
+		makeAttrs: (ctx: DurationCtx) => MetricAttributes,
+		hooks?: { onStart?: (ctx: DurationCtx) => void; onEnd?: (ctx: DurationCtx) => void }
+	): Disposable {
+		let ch = tracingChannel<DurationCtx, DurationCtx>(channelName)
+		// Per-subscription WeakMap, not a pipeline-wide one. The same channel
+		// can be subscribed twice (e.g. session.create feeds both the generic
+		// `db.client.operation.duration` and the specific
+		// `ydb.query.session.create.duration` instruments). Both subscriptions
+		// see the same ctx in `start` and `asyncEnd`; a shared map would let
+		// whichever handler runs first delete the entry before the other reads
+		// it, and the second instrument would silently drop the recording.
+		let starts = new WeakMap<object, number>()
+		let handlers = {
+			start: (ctx: DurationCtx) => {
+				starts.set(ctx, performance.now())
+				hooks?.onStart?.(ctx)
+			},
+			asyncEnd: (ctx: DurationCtx) => {
+				try {
+					let started = starts.get(ctx)
+					if (started === undefined) return
+					starts.delete(ctx)
+					let durationMs = performance.now() - started
+					instrument.record(durationMs / 1000, makeAttrs(ctx))
+				} finally {
+					hooks?.onEnd?.(ctx)
+				}
+			},
+			error: (ctx: DurationCtx & { error?: unknown }) => {
+				try {
+					let started = starts.get(ctx)
+					if (started === undefined) return
+					starts.delete(ctx)
+					let durationMs = performance.now() - started
+					let attrs = makeAttrs(ctx)
+					instrument.record(durationMs / 1000, {
+						...attrs,
+						...recordErrorAttributes(ctx.error),
+					})
+				} finally {
+					hooks?.onEnd?.(ctx)
+				}
+			},
+		}
+		ch.subscribe(handlers as Parameters<typeof ch.subscribe>[0])
+		return {
+			[Symbol.dispose]() {
+				ch.unsubscribe(handlers as Parameters<typeof ch.unsubscribe>[0])
+			},
+		}
+	}
+
+	#subscribeLeafDurations(): void {
+		for (let { channel, operation } of LEAF_OPERATION_CHANNELS) {
+			this.#subs.push(
+				this.#subDuration(channel, this.#dbClientOperationDuration, (ctx) => ({
+					...baseFor(ctx.driver),
+					[ATTR_DB_OPERATION_NAME]: operation,
+				}))
+			)
+		}
+
+		// `session.create.duration` shares its source channel with the generic
+		// `db.client.operation.duration` so dashboards can pivot on either
+		// without filtering. The hooks also drive the `creating` observable.
+		this.#subs.push(
+			this.#subDuration(
+				'tracing:ydb:query.session.create',
+				this.#sessionCreateDuration,
+				(ctx) => baseFor(ctx.driver),
+				{
+					onStart: (ctx) => {
+						if (ctx.driver) this.#sessionState.createStarted(ctx.driver)
+					},
+					onEnd: (ctx) => {
+						if (ctx.driver) this.#sessionState.createEnded(ctx.driver)
+					},
+				}
+			)
+		)
+
+		this.#subs.push(
+			this.#subDuration(
+				'tracing:ydb:query.session.acquire',
+				this.#sessionAcquireDuration,
+				(ctx) => baseFor(ctx.driver)
+			)
+		)
+
+		this.#subs.push(
+			this.#subDuration(
+				'tracing:ydb:auth.token.fetch',
+				this.#authTokenFetchDuration,
+				(ctx: DurationCtx & { provider?: string }) => ({
+					...baseFor(ctx.driver),
+					...(ctx.provider !== undefined ? { [ATTR_YDB_AUTH_PROVIDER]: ctx.provider } : {}),
+				})
+			)
+		)
+
+		this.#subs.push(
+			this.#subDuration(
+				'tracing:ydb:retry.run',
+				this.#retryDuration,
+				(ctx: DurationCtx & { idempotent?: boolean; outcome?: string }) => ({
+					...BASE_ATTRIBUTES,
+					...(ctx.idempotent !== undefined ? { [ATTR_YDB_IDEMPOTENT]: ctx.idempotent } : {}),
+					...(ctx.outcome !== undefined ? { [ATTR_YDB_RETRY_OUTCOME]: ctx.outcome } : {}),
+				})
+			)
+		)
+	}
+
+	#subscribeConnectionEvents(): void {
+		this.#subs.push(
+			this.#subPlain<{ driver: DriverIdentity }>('ydb:driver.connection.added', (msg) =>
+				this.#connectionState.connectionAdded(msg.driver)
+			)
+		)
+		this.#subs.push(
+			this.#subPlain<{ driver: DriverIdentity }>('ydb:driver.connection.pessimized', (msg) => {
+				this.#connectionState.connectionPessimized(msg.driver)
+				this.#connectionPessimizations.add(1, baseFor(msg.driver))
+			})
+		)
+		this.#subs.push(
+			this.#subPlain<{ driver: DriverIdentity }>('ydb:driver.connection.unpessimized', (msg) =>
+				this.#connectionState.connectionUnpessimized(msg.driver)
+			)
+		)
+		this.#subs.push(
+			this.#subPlain<{ driver: DriverIdentity }>('ydb:driver.connection.retired', (msg) =>
+				this.#connectionState.connectionRemoved(msg.driver)
+			)
+		)
+		this.#subs.push(
+			this.#subPlain<{ driver: DriverIdentity }>('ydb:driver.connection.removed', (msg) =>
+				this.#connectionState.connectionRemoved(msg.driver)
+			)
+		)
+		// Driver close is the safety net for the session registry: if the
+		// caller skipped `pool.close()` and let the driver dispose first, this
+		// keeps state from leaking.
+		this.#subs.push(
+			this.#subPlain<{ driver: DriverIdentity }>('ydb:driver.closed', (msg) => {
+				this.#connectionState.driverClosed(msg.driver)
+				this.#sessionState.driverClosed(msg.driver)
+			})
+		)
+	}
+
+	#subscribeSessionEvents(): void {
+		this.#subs.push(
+			this.#subPlain<{ driver: DriverIdentity; maxSize: number; minSize: number }>(
+				'ydb:query.session.pool.opened',
+				(msg) => this.#sessionState.poolOpened(msg.driver, msg.maxSize, msg.minSize)
+			)
+		)
+		this.#subs.push(
+			this.#subPlain<{ driver: DriverIdentity }>('ydb:query.session.pool.closed', (msg) =>
+				this.#sessionState.poolClosed(msg.driver)
+			)
+		)
+		this.#subs.push(
+			this.#subPlain<{ driver: DriverIdentity }>('ydb:query.session.created', (msg) =>
+				this.#sessionState.created(msg.driver)
+			)
+		)
+		this.#subs.push(
+			this.#subPlain<{ driver: DriverIdentity; reason: string }>(
+				'ydb:query.session.closed',
+				(msg) => {
+					this.#sessionState.closed(msg.driver)
+					this.#sessionClosed.add(1, {
+						...baseFor(msg.driver),
+						[ATTR_YDB_SESSION_CLOSE_REASON]: msg.reason,
+					})
+				}
+			)
+		)
+		this.#subs.push(
+			this.#subPlain<{ driver: DriverIdentity }>('ydb:query.session.acquired', (msg) =>
+				this.#sessionState.acquired(msg.driver)
+			)
+		)
+		this.#subs.push(
+			this.#subPlain<{ driver: DriverIdentity }>('ydb:query.session.released', (msg) =>
+				this.#sessionState.released(msg.driver)
+			)
+		)
+		this.#subs.push(
+			this.#subPlain<{ driver: DriverIdentity }>('ydb:query.session.waiter.enqueued', (msg) =>
+				this.#sessionState.waiterEnqueued(msg.driver)
+			)
+		)
+		this.#subs.push(
+			this.#subPlain<{ driver: DriverIdentity }>('ydb:query.session.waiter.dequeued', (msg) =>
+				this.#sessionState.waiterDequeued(msg.driver)
+			)
+		)
+		this.#subs.push(
+			this.#subPlain<{ driver: DriverIdentity; error: unknown }>(
+				'ydb:query.session.acquire.failed',
+				(msg) =>
+					this.#sessionAcquireFailures.add(1, {
+						...baseFor(msg.driver),
+						...recordErrorAttributes(msg.error),
+					})
+			)
+		)
+	}
+
+	#subscribeAuthEvents(): void {
+		this.#subs.push(
+			this.#subPlain<{ provider: string; error: unknown }>('ydb:auth.provider.failed', (msg) =>
+				this.#authTokenFetchFailures.add(1, {
+					...BASE_ATTRIBUTES,
+					[ATTR_YDB_AUTH_PROVIDER]: msg.provider,
+					...recordErrorAttributes(msg.error),
+				})
+			)
+		)
+		this.#subs.push(
+			this.#subPlain<{ provider: string }>('ydb:auth.token.expired', (msg) =>
+				this.#authTokenExpirations.add(1, {
+					...BASE_ATTRIBUTES,
+					[ATTR_YDB_AUTH_PROVIDER]: msg.provider,
+				})
+			)
+		)
+	}
+
+	#subscribeRetryEvents(): void {
+		this.#subs.push(
+			this.#subPlain<{ attempt: number; idempotent: boolean; outcome: string }>(
+				'ydb:retry.attempt.completed',
+				(msg) =>
+					this.#retryAttempts.add(1, {
+						...BASE_ATTRIBUTES,
+						[ATTR_YDB_IDEMPOTENT]: msg.idempotent,
+						[ATTR_YDB_RETRY_OUTCOME]: msg.outcome,
+					})
+			)
+		)
+	}
+}

--- a/packages/telemetry/src/metrics.ts
+++ b/packages/telemetry/src/metrics.ts
@@ -147,8 +147,14 @@ export class YdbMetricsPipeline {
 				description: 'Time to acquire a session lease from the pool.',
 				unit: 's',
 				advice: {
-					// Warm pool ≈ 0; high tail only when starved.
-					explicitBucketBoundaries: [0.0001, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5],
+					// Warm pool resolves in microseconds — keep sub-ms granularity at
+					// the low end. When the pool has capacity but no idle session,
+					// acquire encapsulates a full `session.create`, so the upper
+					// boundaries must cover create's tail (10s) and then some — 30s
+					// is reserved for genuine pool starvation under waiter timeout.
+					explicitBucketBoundaries: [
+						0.0001, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2.5, 5, 10, 30,
+					],
 				},
 			}
 		)

--- a/packages/telemetry/src/metrics.ts
+++ b/packages/telemetry/src/metrics.ts
@@ -108,11 +108,24 @@ export class YdbMetricsPipeline {
 	}
 
 	#registerInstruments(): void {
+		// Suggested bucket boundaries (seconds). Users can override via OTel
+		// Views — these are just defaults so the out-of-the-box histograms are
+		// usable. Without them the SDK falls back to its global ms-oriented
+		// default ([0, 5, 10, 25, ..., 10000]) which silently buckets every YDB
+		// op into the first slot.
 		this.#dbClientOperationDuration = this.#meter.createHistogram(
 			METRIC_DB_CLIENT_OPERATION_DURATION,
 			{
 				description: 'Duration of each client-side YDB operation attempt.',
 				unit: 's',
+				advice: {
+					// Dense middle (1ms–1s) where the bulk of YDB ops live, tail
+					// out to 60s for overload-backoff + slow queries.
+					explicitBucketBoundaries: [
+						0.0005, 0.001, 0.0025, 0.005, 0.0075, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25,
+						0.5, 0.75, 1, 2.5, 5, 7.5, 10, 30, 60,
+					],
+				},
 			}
 		)
 		this.#sessionCreateDuration = this.#meter.createHistogram(
@@ -121,6 +134,11 @@ export class YdbMetricsPipeline {
 				description:
 					'Time to create a query session (CreateSession + AttachStream first message).',
 				unit: 's',
+				advice: {
+					explicitBucketBoundaries: [
+						0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+					],
+				},
 			}
 		)
 		this.#sessionAcquireDuration = this.#meter.createHistogram(
@@ -128,6 +146,10 @@ export class YdbMetricsPipeline {
 			{
 				description: 'Time to acquire a session lease from the pool.',
 				unit: 's',
+				advice: {
+					// Warm pool ≈ 0; high tail only when starved.
+					explicitBucketBoundaries: [0.0001, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5],
+				},
 			}
 		)
 		this.#authTokenFetchDuration = this.#meter.createHistogram(
@@ -135,11 +157,18 @@ export class YdbMetricsPipeline {
 			{
 				description: 'Duration of a token fetch / refresh.',
 				unit: 's',
+				advice: {
+					explicitBucketBoundaries: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30],
+				},
 			}
 		)
 		this.#retryDuration = this.#meter.createHistogram(METRIC_YDB_RETRY_DURATION, {
 			description: 'End-to-end duration of a retry loop including backoffs.',
 			unit: 's',
+			advice: {
+				// Long tail — overload backoff can push a loop into minutes.
+				explicitBucketBoundaries: [0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30, 60, 300],
+			},
 		})
 
 		this.#connectionPessimizations = this.#meter.createCounter(

--- a/packages/telemetry/src/metrics.ts
+++ b/packages/telemetry/src/metrics.ts
@@ -9,12 +9,7 @@ import type {
 	ObservableGauge,
 	ObservableUpDownCounter,
 } from '@opentelemetry/api'
-import {
-	ATTR_DB_NAMESPACE,
-	ATTR_DB_OPERATION_NAME,
-	ATTR_SERVER_ADDRESS,
-	ATTR_SERVER_PORT,
-} from '@opentelemetry/semantic-conventions'
+import { ATTR_DB_OPERATION_NAME } from '@opentelemetry/semantic-conventions'
 
 import type { DriverIdentity } from '@ydbjs/core'
 
@@ -45,18 +40,9 @@ import {
 	METRIC_YDB_QUERY_SESSION_MIN,
 	METRIC_YDB_RETRY_ATTEMPTS,
 	METRIC_YDB_RETRY_DURATION,
+	identityAttrs,
 	recordErrorAttributes,
 } from './semconv/index.js'
-
-function identityAttrs(driver: DriverIdentity | undefined): MetricAttributes {
-	if (!driver) return {}
-	let attrs: MetricAttributes = {
-		[ATTR_DB_NAMESPACE]: driver.database,
-		[ATTR_SERVER_ADDRESS]: driver.address,
-	}
-	if (driver.port !== undefined) attrs[ATTR_SERVER_PORT] = driver.port
-	return attrs
-}
 
 function baseFor(driver: DriverIdentity | undefined): MetricAttributes {
 	return { ...BASE_ATTRIBUTES, ...identityAttrs(driver) }

--- a/packages/telemetry/src/metrics.ts
+++ b/packages/telemetry/src/metrics.ts
@@ -18,6 +18,7 @@ import {
 
 import type { DriverIdentity } from '@ydbjs/core'
 
+import { LEAF_OPERATIONS } from './operations.js'
 import { ConnectionPoolRegistry } from './state/connection-pool.js'
 import { SessionPoolRegistry } from './state/session-pool.js'
 import {
@@ -60,16 +61,6 @@ function identityAttrs(driver: DriverIdentity | undefined): MetricAttributes {
 function baseFor(driver: DriverIdentity | undefined): MetricAttributes {
 	return { ...BASE_ATTRIBUTES, ...identityAttrs(driver) }
 }
-
-const LEAF_OPERATION_CHANNELS: ReadonlyArray<{ channel: string; operation: string }> = [
-	{ channel: 'tracing:ydb:driver.discovery', operation: 'Discovery.ListEndpoints' },
-	{ channel: 'tracing:ydb:query.begin', operation: 'Query.BeginTransaction' },
-	{ channel: 'tracing:ydb:query.execute', operation: 'Query.ExecuteQuery' },
-	{ channel: 'tracing:ydb:query.commit', operation: 'Query.CommitTransaction' },
-	{ channel: 'tracing:ydb:query.rollback', operation: 'Query.RollbackTransaction' },
-	{ channel: 'tracing:ydb:query.session.create', operation: 'Query.CreateSession' },
-	{ channel: 'tracing:ydb:query.session.delete', operation: 'Query.DeleteSession' },
-]
 
 type DurationCtx = { driver?: DriverIdentity }
 
@@ -139,7 +130,8 @@ export class YdbMetricsPipeline {
 		this.#sessionCreateDuration = this.#meter.createHistogram(
 			METRIC_YDB_QUERY_SESSION_CREATE_DURATION,
 			{
-				description: 'Time to create a query session (CreateSession + AttachStream first message).',
+				description:
+					'Time to create a query session (CreateSession + AttachStream first message).',
 				unit: 's',
 			}
 		)
@@ -205,10 +197,13 @@ export class YdbMetricsPipeline {
 				unit: '{connection}',
 			}
 		)
-		this.#sessionCount = this.#meter.createObservableUpDownCounter(METRIC_YDB_QUERY_SESSION_COUNT, {
-			description: 'Current count of live query sessions in the pool, by state.',
-			unit: '{session}',
-		})
+		this.#sessionCount = this.#meter.createObservableUpDownCounter(
+			METRIC_YDB_QUERY_SESSION_COUNT,
+			{
+				description: 'Current count of live query sessions in the pool, by state.',
+				unit: '{session}',
+			}
+		)
 		this.#sessionAcquirePending = this.#meter.createObservableUpDownCounter(
 			METRIC_YDB_QUERY_SESSION_ACQUIRE_PENDING,
 			{
@@ -346,7 +341,7 @@ export class YdbMetricsPipeline {
 	}
 
 	#subscribeLeafDurations(): void {
-		for (let { channel, operation } of LEAF_OPERATION_CHANNELS) {
+		for (let { channel, operation } of LEAF_OPERATIONS) {
 			this.#subs.push(
 				this.#subDuration(channel, this.#dbClientOperationDuration, (ctx) => ({
 					...baseFor(ctx.driver),
@@ -388,7 +383,9 @@ export class YdbMetricsPipeline {
 				this.#authTokenFetchDuration,
 				(ctx: DurationCtx & { provider?: string }) => ({
 					...baseFor(ctx.driver),
-					...(ctx.provider !== undefined ? { [ATTR_YDB_AUTH_PROVIDER]: ctx.provider } : {}),
+					...(ctx.provider !== undefined
+						? { [ATTR_YDB_AUTH_PROVIDER]: ctx.provider }
+						: {}),
 				})
 			)
 		)
@@ -399,7 +396,9 @@ export class YdbMetricsPipeline {
 				this.#retryDuration,
 				(ctx: DurationCtx & { idempotent?: boolean; outcome?: string }) => ({
 					...BASE_ATTRIBUTES,
-					...(ctx.idempotent !== undefined ? { [ATTR_YDB_IDEMPOTENT]: ctx.idempotent } : {}),
+					...(ctx.idempotent !== undefined
+						? { [ATTR_YDB_IDEMPOTENT]: ctx.idempotent }
+						: {}),
 					...(ctx.outcome !== undefined ? { [ATTR_YDB_RETRY_OUTCOME]: ctx.outcome } : {}),
 				})
 			)
@@ -413,14 +412,18 @@ export class YdbMetricsPipeline {
 			)
 		)
 		this.#subs.push(
-			this.#subPlain<{ driver: DriverIdentity }>('ydb:driver.connection.pessimized', (msg) => {
-				this.#connectionState.connectionPessimized(msg.driver)
-				this.#connectionPessimizations.add(1, baseFor(msg.driver))
-			})
+			this.#subPlain<{ driver: DriverIdentity }>(
+				'ydb:driver.connection.pessimized',
+				(msg) => {
+					this.#connectionState.connectionPessimized(msg.driver)
+					this.#connectionPessimizations.add(1, baseFor(msg.driver))
+				}
+			)
 		)
 		this.#subs.push(
-			this.#subPlain<{ driver: DriverIdentity }>('ydb:driver.connection.unpessimized', (msg) =>
-				this.#connectionState.connectionUnpessimized(msg.driver)
+			this.#subPlain<{ driver: DriverIdentity }>(
+				'ydb:driver.connection.unpessimized',
+				(msg) => this.#connectionState.connectionUnpessimized(msg.driver)
 			)
 		)
 		this.#subs.push(
@@ -507,12 +510,14 @@ export class YdbMetricsPipeline {
 
 	#subscribeAuthEvents(): void {
 		this.#subs.push(
-			this.#subPlain<{ provider: string; error: unknown }>('ydb:auth.provider.failed', (msg) =>
-				this.#authTokenFetchFailures.add(1, {
-					...BASE_ATTRIBUTES,
-					[ATTR_YDB_AUTH_PROVIDER]: msg.provider,
-					...recordErrorAttributes(msg.error),
-				})
+			this.#subPlain<{ provider: string; error: unknown }>(
+				'ydb:auth.provider.failed',
+				(msg) =>
+					this.#authTokenFetchFailures.add(1, {
+						...BASE_ATTRIBUTES,
+						[ATTR_YDB_AUTH_PROVIDER]: msg.provider,
+						...recordErrorAttributes(msg.error),
+					})
 			)
 		)
 		this.#subs.push(

--- a/packages/telemetry/src/operations.ts
+++ b/packages/telemetry/src/operations.ts
@@ -1,0 +1,69 @@
+// Canonical table of CLIENT-leaf YDB operations. Each row binds a
+// `tracingChannel` name to its `db.operation.name` value and to the span
+// name we emit. Both the trace pipeline (channels.ts) and the metrics
+// pipeline (metrics.ts) pull from this table so adding a new leaf
+// operation cannot drift — forget the entry and the trace row loses its
+// `ATTR_DB_OPERATION_NAME`; forget the channel and `leafOperation()`
+// throws at module load.
+//
+// Only CLIENT-kind leaves live here. Parent / internal spans
+// (`query.transaction`, `retry.run`, `retry.attempt`, `auth.token.fetch`,
+// the optional `query.session.acquire`) are NOT operations — they do not
+// feed `db.client.operation.duration` and have no `db.operation.name`.
+
+export type LeafOperation = {
+	/** `tracingChannel` name (the `tracing:` prefix is included). */
+	channel: string
+	/** Value placed on `db.operation.name`. Service-qualified. */
+	operation: string
+	/** Span name (`ydb.*`). */
+	span: string
+}
+
+export let LEAF_OPERATIONS: ReadonlyArray<LeafOperation> = [
+	{
+		channel: 'tracing:ydb:driver.discovery',
+		operation: 'Discovery.ListEndpoints',
+		span: 'ydb.Discovery',
+	},
+	{ channel: 'tracing:ydb:query.begin', operation: 'Query.BeginTransaction', span: 'ydb.Begin' },
+	{
+		channel: 'tracing:ydb:query.execute',
+		operation: 'Query.ExecuteQuery',
+		span: 'ydb.ExecuteQuery',
+	},
+	{
+		channel: 'tracing:ydb:query.commit',
+		operation: 'Query.CommitTransaction',
+		span: 'ydb.Commit',
+	},
+	{
+		channel: 'tracing:ydb:query.rollback',
+		operation: 'Query.RollbackTransaction',
+		span: 'ydb.Rollback',
+	},
+	{
+		channel: 'tracing:ydb:query.session.create',
+		operation: 'Query.CreateSession',
+		span: 'ydb.CreateSession',
+	},
+	{
+		channel: 'tracing:ydb:query.session.delete',
+		operation: 'Query.DeleteSession',
+		span: 'ydb.DeleteSession',
+	},
+]
+
+let byChannel: ReadonlyMap<string, LeafOperation> = new Map(
+	LEAF_OPERATIONS.map((row) => [row.channel, row])
+)
+
+export function leafOperation(channel: string): LeafOperation {
+	let row = byChannel.get(channel)
+	if (!row) {
+		throw new Error(
+			`leafOperation: no entry for channel "${channel}". Add it to LEAF_OPERATIONS in operations.ts.`
+		)
+	}
+	return row
+}

--- a/packages/telemetry/src/propagation.ts
+++ b/packages/telemetry/src/propagation.ts
@@ -1,0 +1,24 @@
+import { context, propagation } from '@opentelemetry/api'
+import { type ClientMiddleware, Metadata } from 'nice-grpc'
+
+/**
+ * W3C trace context propagation middleware for `@ydbjs/core`'s gRPC client.
+ *
+ * Injects the active OTel context — `traceparent` / `tracestate` by default,
+ * plus any other propagator registered via `propagation.setGlobalPropagator`
+ * (Baggage, B3, AWS X-Amzn, …) — into outgoing gRPC metadata. Without a
+ * registered OTel SDK the global `propagation` is a no-op, so the middleware
+ * adds no headers and makes no allocations beyond the empty record passed
+ * to `inject`.
+ */
+export let propagator: ClientMiddleware = async function* (call, options) {
+	let metadata = Metadata(options.metadata)
+
+	propagation.inject(context.active(), metadata, {
+		set(carrier, key, value) {
+			carrier.set(key, String(value))
+		},
+	})
+
+	return yield* call.next(call.request, Object.assign(options, { metadata }))
+}

--- a/packages/telemetry/src/register.ts
+++ b/packages/telemetry/src/register.ts
@@ -1,0 +1,14 @@
+/**
+ * Auto-instrumentation entry point. Use with node --import to subscribe to
+ * all @ydbjs diagnostics channels without code changes:
+ *
+ *   node --import @opentelemetry/sdk-node/register \
+ *        --import @ydbjs/telemetry/register \
+ *        your-app.js
+ *
+ * The OTel SDK must be initialised before this file is imported so that
+ * the global tracer provider is already set up when register() runs.
+ */
+import { register } from './index.js'
+
+register()

--- a/packages/telemetry/src/semconv/common.test.ts
+++ b/packages/telemetry/src/semconv/common.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from 'vitest'
+
+import { ClientError, Status } from 'nice-grpc'
+
+import { StatusIds_StatusCode } from '@ydbjs/api/operation'
+import { YDBError } from '@ydbjs/error'
+
+import { BASE_ATTRIBUTES, recordErrorAttributes } from './common.ts'
+
+test('exposes only db.system.name on BASE_ATTRIBUTES', () => {
+	expect(BASE_ATTRIBUTES['db.system.name']).toBe('ydb')
+	expect(BASE_ATTRIBUTES['server.address']).toBeUndefined()
+})
+
+test('marks YDBError as ydb_error and carries the status code', () => {
+	let attrs = recordErrorAttributes(new YDBError(StatusIds_StatusCode.ABORTED, []))
+	expect(attrs['db.response.status_code']).toBe('ABORTED')
+	expect(attrs['error.type']).toBe('ydb_error')
+})
+
+test('marks ClientError as transport_error without a status code', () => {
+	let attrs = recordErrorAttributes(new ClientError('p', Status.UNAVAILABLE, 'down'))
+	expect(attrs['db.response.status_code']).toBeUndefined()
+	expect(attrs['error.type']).toBe('transport_error')
+})
+
+test('returns AbortError as error.type for cancellations', () => {
+	let e = new Error('aborted')
+	e.name = 'AbortError'
+	expect(recordErrorAttributes(e)['error.type']).toBe('AbortError')
+})
+
+test('returns TimeoutError as error.type for timeouts', () => {
+	let e = new Error('timed out')
+	e.name = 'TimeoutError'
+	expect(recordErrorAttributes(e)['error.type']).toBe('TimeoutError')
+})
+
+test('falls back to Error / unknown for plain Error and non-Error throws', () => {
+	expect(recordErrorAttributes(new Error('whatever'))['error.type']).toBe('Error')
+	expect(recordErrorAttributes('string')['error.type']).toBe('unknown')
+	expect(recordErrorAttributes(null)['error.type']).toBe('unknown')
+})

--- a/packages/telemetry/src/semconv/common.ts
+++ b/packages/telemetry/src/semconv/common.ts
@@ -1,11 +1,15 @@
 import type { Attributes } from '@opentelemetry/api'
 import {
+	ATTR_DB_NAMESPACE,
 	ATTR_DB_RESPONSE_STATUS_CODE,
 	ATTR_DB_SYSTEM_NAME,
 	ATTR_ERROR_TYPE,
+	ATTR_SERVER_ADDRESS,
+	ATTR_SERVER_PORT,
 } from '@opentelemetry/semantic-conventions'
 
 import type { StatusIds_StatusCode } from '@ydbjs/api/operation'
+import type { DriverIdentity } from '@ydbjs/core'
 import { YDBError } from '@ydbjs/error'
 import { ClientError } from 'nice-grpc'
 
@@ -20,6 +24,34 @@ export let BASE_ATTRIBUTES: BaseAttributes = { [ATTR_DB_SYSTEM_NAME]: 'ydb' }
 // introduce snake_case variants of the same concept.
 export let ATTR_YDB_NODE_ID = 'ydb.node.id'
 export let ATTR_YDB_NODE_DC = 'ydb.node.dc'
+
+/**
+ * Per-driver identity attributes (`db.namespace`, `server.address`,
+ * `server.port`). Returns an empty object when no identity is present so
+ * callers can spread the result unconditionally. Used by both the traces
+ * and the metrics pipeline.
+ */
+export function identityAttrs(driver: DriverIdentity | undefined): Attributes {
+	if (!driver) return {}
+	let attrs: Attributes = {
+		[ATTR_DB_NAMESPACE]: driver.database,
+		[ATTR_SERVER_ADDRESS]: driver.address,
+	}
+	if (driver.port !== undefined) attrs[ATTR_SERVER_PORT] = driver.port
+	return attrs
+}
+
+/**
+ * Coerce an arbitrary thrown value into an `Error` suitable for
+ * `span.recordException`. We do NOT stringify the value via its own
+ * `toString` because a custom implementation could leak secrets (tokens,
+ * credentials) into the recorded exception.
+ */
+export function coerceError(value: unknown): Error {
+	if (value instanceof Error) return value
+	if (typeof value === 'string') return new Error(value)
+	return new Error('non-Error throw')
+}
 
 /**
  * Error categories mirror ydb-dotnet:

--- a/packages/telemetry/src/semconv/common.ts
+++ b/packages/telemetry/src/semconv/common.ts
@@ -1,0 +1,53 @@
+import type { Attributes } from '@opentelemetry/api'
+import {
+	ATTR_DB_RESPONSE_STATUS_CODE,
+	ATTR_DB_SYSTEM_NAME,
+	ATTR_ERROR_TYPE,
+} from '@opentelemetry/semantic-conventions'
+
+import type { StatusIds_StatusCode } from '@ydbjs/api/operation'
+import { YDBError } from '@ydbjs/error'
+import { ClientError } from 'nice-grpc'
+
+// Keys used by BOTH pipelines live here. Span-only identifiers go in
+// `spans.ts`; metric-only tag enums go in `metrics.ts`.
+
+export type BaseAttributes = Attributes & { [ATTR_DB_SYSTEM_NAME]: 'ydb' }
+
+export let BASE_ATTRIBUTES: BaseAttributes = { [ATTR_DB_SYSTEM_NAME]: 'ydb' }
+
+// Dot-separated to match other YDB SDKs (ydb-dotnet, ydb-go); don't
+// introduce snake_case variants of the same concept.
+export let ATTR_YDB_NODE_ID = 'ydb.node.id'
+export let ATTR_YDB_NODE_DC = 'ydb.node.dc'
+
+/**
+ * Error categories mirror ydb-dotnet:
+ *   - `ydb_error`       — server returned a YDB status code
+ *   - `transport_error` — gRPC client/transport failure (no server response)
+ *   - error.name        — anything else (AbortError, TimeoutError, ...)
+ *
+ * `db.response.status_code` is set only in the first category.
+ */
+export function recordErrorAttributes(error: unknown): {
+	[ATTR_DB_RESPONSE_STATUS_CODE]?: string
+	[ATTR_ERROR_TYPE]: string
+} {
+	if (error instanceof YDBError) {
+		return {
+			[ATTR_DB_RESPONSE_STATUS_CODE]:
+				YDBError.codes[error.code as StatusIds_StatusCode] ?? 'STATUS_CODE_UNSPECIFIED',
+			[ATTR_ERROR_TYPE]: 'ydb_error',
+		}
+	}
+
+	if (error instanceof ClientError) {
+		return { [ATTR_ERROR_TYPE]: 'transport_error' }
+	}
+
+	if (error instanceof Error) {
+		return { [ATTR_ERROR_TYPE]: error.name || 'Error' }
+	}
+
+	return { [ATTR_ERROR_TYPE]: 'unknown' }
+}

--- a/packages/telemetry/src/semconv/events.ts
+++ b/packages/telemetry/src/semconv/events.ts
@@ -1,0 +1,17 @@
+// Point-in-time event names (first argument to `span.addEvent`) and the
+// attribute keys those events carry. Namespaced by component so the driver's
+// connection pool can't be confused with the query service's session pool.
+
+export let EVENT_YDB_DRIVER_CONNECTION_ADDED = 'ydb.driver.connection.added'
+export let EVENT_YDB_DRIVER_CONNECTION_PESSIMIZED = 'ydb.driver.connection.pessimized'
+export let EVENT_YDB_DRIVER_CONNECTION_UNPESSIMIZED = 'ydb.driver.connection.unpessimized'
+export let EVENT_YDB_DRIVER_CONNECTION_RETIRED = 'ydb.driver.connection.retired'
+export let EVENT_YDB_DRIVER_CONNECTION_REMOVED = 'ydb.driver.connection.removed'
+
+/** unix seconds */
+export let ATTR_YDB_DRIVER_CONNECTION_PESSIMIZATION_UNTIL = 'ydb.driver.connection.pessimization.until'
+/** seconds */
+export let ATTR_YDB_DRIVER_CONNECTION_PESSIMIZATION_DURATION = 'ydb.driver.connection.pessimization.duration'
+
+export let ATTR_YDB_DRIVER_CONNECTION_RETIRE_REASON = 'ydb.driver.connection.retire.reason'
+export let ATTR_YDB_DRIVER_CONNECTION_REMOVE_REASON = 'ydb.driver.connection.remove.reason'

--- a/packages/telemetry/src/semconv/index.ts
+++ b/packages/telemetry/src/semconv/index.ts
@@ -1,0 +1,4 @@
+export * from './common.js'
+export * from './spans.js'
+export * from './events.js'
+export * from './metrics.js'

--- a/packages/telemetry/src/semconv/metrics.ts
+++ b/packages/telemetry/src/semconv/metrics.ts
@@ -18,6 +18,7 @@ export let METRIC_YDB_DRIVER_CONNECTION_COUNT = 'ydb.driver.connection.count'
 
 export let METRIC_YDB_AUTH_TOKEN_FETCH_DURATION = 'ydb.auth.token.fetch.duration'
 export let METRIC_YDB_AUTH_TOKEN_FETCH_FAILURES = 'ydb.auth.token.fetch.failures'
+export let METRIC_YDB_AUTH_TOKEN_REFRESHES = 'ydb.auth.token.refreshes'
 export let METRIC_YDB_AUTH_TOKEN_EXPIRATIONS = 'ydb.auth.token.expirations'
 
 export let METRIC_YDB_RETRY_ATTEMPTS = 'ydb.retry.attempts'

--- a/packages/telemetry/src/semconv/metrics.ts
+++ b/packages/telemetry/src/semconv/metrics.ts
@@ -1,0 +1,29 @@
+// Metric instrument names and tag keys that exist only on metrics.
+// Tag keys shared with spans are declared in `spans.ts` / `common.ts` to
+// keep both pipelines pointed at one string.
+
+export let METRIC_DB_CLIENT_OPERATION_DURATION = 'db.client.operation.duration'
+
+export let METRIC_YDB_DRIVER_CONNECTION_PESSIMIZATIONS = 'ydb.driver.connection.pessimizations'
+
+export let METRIC_YDB_QUERY_SESSION_CREATE_DURATION = 'ydb.query.session.create.duration'
+export let METRIC_YDB_QUERY_SESSION_ACQUIRE_DURATION = 'ydb.query.session.acquire.duration'
+export let METRIC_YDB_QUERY_SESSION_ACQUIRE_PENDING = 'ydb.query.session.acquire.pending'
+export let METRIC_YDB_QUERY_SESSION_ACQUIRE_FAILURES = 'ydb.query.session.acquire.failures'
+export let METRIC_YDB_QUERY_SESSION_CLOSED = 'ydb.query.session.closed'
+export let METRIC_YDB_QUERY_SESSION_COUNT = 'ydb.query.session.count'
+export let METRIC_YDB_QUERY_SESSION_MAX = 'ydb.query.session.max'
+export let METRIC_YDB_QUERY_SESSION_MIN = 'ydb.query.session.min'
+export let METRIC_YDB_DRIVER_CONNECTION_COUNT = 'ydb.driver.connection.count'
+
+export let METRIC_YDB_AUTH_TOKEN_FETCH_DURATION = 'ydb.auth.token.fetch.duration'
+export let METRIC_YDB_AUTH_TOKEN_FETCH_FAILURES = 'ydb.auth.token.fetch.failures'
+export let METRIC_YDB_AUTH_TOKEN_EXPIRATIONS = 'ydb.auth.token.expirations'
+
+export let METRIC_YDB_RETRY_ATTEMPTS = 'ydb.retry.attempts'
+export let METRIC_YDB_RETRY_DURATION = 'ydb.retry.duration'
+
+export let ATTR_YDB_RETRY_OUTCOME = 'ydb.retry.outcome'
+
+export let ATTR_YDB_CONNECTION_STATE = 'ydb.connection.state'
+export let ATTR_YDB_SESSION_STATE = 'ydb.session.state'

--- a/packages/telemetry/src/semconv/spans.ts
+++ b/packages/telemetry/src/semconv/spans.ts
@@ -1,0 +1,27 @@
+// Attribute keys for spans (and channel events that fold into the active
+// span's attributes). Identifiers here MUST NOT cross over into metric
+// tags — `session.id` / `transaction.id` would blow the cardinality budget.
+
+export let ATTR_YDB_SESSION_ID = 'ydb.session.id'
+export let ATTR_YDB_TRANSACTION_ID = 'ydb.transaction.id'
+
+export let ATTR_YDB_ISOLATION = 'ydb.isolation'
+export let ATTR_YDB_IDEMPOTENT = 'ydb.idempotent'
+export let ATTR_YDB_AUTH_PROVIDER = 'ydb.auth.provider'
+
+export let ATTR_YDB_SESSION_CLOSE_REASON = 'ydb.session.close.reason'
+/** seconds */
+export let ATTR_YDB_SESSION_UPTIME = 'ydb.session.uptime'
+
+export let ATTR_YDB_DISCOVERY_ADDED_COUNT = 'ydb.discovery.added_count'
+export let ATTR_YDB_DISCOVERY_REMOVED_COUNT = 'ydb.discovery.removed_count'
+export let ATTR_YDB_DISCOVERY_TOTAL_COUNT = 'ydb.discovery.total_count'
+/** seconds */
+export let ATTR_YDB_DISCOVERY_DURATION = 'ydb.discovery.duration'
+
+export let ATTR_YDB_RETRY_ATTEMPT = 'ydb.retry.attempt'
+/** seconds */
+export let ATTR_YDB_RETRY_BACKOFF = 'ydb.retry.backoff'
+export let ATTR_YDB_RETRY_ATTEMPTS_TOTAL = 'ydb.retry.attempts_total'
+/** seconds */
+export let ATTR_YDB_RETRY_TOTAL_DURATION = 'ydb.retry.total_duration'

--- a/packages/telemetry/src/semconv/spans.ts
+++ b/packages/telemetry/src/semconv/spans.ts
@@ -20,8 +20,6 @@ export let ATTR_YDB_DISCOVERY_TOTAL_COUNT = 'ydb.discovery.total_count'
 export let ATTR_YDB_DISCOVERY_DURATION = 'ydb.discovery.duration'
 
 export let ATTR_YDB_RETRY_ATTEMPT = 'ydb.retry.attempt'
-/** seconds */
-export let ATTR_YDB_RETRY_BACKOFF = 'ydb.retry.backoff'
 export let ATTR_YDB_RETRY_ATTEMPTS_TOTAL = 'ydb.retry.attempts_total'
 /** seconds */
 export let ATTR_YDB_RETRY_TOTAL_DURATION = 'ydb.retry.total_duration'

--- a/packages/telemetry/src/semconv/spans.ts
+++ b/packages/telemetry/src/semconv/spans.ts
@@ -20,6 +20,8 @@ export let ATTR_YDB_DISCOVERY_TOTAL_COUNT = 'ydb.discovery.total_count'
 export let ATTR_YDB_DISCOVERY_DURATION = 'ydb.discovery.duration'
 
 export let ATTR_YDB_RETRY_ATTEMPT = 'ydb.retry.attempt'
+/** seconds — wait observed before this attempt started; `0` for attempt 1. */
+export let ATTR_YDB_RETRY_BACKOFF = 'ydb.retry.backoff'
 export let ATTR_YDB_RETRY_ATTEMPTS_TOTAL = 'ydb.retry.attempts_total'
 /** seconds */
 export let ATTR_YDB_RETRY_TOTAL_DURATION = 'ydb.retry.total_duration'

--- a/packages/telemetry/src/state/connection-pool.ts
+++ b/packages/telemetry/src/state/connection-pool.ts
@@ -1,0 +1,58 @@
+import type { DriverIdentity } from '@ydbjs/core'
+
+export type ConnectionState = {
+	live: number
+	pessimized: number
+}
+
+/**
+ * Per-driver state of the gRPC connection pool, rebuilt from
+ * `ydb:driver.connection.*` events. Keyed by `DriverIdentity` *reference*
+ * (Map identity), so callers must pass the same identity object that the
+ * publisher stamps on each payload.
+ */
+export class ConnectionPoolRegistry {
+	#connections = new Map<DriverIdentity, ConnectionState>()
+
+	connections(): ReadonlyMap<DriverIdentity, ConnectionState> {
+		return this.#connections
+	}
+
+	driverClosed(driver: DriverIdentity): void {
+		this.#connections.delete(driver)
+	}
+
+	connectionAdded(driver: DriverIdentity): void {
+		this.#get(driver).live += 1
+	}
+
+	connectionPessimized(driver: DriverIdentity): void {
+		let s = this.#get(driver)
+		s.live = Math.max(0, s.live - 1)
+		s.pessimized += 1
+	}
+
+	connectionUnpessimized(driver: DriverIdentity): void {
+		let s = this.#get(driver)
+		s.pessimized = Math.max(0, s.pessimized - 1)
+		s.live += 1
+	}
+
+	// `retired` and `removed` collapse into one transition: the connection is
+	// gone. The event doesn't carry the prior bucket, so we drain whichever
+	// has stock.
+	connectionRemoved(driver: DriverIdentity): void {
+		let s = this.#get(driver)
+		if (s.live > 0) s.live -= 1
+		else if (s.pessimized > 0) s.pessimized -= 1
+	}
+
+	#get(driver: DriverIdentity): ConnectionState {
+		let s = this.#connections.get(driver)
+		if (!s) {
+			s = { live: 0, pessimized: 0 }
+			this.#connections.set(driver, s)
+		}
+		return s
+	}
+}

--- a/packages/telemetry/src/state/session-pool.ts
+++ b/packages/telemetry/src/state/session-pool.ts
@@ -1,0 +1,96 @@
+import type { DriverIdentity } from '@ydbjs/core'
+
+export type SessionPoolState = {
+	/** Sessions registered with the pool (idle + busy). */
+	total: number
+	/** Sessions currently held by a `SessionLease`. */
+	acquired: number
+	/** In-flight `Session.open` calls. */
+	creating: number
+	/** Length of the wait queue. */
+	waiters: number
+	maxSize: number
+	minSize: number
+}
+
+let EMPTY: SessionPoolState = {
+	total: 0,
+	acquired: 0,
+	creating: 0,
+	waiters: 0,
+	maxSize: 0,
+	minSize: 0,
+}
+
+/**
+ * Per-driver state of the query session pool, rebuilt from
+ * `ydb:query.session.*` events. A future table-service session pool gets
+ * its own registry rather than sharing this one — the two pools have
+ * independent lifecycles. Keyed by `DriverIdentity` reference.
+ */
+export class SessionPoolRegistry {
+	#sessions = new Map<DriverIdentity, SessionPoolState>()
+
+	sessions(): ReadonlyMap<DriverIdentity, SessionPoolState> {
+		return this.#sessions
+	}
+
+	driverClosed(driver: DriverIdentity): void {
+		this.#sessions.delete(driver)
+	}
+
+	// `pool.opened` carries the authoritative max/min snapshot, so we replace
+	// any state from a prior pool generation on the same driver.
+	poolOpened(driver: DriverIdentity, maxSize: number, minSize: number): void {
+		this.#sessions.set(driver, { ...EMPTY, maxSize, minSize })
+	}
+
+	poolClosed(driver: DriverIdentity): void {
+		this.#sessions.delete(driver)
+	}
+
+	createStarted(driver: DriverIdentity): void {
+		this.#get(driver).creating += 1
+	}
+
+	createEnded(driver: DriverIdentity): void {
+		let s = this.#get(driver)
+		s.creating = Math.max(0, s.creating - 1)
+	}
+
+	created(driver: DriverIdentity): void {
+		this.#get(driver).total += 1
+	}
+
+	closed(driver: DriverIdentity): void {
+		let s = this.#get(driver)
+		s.total = Math.max(0, s.total - 1)
+	}
+
+	acquired(driver: DriverIdentity): void {
+		this.#get(driver).acquired += 1
+	}
+
+	released(driver: DriverIdentity): void {
+		let s = this.#get(driver)
+		s.acquired = Math.max(0, s.acquired - 1)
+	}
+
+	waiterEnqueued(driver: DriverIdentity): void {
+		this.#get(driver).waiters += 1
+	}
+
+	waiterDequeued(driver: DriverIdentity): void {
+		let s = this.#get(driver)
+		s.waiters = Math.max(0, s.waiters - 1)
+	}
+
+	#get(driver: DriverIdentity): SessionPoolState {
+		let s = this.#sessions.get(driver)
+		if (!s) {
+			s = { ...EMPTY }
+			this.#sessions.set(driver, s)
+		}
+		return s
+	}
+}

--- a/packages/telemetry/src/traces.ts
+++ b/packages/telemetry/src/traces.ts
@@ -8,11 +8,6 @@ import {
 	context,
 	trace,
 } from '@opentelemetry/api'
-import {
-	ATTR_DB_NAMESPACE,
-	ATTR_SERVER_ADDRESS,
-	ATTR_SERVER_PORT,
-} from '@opentelemetry/semantic-conventions'
 
 import type { DriverIdentity } from '@ydbjs/core'
 
@@ -23,7 +18,12 @@ import {
 	buildTracingChannels,
 } from './channels.js'
 import { getActiveSubscriberSpan, spanStorage } from './context.js'
-import { BASE_ATTRIBUTES, recordErrorAttributes } from './semconv/index.js'
+import {
+	BASE_ATTRIBUTES,
+	coerceError,
+	identityAttrs,
+	recordErrorAttributes,
+} from './semconv/index.js'
 
 export type YdbTracesPipelineOptions = {
 	captureQueryText: boolean
@@ -63,7 +63,9 @@ export class YdbTracesPipeline {
 	}
 
 	#subscribeTracing(entry: TracingChannelEntry): Disposable {
-		let ch = tracingChannel<object, Span>(entry.channel)
+		// StoreType=Span | undefined matches spanStorage; ContextType=object is
+		// the payload shape (each row's lambda narrows it).
+		let ch = tracingChannel<Span | undefined, object>(entry.channel)
 
 		// Skip `end` (it fires on callback return — too early for async fns,
 		// which would close the span before the awaited work runs) and
@@ -71,33 +73,38 @@ export class YdbTracesPipeline {
 		// `error` as well, but `#finish` is a no-op the second time because
 		// the WeakMap entry is already gone.
 		//
-		// The cast is load-bearing: `bindStore` may return `undefined` when
-		// `#safeCreateSpan` swallows a span-creation error, and children fall
-		// back to `context.active()` instead of seeing a poisoned parent.
-		ch.start.bindStore(spanStorage, (ctx) => this.#safeCreateSpan(entry, ctx) as Span)
+		// When `#safeCreateSpan` swallows a span-creation error, bindStore
+		// stores `undefined`; children fall back to `context.active()` via
+		// `getActiveSubscriberSpan`. No cast needed — the ALS type allows it.
+		ch.start.bindStore(spanStorage, (ctx) => this.#safeCreateSpan(entry, ctx))
 
-		let handlers = {
-			asyncEnd: (ctx: object) => {
+		// @types/node declares the start/end/asyncStart fields as required even
+		// though `subscribe` accepts a partial set at runtime — we only need
+		// `asyncEnd` and `error`, so we type the literal as Partial and open
+		// it to the full shape at the boundary.
+		type Subs = Parameters<typeof ch.subscribe>[0]
+		let handlers: Partial<Subs> = {
+			asyncEnd: (ctx) => {
 				try {
 					this.#finish(ctx, undefined)
 				} catch (err) {
 					this.#diag.error(`telemetry asyncEnd in ${entry.channel}`, err as Error)
 				}
 			},
-			error: (ctx: object) => {
+			error: (ctx) => {
 				try {
-					this.#finish(ctx, (ctx as { error?: unknown }).error)
+					this.#finish(ctx, ctx.error)
 				} catch (err) {
 					this.#diag.error(`telemetry error in ${entry.channel}`, err as Error)
 				}
 			},
 		}
 
-		ch.subscribe(handlers as unknown as Parameters<typeof ch.subscribe>[0])
+		ch.subscribe(handlers as Subs)
 
 		return {
 			[Symbol.dispose]() {
-				ch.unsubscribe(handlers as unknown as Parameters<typeof ch.unsubscribe>[0])
+				ch.unsubscribe(handlers as Subs)
 				ch.start.unbindStore(spanStorage)
 			},
 		}
@@ -136,22 +143,14 @@ export class YdbTracesPipeline {
 		}
 	}
 
-	#createSpan(entry: TracingChannelEntry, ctx: object): Span | undefined {
+	#createSpan(entry: TracingChannelEntry, ctx: object): Span {
 		// Identity rides in the payload, not in ALS — that's what makes
 		// multi-driver attribution work without producers having to wrap their
 		// own entry points in any subscriber context.
 		let identity = (ctx as { driver?: DriverIdentity }).driver
-		let driverAttrs = identity
-			? {
-					[ATTR_SERVER_ADDRESS]: identity.address,
-					...(identity.port !== undefined && { [ATTR_SERVER_PORT]: identity.port }),
-					[ATTR_DB_NAMESPACE]: identity.database,
-				}
-			: {}
-
 		let attrs = {
 			...BASE_ATTRIBUTES,
-			...driverAttrs,
+			...identityAttrs(identity),
 			...(entry.attrs ? entry.attrs(ctx as never) : {}),
 		}
 
@@ -172,17 +171,8 @@ export class YdbTracesPipeline {
 		let state = this.#stateMap.get(ctx)
 		if (!state) return
 		if (error !== undefined) {
-			let errAttrs = recordErrorAttributes(error)
-			state.span.setAttributes(errAttrs)
-			// Don't stringify arbitrary thrown values — a custom toString could
-			// dump secrets (tokens, credentials) into the recorded exception.
-			let recorded =
-				error instanceof Error
-					? error
-					: typeof error === 'string'
-						? new Error(error)
-						: new Error('non-Error throw')
-			state.span.recordException(recorded)
+			state.span.setAttributes(recordErrorAttributes(error))
+			state.span.recordException(coerceError(error))
 			state.span.setStatus({ code: SpanStatusCode.ERROR })
 		}
 		state.span.end()

--- a/packages/telemetry/src/traces.ts
+++ b/packages/telemetry/src/traces.ts
@@ -1,0 +1,191 @@
+import { channel as plainChannel, tracingChannel } from 'node:diagnostics_channel'
+
+import {
+	type DiagLogger,
+	type Span,
+	SpanStatusCode,
+	type Tracer,
+	context,
+	trace,
+} from '@opentelemetry/api'
+import {
+	ATTR_DB_NAMESPACE,
+	ATTR_SERVER_ADDRESS,
+	ATTR_SERVER_PORT,
+} from '@opentelemetry/semantic-conventions'
+
+import type { DriverIdentity } from '@ydbjs/core'
+
+import {
+	EVENT_CHANNELS,
+	type EventChannelEntry,
+	type TracingChannelEntry,
+	buildTracingChannels,
+} from './channels.js'
+import { getActiveSubscriberSpan, spanStorage } from './context.js'
+import { BASE_ATTRIBUTES, recordErrorAttributes } from './semconv/index.js'
+
+export type YdbTracesPipelineOptions = {
+	captureQueryText: boolean
+	emitAcquireSessionSpan: boolean
+}
+
+type SpanState = { span: Span }
+
+export class YdbTracesPipeline {
+	#tracer: Tracer
+	#diag: DiagLogger
+	#opts: YdbTracesPipelineOptions
+	#subs: Disposable[] = []
+	#stateMap: WeakMap<object, SpanState> = new WeakMap()
+
+	constructor(tracer: Tracer, diag: DiagLogger, opts: YdbTracesPipelineOptions) {
+		this.#tracer = tracer
+		this.#diag = diag
+		this.#opts = opts
+	}
+
+	enable(): void {
+		if (this.#subs.length > 0) return
+
+		let table = buildTracingChannels({
+			captureQueryText: this.#opts.captureQueryText,
+			emitAcquireSessionSpan: this.#opts.emitAcquireSessionSpan,
+		})
+
+		for (let entry of table) this.#subs.push(this.#subscribeTracing(entry))
+		for (let entry of EVENT_CHANNELS) this.#subs.push(this.#subscribeEvent(entry))
+	}
+
+	disable(): void {
+		for (let s of this.#subs) s[Symbol.dispose]()
+		this.#subs.length = 0
+	}
+
+	#subscribeTracing(entry: TracingChannelEntry): Disposable {
+		let ch = tracingChannel<object, Span>(entry.channel)
+
+		// Skip `end` (it fires on callback return — too early for async fns,
+		// which would close the span before the awaited work runs) and
+		// `asyncStart` (no trace-relevant signal). `asyncEnd` runs after
+		// `error` as well, but `#finish` is a no-op the second time because
+		// the WeakMap entry is already gone.
+		//
+		// The cast is load-bearing: `bindStore` may return `undefined` when
+		// `#safeCreateSpan` swallows a span-creation error, and children fall
+		// back to `context.active()` instead of seeing a poisoned parent.
+		ch.start.bindStore(spanStorage, (ctx) => this.#safeCreateSpan(entry, ctx) as Span)
+
+		let handlers = {
+			asyncEnd: (ctx: object) => {
+				try {
+					this.#finish(ctx, undefined)
+				} catch (err) {
+					this.#diag.error(`telemetry asyncEnd in ${entry.channel}`, err as Error)
+				}
+			},
+			error: (ctx: object) => {
+				try {
+					this.#finish(ctx, (ctx as { error?: unknown }).error)
+				} catch (err) {
+					this.#diag.error(`telemetry error in ${entry.channel}`, err as Error)
+				}
+			},
+		}
+
+		ch.subscribe(handlers as unknown as Parameters<typeof ch.subscribe>[0])
+
+		return {
+			[Symbol.dispose]() {
+				ch.unsubscribe(handlers as unknown as Parameters<typeof ch.unsubscribe>[0])
+				ch.start.unbindStore(spanStorage)
+			},
+		}
+	}
+
+	#subscribeEvent(entry: EventChannelEntry): Disposable {
+		let ch = plainChannel(entry.channel)
+		let diag = this.#diag
+
+		let fn = (msg: unknown) => {
+			try {
+				let span = getActiveSubscriberSpan()
+				if (span) entry.apply(msg as never, span)
+			} catch (err) {
+				diag.error(`telemetry event in ${entry.channel}`, err as Error)
+			}
+		}
+
+		ch.subscribe(fn)
+
+		return {
+			[Symbol.dispose]() {
+				ch.unsubscribe(fn)
+			},
+		}
+	}
+
+	// Swallows errors from #createSpan so a thrown attribute hook can't poison
+	// the parent ALS scope — children just see the prior active span.
+	#safeCreateSpan(entry: TracingChannelEntry, ctx: object): Span | undefined {
+		try {
+			return this.#createSpan(entry, ctx)
+		} catch (err) {
+			this.#diag.error(`telemetry start in ${entry.channel}`, err as Error)
+			return undefined
+		}
+	}
+
+	#createSpan(entry: TracingChannelEntry, ctx: object): Span | undefined {
+		// Identity rides in the payload, not in ALS — that's what makes
+		// multi-driver attribution work without producers having to wrap their
+		// own entry points in any subscriber context.
+		let identity = (ctx as { driver?: DriverIdentity }).driver
+		let driverAttrs = identity
+			? {
+					[ATTR_SERVER_ADDRESS]: identity.address,
+					...(identity.port !== undefined && { [ATTR_SERVER_PORT]: identity.port }),
+					[ATTR_DB_NAMESPACE]: identity.database,
+				}
+			: {}
+
+		let attrs = {
+			...BASE_ATTRIBUTES,
+			...driverAttrs,
+			...(entry.attrs ? entry.attrs(ctx as never) : {}),
+		}
+
+		let parentSpan = getActiveSubscriberSpan()
+		let parentCtx = parentSpan ? trace.setSpan(context.active(), parentSpan) : context.active()
+
+		let span = this.#tracer.startSpan(
+			entry.span,
+			{ kind: entry.kind, attributes: attrs as never },
+			parentCtx
+		)
+
+		this.#stateMap.set(ctx, { span })
+		return span
+	}
+
+	#finish(ctx: object, error: unknown): void {
+		let state = this.#stateMap.get(ctx)
+		if (!state) return
+		if (error !== undefined) {
+			let errAttrs = recordErrorAttributes(error)
+			state.span.setAttributes(errAttrs)
+			// Don't stringify arbitrary thrown values — a custom toString could
+			// dump secrets (tokens, credentials) into the recorded exception.
+			let recorded =
+				error instanceof Error
+					? error
+					: typeof error === 'string'
+						? new Error(error)
+						: new Error('non-Error throw')
+			state.span.recordException(recorded)
+			state.span.setStatus({ code: SpanStatusCode.ERROR })
+		}
+		state.span.end()
+		this.#stateMap.delete(ctx)
+	}
+}

--- a/packages/telemetry/tests/config.test.ts
+++ b/packages/telemetry/tests/config.test.ts
@@ -1,0 +1,84 @@
+import { tracingChannel } from 'node:diagnostics_channel'
+import { afterEach, beforeAll, expect, test } from 'vitest'
+
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
+
+import { YdbInstrumentation } from '../src/index.ts'
+
+let exporter = new InMemorySpanExporter()
+let provider = new NodeTracerProvider({
+	spanProcessors: [new SimpleSpanProcessor(exporter)],
+})
+provider.register()
+
+let active: YdbInstrumentation | undefined
+afterEach(() => {
+	active?.disable()
+	active = undefined
+	exporter.reset()
+})
+
+beforeAll(() => exporter.reset())
+
+async function fireExecute() {
+	let exec = tracingChannel('tracing:ydb:query.execute')
+	await exec.tracePromise(async () => {}, {
+		text: 'SELECT 1',
+		sessionId: 's1',
+		nodeId: 1n,
+		idempotent: true,
+		isolation: 'serializableReadWrite',
+	})
+}
+
+test('omits ydb.AcquireSession span by default', async () => {
+	active = new YdbInstrumentation()
+	active.enable()
+
+	let acq = tracingChannel('tracing:ydb:query.session.acquire')
+	await acq.tracePromise(async () => {}, {})
+
+	expect(exporter.getFinishedSpans().some((s) => s.name === 'ydb.AcquireSession')).toBe(false)
+})
+
+test('emits ydb.AcquireSession span when emitAcquireSessionSpan is true', async () => {
+	active = new YdbInstrumentation({ emitAcquireSessionSpan: true })
+	active.enable()
+
+	let acq = tracingChannel('tracing:ydb:query.session.acquire')
+	await acq.tracePromise(async () => {}, {})
+
+	expect(exporter.getFinishedSpans().some((s) => s.name === 'ydb.AcquireSession')).toBe(true)
+})
+
+test('exposes raw query text when captureQueryText is true', async () => {
+	active = new YdbInstrumentation({ captureQueryText: true })
+	active.enable()
+
+	await fireExecute()
+
+	let span = exporter.getFinishedSpans().find((s) => s.name === 'ydb.ExecuteQuery')!
+	expect(span.attributes['db.query.text']).toBe('SELECT 1')
+})
+
+test('does not double-subscribe on repeated enable calls', async () => {
+	active = new YdbInstrumentation()
+	active.enable()
+	active.enable()
+
+	await fireExecute()
+	let spans = exporter.getFinishedSpans().filter((s) => s.name === 'ydb.ExecuteQuery')
+	expect(spans).toHaveLength(1)
+})
+
+test('reattaches subscribers after disable then enable', async () => {
+	active = new YdbInstrumentation()
+	active.enable()
+	active.disable()
+	active.enable()
+
+	await fireExecute()
+	let spans = exporter.getFinishedSpans().filter((s) => s.name === 'ydb.ExecuteQuery')
+	expect(spans).toHaveLength(1)
+})

--- a/packages/telemetry/tests/grpc-propagation.test.ts
+++ b/packages/telemetry/tests/grpc-propagation.test.ts
@@ -1,0 +1,87 @@
+import { context, propagation, trace } from '@opentelemetry/api'
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks'
+import { W3CTraceContextPropagator } from '@opentelemetry/core'
+import {
+	BasicTracerProvider,
+	InMemorySpanExporter,
+	SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base'
+import type { ClientMiddleware, MethodDescriptor } from 'nice-grpc'
+import { afterEach, beforeAll, expect, test } from 'vitest'
+
+import { propagator } from '../src/propagation.ts'
+
+let exporter = new InMemorySpanExporter()
+
+beforeAll(() => {
+	let provider = new BasicTracerProvider({
+		spanProcessors: [new SimpleSpanProcessor(exporter)],
+	})
+	trace.setGlobalTracerProvider(provider)
+	propagation.setGlobalPropagator(new W3CTraceContextPropagator())
+	context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable())
+})
+
+afterEach(() => exporter.reset())
+
+// Drive a middleware like nice-grpc does at runtime: pump the generator,
+// ignore yields, capture the options handed to call.next.
+async function drive(
+	mw: ClientMiddleware,
+	options: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+	let seen: Record<string, unknown> | undefined
+	let call = {
+		method: { path: '/test/method' } as unknown as MethodDescriptor,
+		request: undefined,
+		async *next(_req: unknown, opts: Record<string, unknown>) {
+			seen = opts
+			yield undefined
+		},
+	}
+
+	let gen = (mw as any)(call, options) as AsyncGenerator
+	for await (let chunk of gen) void chunk
+
+	if (!seen) {
+		throw new Error('call.next was not invoked')
+	}
+
+	return seen
+}
+
+test('injects traceparent into metadata when a span is active', async () => {
+	let tracer = trace.getTracer('test')
+	let span = tracer.startSpan('outer')
+	let traceparent: string | undefined
+	await context.with(trace.setSpan(context.active(), span), async () => {
+		let opts = await drive(propagator, {})
+		let m = opts.metadata as { get(k: string): string | undefined }
+		traceparent = m.get('traceparent')
+	})
+	span.end()
+
+	expect(traceparent).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]$/)
+	expect(traceparent).toContain(span.spanContext().traceId)
+})
+
+test('skips traceparent when no span is active', async () => {
+	let opts = await drive(propagator, {})
+	let m = opts.metadata as { get(k: string): string | undefined }
+	expect(m.get('traceparent')).toBeUndefined()
+})
+
+test('preserves existing metadata entries alongside traceparent', async () => {
+	let tracer = trace.getTracer('test')
+	let span = tracer.startSpan('outer')
+	let pre = new Map<string, string>([['x-ydb-database', '/local']])
+	let m: { get(k: string): string | undefined } | undefined
+	await context.with(trace.setSpan(context.active(), span), async () => {
+		let opts = await drive(propagator, { metadata: pre })
+		m = opts.metadata as { get(k: string): string | undefined }
+	})
+	span.end()
+
+	expect(m!.get('x-ydb-database')).toBe('/local')
+	expect(m!.get('traceparent')).toBeDefined()
+})

--- a/packages/telemetry/tests/leak.test.ts
+++ b/packages/telemetry/tests/leak.test.ts
@@ -1,0 +1,136 @@
+// oxlint-disable no-await-in-loop
+import { tracingChannel } from 'node:diagnostics_channel'
+import { afterEach, expect, test } from 'vitest'
+
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
+
+import { YdbInstrumentation } from '../src/index.ts'
+
+let exporter = new InMemorySpanExporter()
+let provider = new NodeTracerProvider({
+	spanProcessors: [new SimpleSpanProcessor(exporter)],
+})
+provider.register()
+
+let active: YdbInstrumentation | undefined
+afterEach(() => {
+	active?.disable()
+	active = undefined
+	exporter.reset()
+})
+
+async function settle() {
+	// Two GC + microtask cycles flush WeakRef deref reliably across V8 idle work.
+	for (let i = 0; i < 5; i++) {
+		global.gc!()
+		await new Promise((r) => setImmediate(r))
+	}
+}
+
+test('reclaims tracing channel ctx after tracePromise completes', async () => {
+	active = new YdbInstrumentation()
+	active.enable()
+
+	let ch = tracingChannel('tracing:ydb:query.execute')
+	let ref: WeakRef<object>
+
+	await (async () => {
+		let ctx = {
+			text: 'SELECT 1',
+			sessionId: 'leak-1',
+			nodeId: 1n,
+			idempotent: true,
+			isolation: 'serializableReadWrite',
+		}
+		ref = new WeakRef(ctx)
+		await ch.tracePromise(async () => {}, ctx)
+	})()
+
+	await settle()
+	expect(ref!.deref()).toBeUndefined()
+})
+
+test('reclaims ctx via WeakMap on orphaned start without asyncEnd', async () => {
+	active = new YdbInstrumentation()
+	active.enable()
+
+	let startCh = tracingChannel('tracing:ydb:query.execute')
+	let ref: WeakRef<object>
+
+	;(() => {
+		let ctx = {
+			text: 'SELECT 1',
+			sessionId: 'leak-orphan',
+			nodeId: 1n,
+			idempotent: true,
+			isolation: 'serializableReadWrite',
+		}
+		ref = new WeakRef(ctx)
+		// Publish only `start` — asyncEnd / error never fire. WeakMap should
+		// still let ctx be reclaimed once the local reference goes out of scope.
+		startCh.start.publish(ctx)
+	})()
+
+	await settle()
+	expect(ref!.deref()).toBeUndefined()
+})
+
+test('releases channel handler references after disable', async () => {
+	let ref: WeakRef<YdbInstrumentation>
+
+	;(() => {
+		let inst = new YdbInstrumentation()
+		inst.enable()
+		inst.disable()
+		ref = new WeakRef(inst)
+	})()
+
+	await settle()
+	expect(ref!.deref()).toBeUndefined()
+})
+
+test('does not retain ctx across 1k tracePromise iterations', async () => {
+	active = new YdbInstrumentation()
+	active.enable()
+
+	let ch = tracingChannel('tracing:ydb:query.execute')
+	let lastRef: WeakRef<object> | undefined
+
+	for (let i = 0; i < 1000; i++) {
+		await (async () => {
+			let ctx = {
+				text: 'SELECT 1',
+				sessionId: `s-${i}`,
+				nodeId: 1n,
+				idempotent: true,
+				isolation: 'serializableReadWrite',
+			}
+			if (i === 999) lastRef = new WeakRef(ctx)
+			await ch.tracePromise(async () => {}, ctx)
+		})()
+	}
+
+	await settle()
+	expect(lastRef!.deref()).toBeUndefined()
+})
+
+test('clears spanStorage ALS frame at tracePromise boundaries', async () => {
+	active = new YdbInstrumentation()
+	active.enable()
+
+	let tx = tracingChannel('tracing:ydb:query.transaction')
+
+	// Inside tx scope getActiveSubscriberSpan returns the Transaction span;
+	// after tx.tracePromise resolves there must be no active span.
+	let { getActiveSubscriberSpan } = await import('../src/context.ts')
+
+	expect(getActiveSubscriberSpan()).toBeUndefined()
+
+	await tx.tracePromise(async () => {}, {
+		isolation: 'serializableReadWrite',
+		idempotent: false,
+	})
+
+	expect(getActiveSubscriberSpan()).toBeUndefined()
+})

--- a/packages/telemetry/tests/metrics.test.ts
+++ b/packages/telemetry/tests/metrics.test.ts
@@ -55,8 +55,8 @@ async function collect(): Promise<ResourceMetrics> {
 
 function findInstrument(rm: ResourceMetrics, name: string) {
 	for (let scope of rm.scopeMetrics) {
-		let m = scope.metrics.find((m) => m.descriptor.name === name)
-		if (m) return m
+		let found = scope.metrics.find((inst) => inst.descriptor.name === name)
+		if (found) return found
 	}
 	throw new Error(`no instrument named ${name}`)
 }

--- a/packages/telemetry/tests/metrics.test.ts
+++ b/packages/telemetry/tests/metrics.test.ts
@@ -240,6 +240,31 @@ test('counts ydb.auth.token.expirations with provider tag', async () => {
 	expect(point.value).toBe(1)
 })
 
+test('counts ydb.auth.token.refreshes with provider tag', async () => {
+	channel('ydb:auth.token.refreshed').publish({
+		provider: 'yc-service-account',
+		expiresAt: Date.now() + 3_600_000,
+	})
+	channel('ydb:auth.token.refreshed').publish({
+		provider: 'yc-service-account',
+		expiresAt: Date.now() + 3_600_000,
+	})
+	channel('ydb:auth.token.refreshed').publish({
+		provider: 'static',
+		expiresAt: Date.now() + 60_000,
+	})
+
+	let rm = await collect()
+	let yc = findPoint<number>(rm, 'ydb.auth.token.refreshes', {
+		'ydb.auth.provider': 'yc-service-account',
+	})
+	let stat = findPoint<number>(rm, 'ydb.auth.token.refreshes', {
+		'ydb.auth.provider': 'static',
+	})
+	expect(yc.value).toBe(2)
+	expect(stat.value).toBe(1)
+})
+
 // --- observable gauge ------------------------------------------------------
 
 test('observes ydb.driver.connection.count split by ydb.connection.state', async () => {

--- a/packages/telemetry/tests/metrics.test.ts
+++ b/packages/telemetry/tests/metrics.test.ts
@@ -1,0 +1,465 @@
+import { channel, tracingChannel } from 'node:diagnostics_channel'
+import { afterEach, beforeEach, expect, test } from 'vitest'
+
+import { type MetricAttributes, metrics } from '@opentelemetry/api'
+import {
+	AggregationTemporality,
+	type DataPoint,
+	type Histogram as HistogramData,
+	InMemoryMetricExporter,
+	MeterProvider,
+	PeriodicExportingMetricReader,
+	type ResourceMetrics,
+} from '@opentelemetry/sdk-metrics'
+
+import { YdbInstrumentation } from '../src/index.ts'
+
+let exporter: InMemoryMetricExporter
+let reader: PeriodicExportingMetricReader
+let provider: MeterProvider
+let instrumentation: YdbInstrumentation
+
+beforeEach(() => {
+	exporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE)
+	reader = new PeriodicExportingMetricReader({
+		exporter,
+		// Long enough that it never auto-fires within a test; we drive flushes
+		// explicitly via provider.forceFlush().
+		exportIntervalMillis: 60_000,
+		exportTimeoutMillis: 5_000,
+	})
+	provider = new MeterProvider({ readers: [reader] })
+	metrics.setGlobalMeterProvider(provider)
+	instrumentation = new YdbInstrumentation()
+	instrumentation.enable()
+})
+
+afterEach(async () => {
+	instrumentation.disable()
+	await provider.shutdown()
+	metrics.disable()
+})
+
+let driverIdentity = {
+	address: '127.0.0.1',
+	port: 2136,
+	database: '/local',
+	registeredAt: 0,
+}
+
+async function collect(): Promise<ResourceMetrics> {
+	await provider.forceFlush()
+	let exported = exporter.getMetrics()
+	return exported[exported.length - 1]
+}
+
+function findInstrument(rm: ResourceMetrics, name: string) {
+	for (let scope of rm.scopeMetrics) {
+		let m = scope.metrics.find((m) => m.descriptor.name === name)
+		if (m) return m
+	}
+	throw new Error(`no instrument named ${name}`)
+}
+
+function findPoint<T>(rm: ResourceMetrics, name: string, filter: MetricAttributes): DataPoint<T> {
+	let inst = findInstrument(rm, name)
+	let point = (inst.dataPoints as DataPoint<T>[]).find((p) =>
+		Object.entries(filter).every(([k, v]) => (p.attributes as Record<string, unknown>)[k] === v)
+	)
+	if (!point) {
+		throw new Error(
+			`no datapoint for ${name} matching ${JSON.stringify(filter)}. Got: ${JSON.stringify(inst.dataPoints.map((p) => p.attributes))}`
+		)
+	}
+	return point
+}
+
+// --- duration histogram ----------------------------------------------------
+
+test('records db.client.operation.duration on tracing:ydb:query.execute', async () => {
+	let exec = tracingChannel('tracing:ydb:query.execute')
+	await exec.tracePromise(async () => {}, {
+		driver: driverIdentity,
+		text: 'SELECT 1',
+		sessionId: 's1',
+		nodeId: 1n,
+		idempotent: false,
+		isolation: 'serializableReadWrite',
+	})
+
+	let rm = await collect()
+	let point = findPoint<HistogramData>(rm, 'db.client.operation.duration', {
+		'db.operation.name': 'Query.ExecuteQuery',
+		'db.namespace': '/local',
+		'server.address': '127.0.0.1',
+		'db.system.name': 'ydb',
+	})
+	expect(point.value.count).toBe(1)
+	expect(point.value.sum).toBeGreaterThanOrEqual(0)
+})
+
+test('tags db.client.operation.duration with error.type when the channel fires error', async () => {
+	let exec = tracingChannel('tracing:ydb:query.execute')
+	await expect(
+		exec.tracePromise(
+			async () => {
+				let e = new Error('boom')
+				e.name = 'TimeoutError'
+				throw e
+			},
+			{
+				driver: driverIdentity,
+				text: 'SELECT 1',
+				sessionId: 's1',
+				nodeId: 1n,
+				idempotent: false,
+				isolation: 'serializableReadWrite',
+			}
+		)
+	).rejects.toThrow('boom')
+
+	let rm = await collect()
+	let point = findPoint<HistogramData>(rm, 'db.client.operation.duration', {
+		'db.operation.name': 'Query.ExecuteQuery',
+		'error.type': 'TimeoutError',
+	})
+	expect(point.value.count).toBe(1)
+})
+
+// --- counters --------------------------------------------------------------
+
+test('counts ydb.driver.connection.pessimizations from pessimized event', async () => {
+	channel('ydb:driver.connection.pessimized').publish({
+		driver: driverIdentity,
+		nodeId: 7n,
+		address: '10.0.0.1:2135',
+		location: 'dc1',
+		until: Date.now() + 5000,
+	})
+	channel('ydb:driver.connection.pessimized').publish({
+		driver: driverIdentity,
+		nodeId: 8n,
+		address: '10.0.0.2:2135',
+		location: 'dc1',
+		until: Date.now() + 5000,
+	})
+
+	let rm = await collect()
+	let point = findPoint<number>(rm, 'ydb.driver.connection.pessimizations', {
+		'db.namespace': '/local',
+	})
+	expect(point.value).toBe(2)
+})
+
+test('counts ydb.query.session.closed with close.reason tag', async () => {
+	channel('ydb:query.session.closed').publish({
+		driver: driverIdentity,
+		sessionId: 's1',
+		nodeId: 1n,
+		reason: 'stream_error',
+		uptime: 1000,
+	})
+	channel('ydb:query.session.closed').publish({
+		driver: driverIdentity,
+		sessionId: 's2',
+		nodeId: 1n,
+		reason: 'pool_close',
+		uptime: 2000,
+	})
+
+	let rm = await collect()
+	let streamError = findPoint<number>(rm, 'ydb.query.session.closed', {
+		'ydb.session.close.reason': 'stream_error',
+	})
+	let poolClose = findPoint<number>(rm, 'ydb.query.session.closed', {
+		'ydb.session.close.reason': 'pool_close',
+	})
+	expect(streamError.value).toBe(1)
+	expect(poolClose.value).toBe(1)
+})
+
+test('counts ydb.retry.attempts with outcome tag from retry.attempt.completed', async () => {
+	channel('ydb:retry.attempt.completed').publish({
+		attempt: 1,
+		idempotent: true,
+		outcome: 'retried',
+	})
+	channel('ydb:retry.attempt.completed').publish({
+		attempt: 2,
+		idempotent: true,
+		outcome: 'success',
+	})
+
+	let rm = await collect()
+	let retried = findPoint<number>(rm, 'ydb.retry.attempts', { 'ydb.retry.outcome': 'retried' })
+	let success = findPoint<number>(rm, 'ydb.retry.attempts', { 'ydb.retry.outcome': 'success' })
+	expect(retried.value).toBe(1)
+	expect(success.value).toBe(1)
+})
+
+test('counts ydb.auth.token.fetch.failures with provider tag', async () => {
+	channel('ydb:auth.provider.failed').publish({
+		provider: 'static',
+		error: new Error('network down'),
+	})
+
+	let rm = await collect()
+	let point = findPoint<number>(rm, 'ydb.auth.token.fetch.failures', {
+		'ydb.auth.provider': 'static',
+	})
+	expect(point.value).toBe(1)
+})
+
+test('counts ydb.auth.token.expirations with provider tag', async () => {
+	channel('ydb:auth.token.expired').publish({ provider: 'metadata' })
+
+	let rm = await collect()
+	let point = findPoint<number>(rm, 'ydb.auth.token.expirations', {
+		'ydb.auth.provider': 'metadata',
+	})
+	expect(point.value).toBe(1)
+})
+
+// --- observable gauge ------------------------------------------------------
+
+test('observes ydb.driver.connection.count split by ydb.connection.state', async () => {
+	channel('ydb:driver.connection.added').publish({ driver: driverIdentity, nodeId: 1n })
+	channel('ydb:driver.connection.added').publish({ driver: driverIdentity, nodeId: 2n })
+	channel('ydb:driver.connection.added').publish({ driver: driverIdentity, nodeId: 3n })
+	channel('ydb:driver.connection.pessimized').publish({
+		driver: driverIdentity,
+		nodeId: 2n,
+		address: '10.0.0.2:2135',
+		location: 'dc1',
+		until: Date.now() + 5000,
+	})
+
+	let rm = await collect()
+	let live = findPoint<number>(rm, 'ydb.driver.connection.count', {
+		'ydb.connection.state': 'live',
+		'db.namespace': '/local',
+	})
+	let pessimized = findPoint<number>(rm, 'ydb.driver.connection.count', {
+		'ydb.connection.state': 'pessimized',
+		'db.namespace': '/local',
+	})
+	expect(live.value).toBe(2)
+	expect(pessimized.value).toBe(1)
+})
+
+test('observes ydb.query.session.count split by ydb.session.state', async () => {
+	channel('ydb:query.session.pool.opened').publish({
+		driver: driverIdentity,
+		maxSize: 10,
+		minSize: 0,
+	})
+	channel('ydb:query.session.created').publish({
+		driver: driverIdentity,
+		sessionId: 's1',
+		nodeId: 1n,
+	})
+	channel('ydb:query.session.created').publish({
+		driver: driverIdentity,
+		sessionId: 's2',
+		nodeId: 1n,
+	})
+	channel('ydb:query.session.created').publish({
+		driver: driverIdentity,
+		sessionId: 's3',
+		nodeId: 1n,
+	})
+	channel('ydb:query.session.acquired').publish({
+		driver: driverIdentity,
+		sessionId: 's2',
+		nodeId: 1n,
+	})
+	channel('ydb:query.session.closed').publish({
+		driver: driverIdentity,
+		sessionId: 's1',
+		nodeId: 1n,
+		reason: 'stream_closed',
+		uptime: 100,
+	})
+
+	let rm = await collect()
+	let idle = findPoint<number>(rm, 'ydb.query.session.count', {
+		'ydb.session.state': 'idle',
+		'db.namespace': '/local',
+	})
+	let acquired = findPoint<number>(rm, 'ydb.query.session.count', {
+		'ydb.session.state': 'acquired',
+		'db.namespace': '/local',
+	})
+	let creating = findPoint<number>(rm, 'ydb.query.session.count', {
+		'ydb.session.state': 'creating',
+		'db.namespace': '/local',
+	})
+	// total = 2 (3 created − 1 closed). acquired = 1 (s2). idle = total − acquired.
+	expect(acquired.value).toBe(1)
+	expect(idle.value).toBe(1)
+	expect(creating.value).toBe(0)
+})
+
+test('records ydb.query.session.create.duration and reports creating state mid-flight', async () => {
+	let createCh = tracingChannel('tracing:ydb:query.session.create')
+	let started = Promise.withResolvers<void>()
+	let finish = Promise.withResolvers<void>()
+
+	let traced = createCh.tracePromise(
+		async () => {
+			started.resolve()
+			await finish.promise
+		},
+		{ driver: driverIdentity }
+	)
+
+	await started.promise
+	// `creating` is incremented by the start hook and decremented by asyncEnd —
+	// observe it while the traced fn is suspended.
+	let midflight = await collect()
+	let creating = findPoint<number>(midflight, 'ydb.query.session.count', {
+		'ydb.session.state': 'creating',
+		'db.namespace': '/local',
+	})
+	expect(creating.value).toBe(1)
+
+	finish.resolve()
+	await traced
+
+	let rm = await collect()
+	let dur = findPoint<HistogramData>(rm, 'ydb.query.session.create.duration', {
+		'db.namespace': '/local',
+	})
+	expect(dur.value.count).toBe(1)
+
+	// `creating` falls back to 0 once the create resolves.
+	let after = findPoint<number>(rm, 'ydb.query.session.count', {
+		'ydb.session.state': 'creating',
+		'db.namespace': '/local',
+	})
+	expect(after.value).toBe(0)
+})
+
+test('records ydb.query.session.acquire.duration', async () => {
+	let acquireCh = tracingChannel('tracing:ydb:query.session.acquire')
+	await acquireCh.tracePromise(async () => {}, { driver: driverIdentity })
+
+	let rm = await collect()
+	let point = findPoint<HistogramData>(rm, 'ydb.query.session.acquire.duration', {
+		'db.namespace': '/local',
+	})
+	expect(point.value.count).toBe(1)
+})
+
+test('counts ydb.query.session.acquire.failures with error.type on acquire.failed', async () => {
+	let err = new Error('pool full')
+	err.name = 'SessionPoolFullError'
+	channel('ydb:query.session.acquire.failed').publish({ driver: driverIdentity, error: err })
+
+	let rm = await collect()
+	let point = findPoint<number>(rm, 'ydb.query.session.acquire.failures', {
+		'error.type': 'SessionPoolFullError',
+		'db.namespace': '/local',
+	})
+	expect(point.value).toBe(1)
+})
+
+test('observes ydb.query.session.acquire.pending from waiter enqueue/dequeue events', async () => {
+	channel('ydb:query.session.pool.opened').publish({
+		driver: driverIdentity,
+		maxSize: 5,
+		minSize: 0,
+	})
+	channel('ydb:query.session.waiter.enqueued').publish({ driver: driverIdentity })
+	channel('ydb:query.session.waiter.enqueued').publish({ driver: driverIdentity })
+	channel('ydb:query.session.waiter.enqueued').publish({ driver: driverIdentity })
+	channel('ydb:query.session.waiter.dequeued').publish({ driver: driverIdentity })
+
+	let rm = await collect()
+	let pending = findPoint<number>(rm, 'ydb.query.session.acquire.pending', {
+		'db.namespace': '/local',
+	})
+	expect(pending.value).toBe(2)
+})
+
+test('observes ydb.query.session.max and ydb.query.session.min from pool.opened snapshot', async () => {
+	channel('ydb:query.session.pool.opened').publish({
+		driver: driverIdentity,
+		maxSize: 42,
+		minSize: 7,
+	})
+
+	let rm = await collect()
+	let max = findPoint<number>(rm, 'ydb.query.session.max', { 'db.namespace': '/local' })
+	let min = findPoint<number>(rm, 'ydb.query.session.min', { 'db.namespace': '/local' })
+	expect(max.value).toBe(42)
+	expect(min.value).toBe(7)
+})
+
+test('records ydb.auth.token.fetch.duration tagged by provider', async () => {
+	let fetchCh = tracingChannel('tracing:ydb:auth.token.fetch')
+	await fetchCh.tracePromise(async () => {}, { provider: 'metadata' })
+
+	let rm = await collect()
+	let point = findPoint<HistogramData>(rm, 'ydb.auth.token.fetch.duration', {
+		'ydb.auth.provider': 'metadata',
+	})
+	expect(point.value.count).toBe(1)
+})
+
+test('records ydb.retry.duration tagged by outcome', async () => {
+	let runCh = tracingChannel<{ idempotent: boolean; outcome?: string }, never>(
+		'tracing:ydb:retry.run'
+	)
+	let ctx = { idempotent: true, outcome: undefined as string | undefined }
+	await runCh.tracePromise(async () => {
+		ctx.outcome = 'success'
+	}, ctx)
+
+	let rm = await collect()
+	let point = findPoint<HistogramData>(rm, 'ydb.retry.duration', {
+		'ydb.retry.outcome': 'success',
+		'ydb.idempotent': true,
+	})
+	expect(point.value.count).toBe(1)
+})
+
+test('driver.closed drops both connection and session pool state for that driver', async () => {
+	channel('ydb:driver.connection.added').publish({ driver: driverIdentity, nodeId: 1n })
+	channel('ydb:driver.connection.added').publish({ driver: driverIdentity, nodeId: 2n })
+	channel('ydb:query.session.pool.opened').publish({
+		driver: driverIdentity,
+		maxSize: 4,
+		minSize: 0,
+	})
+	channel('ydb:query.session.created').publish({
+		driver: driverIdentity,
+		sessionId: 's1',
+		nodeId: 1n,
+	})
+
+	channel('ydb:driver.closed').publish({ driver: driverIdentity })
+
+	// Both registries are gone, so newly-published events start the counters
+	// from zero rather than accumulating on top of the prior driver lifetime.
+	channel('ydb:driver.connection.added').publish({ driver: driverIdentity, nodeId: 9n })
+	channel('ydb:query.session.pool.opened').publish({
+		driver: driverIdentity,
+		maxSize: 10,
+		minSize: 2,
+	})
+
+	let rm = await collect()
+	let live = findPoint<number>(rm, 'ydb.driver.connection.count', {
+		'ydb.connection.state': 'live',
+		'db.namespace': '/local',
+	})
+	expect(live.value).toBe(1)
+	let max = findPoint<number>(rm, 'ydb.query.session.max', { 'db.namespace': '/local' })
+	expect(max.value).toBe(10)
+	let idle = findPoint<number>(rm, 'ydb.query.session.count', {
+		'ydb.session.state': 'idle',
+		'db.namespace': '/local',
+	})
+	expect(idle.value).toBe(0)
+})

--- a/packages/telemetry/tests/metrics.test.ts
+++ b/packages/telemetry/tests/metrics.test.ts
@@ -98,6 +98,26 @@ test('records db.client.operation.duration on tracing:ydb:query.execute', async 
 	expect(point.value.sum).toBeGreaterThanOrEqual(0)
 })
 
+test('records db.client.operation.duration on tracing:ydb:query.session.delete', async () => {
+	let del = tracingChannel('tracing:ydb:query.session.delete')
+	await del.tracePromise(async () => {}, {
+		driver: driverIdentity,
+		sessionId: 's1',
+		nodeId: 1n,
+		reason: 'pool_close',
+		uptime: 1000,
+	})
+
+	let rm = await collect()
+	let point = findPoint<HistogramData>(rm, 'db.client.operation.duration', {
+		'db.operation.name': 'Query.DeleteSession',
+		'db.namespace': '/local',
+		'server.address': '127.0.0.1',
+		'db.system.name': 'ydb',
+	})
+	expect(point.value.count).toBe(1)
+})
+
 test('tags db.client.operation.duration with error.type when the channel fires error', async () => {
 	let exec = tracingChannel('tracing:ydb:query.execute')
 	await expect(

--- a/packages/telemetry/tests/multi-driver.test.ts
+++ b/packages/telemetry/tests/multi-driver.test.ts
@@ -1,0 +1,95 @@
+import { tracingChannel } from 'node:diagnostics_channel'
+import { afterEach, expect, test } from 'vitest'
+
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
+
+import { YdbInstrumentation } from '../src/index.ts'
+
+let exporter = new InMemorySpanExporter()
+let provider = new NodeTracerProvider({
+	spanProcessors: [new SimpleSpanProcessor(exporter)],
+})
+provider.register()
+
+let active: YdbInstrumentation | undefined
+afterEach(() => {
+	active?.disable()
+	active = undefined
+	exporter.reset()
+})
+
+test('inherits driver identity from channel payload', async () => {
+	active = new YdbInstrumentation()
+	active.enable()
+
+	let exec = tracingChannel('tracing:ydb:query.execute')
+
+	await exec.tracePromise(async () => {}, {
+		driver: { database: '/db1', address: '10.0.0.1', port: 2136 },
+		text: 'SELECT 1',
+		sessionId: 's1',
+		nodeId: 1n,
+		idempotent: true,
+		isolation: 'serializableReadWrite',
+	})
+
+	let span = exporter.getFinishedSpans().find((s) => s.name === 'ydb.ExecuteQuery')!
+	expect(span.attributes['db.namespace']).toBe('/db1')
+	expect(span.attributes['server.address']).toBe('10.0.0.1')
+	expect(span.attributes['server.port']).toBe(2136)
+})
+
+test('attributes spans independently for parallel driver identities', async () => {
+	active = new YdbInstrumentation()
+	active.enable()
+
+	let exec = tracingChannel('tracing:ydb:query.execute')
+	let baseCtx = {
+		text: 'SELECT 1',
+		nodeId: 1n,
+		idempotent: true,
+		isolation: 'serializableReadWrite',
+	}
+
+	await Promise.all([
+		exec.tracePromise(async () => {}, {
+			...baseCtx,
+			sessionId: 'a',
+			driver: { database: '/db1', address: '10.0.0.1', port: 2136 },
+		}),
+		exec.tracePromise(async () => {}, {
+			...baseCtx,
+			sessionId: 'b',
+			driver: { database: '/db2', address: '10.0.0.2', port: 2136 },
+		}),
+	])
+
+	let spans = exporter.getFinishedSpans().filter((s) => s.name === 'ydb.ExecuteQuery')
+	expect(spans).toHaveLength(2)
+
+	let bySession = Object.fromEntries(spans.map((s) => [s.attributes['ydb.session.id'], s]))
+	expect(bySession.a!.attributes['db.namespace']).toBe('/db1')
+	expect(bySession.a!.attributes['server.address']).toBe('10.0.0.1')
+	expect(bySession.b!.attributes['db.namespace']).toBe('/db2')
+	expect(bySession.b!.attributes['server.address']).toBe('10.0.0.2')
+})
+
+test('omits server.address and db.namespace when payload has no driver', async () => {
+	active = new YdbInstrumentation()
+	active.enable()
+
+	let exec = tracingChannel('tracing:ydb:query.execute')
+	await exec.tracePromise(async () => {}, {
+		text: 'SELECT 1',
+		sessionId: 's',
+		nodeId: 1n,
+		idempotent: true,
+		isolation: 'serializableReadWrite',
+	})
+
+	let span = exporter.getFinishedSpans().find((s) => s.name === 'ydb.ExecuteQuery')!
+	expect(span.attributes['db.system.name']).toBe('ydb')
+	expect(span.attributes['server.address']).toBeUndefined()
+	expect(span.attributes['db.namespace']).toBeUndefined()
+})

--- a/packages/telemetry/tests/propagation.test.ts
+++ b/packages/telemetry/tests/propagation.test.ts
@@ -1,0 +1,296 @@
+import { tracingChannel } from 'node:diagnostics_channel'
+import { afterAll, beforeAll, beforeEach, expect, test } from 'vitest'
+
+import { context, trace } from '@opentelemetry/api'
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
+
+import { YdbInstrumentation } from '../src/index.ts'
+
+let exporter = new InMemorySpanExporter()
+let provider = new NodeTracerProvider({
+	spanProcessors: [new SimpleSpanProcessor(exporter)],
+})
+provider.register()
+
+let instrumentation: YdbInstrumentation
+beforeAll(() => {
+	instrumentation = new YdbInstrumentation()
+	instrumentation.enable()
+})
+afterAll(() => instrumentation.disable())
+beforeEach(() => exporter.reset())
+
+test('nests ExecuteQuery under Transaction', async () => {
+	let tx = tracingChannel('tracing:ydb:query.transaction')
+	let exec = tracingChannel('tracing:ydb:query.execute')
+
+	await tx.tracePromise(
+		async () => {
+			await exec.tracePromise(async () => {}, {
+				text: 'SELECT 1',
+				sessionId: 's1',
+				nodeId: 1n,
+				idempotent: false,
+				isolation: 'serializableReadWrite',
+			})
+		},
+		{ isolation: 'serializableReadWrite', idempotent: false }
+	)
+
+	let spans = exporter.getFinishedSpans()
+	let txSpan = spans.find((s) => s.name === 'ydb.Transaction')!
+	let execSpan = spans.find((s) => s.name === 'ydb.ExecuteQuery')!
+	expect(execSpan.parentSpanContext?.spanId).toBe(txSpan.spanContext().spanId)
+})
+
+test('nests CreateSession under Try under RunWithRetry', async () => {
+	let run = tracingChannel('tracing:ydb:retry.run')
+	let attempt = tracingChannel('tracing:ydb:retry.attempt')
+	let create = tracingChannel('tracing:ydb:query.session.create')
+
+	await run.tracePromise(
+		async () => {
+			await attempt.tracePromise(
+				async () => {
+					await create.tracePromise(async () => {}, {
+						liveSessions: 0,
+						maxSize: 50,
+						creating: 1,
+					})
+				},
+				{ attempt: 1, idempotent: true, backoffMs: 0 }
+			)
+		},
+		{ idempotent: true }
+	)
+
+	let spans = exporter.getFinishedSpans()
+	let runSpan = spans.find((s) => s.name === 'ydb.RunWithRetry')!
+	let trySpan = spans.find((s) => s.name === 'ydb.Try')!
+	let createSpan = spans.find((s) => s.name === 'ydb.CreateSession')!
+	expect(trySpan.parentSpanContext?.spanId).toBe(runSpan.spanContext().spanId)
+	expect(createSpan.parentSpanContext?.spanId).toBe(trySpan.spanContext().spanId)
+})
+
+test('keeps retry attempts as siblings under RunWithRetry', async () => {
+	let run = tracingChannel('tracing:ydb:retry.run')
+	let attempt = tracingChannel('tracing:ydb:retry.attempt')
+
+	await run.tracePromise(
+		async () => {
+			await attempt.tracePromise(async () => {}, {
+				attempt: 1,
+				idempotent: true,
+				backoffMs: 0,
+			})
+			await attempt.tracePromise(async () => {}, {
+				attempt: 2,
+				idempotent: true,
+				backoffMs: 5,
+			})
+		},
+		{ idempotent: true }
+	)
+
+	let spans = exporter.getFinishedSpans()
+	let runSpan = spans.find((s) => s.name === 'ydb.RunWithRetry')!
+	let tries = spans.filter((s) => s.name === 'ydb.Try')
+	expect(tries).toHaveLength(2)
+	for (let t of tries) expect(t.parentSpanContext?.spanId).toBe(runSpan.spanContext().spanId)
+})
+
+test('carries ydb.transaction.id on Commit span from txId field', async () => {
+	let commit = tracingChannel('tracing:ydb:query.commit')
+	await commit.tracePromise(async () => {}, {
+		sessionId: 's1',
+		nodeId: 1n,
+		txId: 'tx-abc',
+	})
+	let spans = exporter.getFinishedSpans()
+	let commitSpan = spans.find((s) => s.name === 'ydb.Commit')!
+	expect(commitSpan.attributes['ydb.transaction.id']).toBe('tx-abc')
+})
+
+test('omits db.query.text by default', async () => {
+	let exec = tracingChannel('tracing:ydb:query.execute')
+	await exec.tracePromise(async () => {}, {
+		text: 'SELECT secret FROM users',
+		sessionId: 's1',
+		nodeId: 1n,
+		idempotent: false,
+		isolation: 'serializableReadWrite',
+	})
+	let span = exporter.getFinishedSpans().find((s) => s.name === 'ydb.ExecuteQuery')!
+	expect(span.attributes['db.query.text']).toBeUndefined()
+})
+
+test('stamps db.system.name=ydb on every span', async () => {
+	let exec = tracingChannel('tracing:ydb:query.execute')
+	await exec.tracePromise(async () => {}, {
+		text: 'SELECT 1',
+		sessionId: 's1',
+		nodeId: 1n,
+		idempotent: true,
+		isolation: 'serializableReadWrite',
+	})
+	let span = exporter.getFinishedSpans().find((s) => s.name === 'ydb.ExecuteQuery')!
+	expect(span.attributes['db.system.name']).toBe('ydb')
+})
+
+test('sets ERROR status and error.type on tracing channel error', async () => {
+	let exec = tracingChannel('tracing:ydb:query.execute')
+	await expect(
+		exec.tracePromise(
+			async () => {
+				throw new Error('boom')
+			},
+			{
+				text: 'SELECT 1',
+				sessionId: 's1',
+				nodeId: 1n,
+				idempotent: false,
+				isolation: 'serializableReadWrite',
+			}
+		)
+	).rejects.toThrow('boom')
+
+	let span = exporter.getFinishedSpans().find((s) => s.name === 'ydb.ExecuteQuery')!
+	expect(span.status?.code).toBe(2)
+	expect(span.attributes['error.type']).toBe('Error')
+})
+
+test('nests user span → tx → retry.run → retry.attempt → exec chain', async () => {
+	let userTracer = trace.getTracer('test-app')
+	let userSpan = userTracer.startSpan('checkout')
+
+	let tx = tracingChannel('tracing:ydb:query.transaction')
+	let run = tracingChannel('tracing:ydb:retry.run')
+	let attempt = tracingChannel('tracing:ydb:retry.attempt')
+	let exec = tracingChannel('tracing:ydb:query.execute')
+
+	let driver = { database: '/local', address: '127.0.0.1', port: 2136 }
+
+	await context.with(trace.setSpan(context.active(), userSpan), async () => {
+		await tx.tracePromise(
+			async () => {
+				await run.tracePromise(
+					async () => {
+						await attempt.tracePromise(
+							async () => {
+								await exec.tracePromise(async () => {}, {
+									driver,
+									text: 'INSERT INTO orders ...',
+									sessionId: 'sess-tx',
+									nodeId: 7n,
+									idempotent: false,
+									isolation: 'serializableReadWrite',
+								})
+							},
+							{ attempt: 1, idempotent: false, backoffMs: 0 }
+						)
+					},
+					{ idempotent: false }
+				)
+			},
+			{ driver, isolation: 'serializableReadWrite', idempotent: false }
+		)
+	})
+
+	userSpan.end()
+
+	let spans = exporter.getFinishedSpans()
+	let user = spans.find((s) => s.name === 'checkout')!
+	let txSpan = spans.find((s) => s.name === 'ydb.Transaction')!
+	let runSpan = spans.find((s) => s.name === 'ydb.RunWithRetry')!
+	let trySpan = spans.find((s) => s.name === 'ydb.Try')!
+	let execSpan = spans.find((s) => s.name === 'ydb.ExecuteQuery')!
+
+	// Topology: checkout → Transaction → RunWithRetry → Try → ExecuteQuery
+	expect(txSpan.parentSpanContext?.spanId).toBe(user.spanContext().spanId)
+	expect(runSpan.parentSpanContext?.spanId).toBe(txSpan.spanContext().spanId)
+	expect(trySpan.parentSpanContext?.spanId).toBe(runSpan.spanContext().spanId)
+	expect(execSpan.parentSpanContext?.spanId).toBe(trySpan.spanContext().spanId)
+
+	// All spans in the chain share one traceId.
+	let traceId = user.spanContext().traceId
+	for (let s of [txSpan, runSpan, trySpan, execSpan]) {
+		expect(s.spanContext().traceId).toBe(traceId)
+	}
+
+	// Identity carried only by spans whose payload includes `driver` (db-scoped
+	// spans). Retry spans are generic and inherit identity through the trace
+	// hierarchy, not attributes.
+	for (let s of [txSpan, execSpan]) {
+		expect(s.attributes['db.namespace']).toBe('/local')
+		expect(s.attributes['server.address']).toBe('127.0.0.1')
+	}
+	for (let s of [runSpan, trySpan]) {
+		expect(s.attributes['db.namespace']).toBeUndefined()
+		expect(s.attributes['server.address']).toBeUndefined()
+	}
+})
+
+test('records pool.connection.added as span event on active span', async () => {
+	let { channel } = await import('node:diagnostics_channel')
+	let tx = tracingChannel('tracing:ydb:query.transaction')
+
+	await tx.tracePromise(
+		async () => {
+			channel('ydb:driver.connection.added').publish({
+				nodeId: 7n,
+				address: '10.0.0.1:2135',
+				location: 'dc1',
+			})
+		},
+		{ isolation: 'serializableReadWrite', idempotent: false }
+	)
+
+	let txSpan = exporter.getFinishedSpans().find((s) => s.name === 'ydb.Transaction')!
+	let event = txSpan.events.find((e) => e.name === 'ydb.driver.connection.added')
+	expect(event).toBeDefined()
+	expect(event!.attributes?.['ydb.node.id']).toBe(7)
+	expect(event!.attributes?.['ydb.node.dc']).toBe('dc1')
+})
+
+test('emits ydb.DeleteSession span with Query.DeleteSession operation and uptime in seconds', async () => {
+	let del = tracingChannel('tracing:ydb:query.session.delete')
+
+	// Payload `uptime` is in ms (Node convention); the OTel attribute should
+	// be in seconds — that conversion lives in the telemetry mapping.
+	await del.tracePromise(async () => {}, {
+		sessionId: 'sess-42',
+		nodeId: 3n,
+		reason: 'pool_close',
+		uptime: 2500,
+	})
+
+	let span = exporter.getFinishedSpans().find((s) => s.name === 'ydb.DeleteSession')!
+	expect(span).toBeDefined()
+	expect(span.attributes['db.operation.name']).toBe('Query.DeleteSession')
+	expect(span.attributes['ydb.session.id']).toBe('sess-42')
+	expect(span.attributes['ydb.node.id']).toBe(3)
+	expect(span.attributes['ydb.session.close.reason']).toBe('pool_close')
+	expect(span.attributes['ydb.session.uptime']).toBe(2.5)
+})
+
+test('converts connection.pessimization durations from ms payload to seconds attribute', async () => {
+	let { channel } = await import('node:diagnostics_channel')
+	// Connection pool events naturally fire within a discovery round (pool
+	// reshuffle is part of `Driver.runDiscoveryRound`), so the discovery span
+	// is the natural carrier for their addEvent — not a transaction.
+	let discovery = tracingChannel('tracing:ydb:driver.discovery')
+
+	await discovery.tracePromise(async () => {
+		channel('ydb:driver.connection.unpessimized').publish({
+			nodeId: 9n,
+			address: '10.0.0.2:2135',
+			location: 'dc2',
+			duration: 3000, // ms
+		})
+	}, {})
+
+	let span = exporter.getFinishedSpans().find((s) => s.name === 'ydb.Discovery')!
+	let event = span.events.find((e) => e.name === 'ydb.driver.connection.unpessimized')
+	expect(event!.attributes?.['ydb.driver.connection.pessimization.duration']).toBe(3)
+})

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"outDir": "./dist"
+	},
+	"exclude": ["dist/**/*", "**/*.test.ts", "vitest.config.ts"]
+}

--- a/packages/telemetry/vitest.config.ts
+++ b/packages/telemetry/vitest.config.ts
@@ -1,0 +1,31 @@
+import { defineProject } from 'vitest/config'
+
+export default defineProject({
+	test: {
+		projects: [
+			{
+				test: {
+					name: {
+						label: 'uni',
+						color: 'yellow',
+					},
+					include: ['src/**/*.test.ts'],
+					environment: 'node',
+				},
+			},
+			{
+				test: {
+					name: {
+						label: 'int',
+						color: 'blue',
+					},
+					include: ['tests/**/*.test.ts'],
+					environment: 'node',
+					testTimeout: 30000,
+					// leak.test.ts uses global.gc() to verify WeakRef reclamation.
+					execArgv: ['--expose-gc'],
+				},
+			},
+		],
+	},
+})

--- a/tests/slo/package.json
+++ b/tests/slo/package.json
@@ -8,8 +8,8 @@
 	},
 	"dependencies": {
 		"hdr-histogram-js": "3.0.1",
-		"@opentelemetry/exporter-metrics-otlp-http": "^0.215.0",
-		"@opentelemetry/sdk-metrics": "^2.7.0",
+		"@opentelemetry/exporter-metrics-otlp-http": "^0.218.0",
+		"@opentelemetry/sdk-metrics": "^2.7.1",
 		"@ydbjs/api": "*",
 		"@ydbjs/core": "*",
 		"@ydbjs/query": "*",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
 					},
 					include: ['packages/*/src/**/*.test.ts', 'third-parties/*/src/**/*.test.ts'],
 					environment: 'node',
+					execArgv: ['--expose-gc'],
 					benchmark: {
 						include: [
 							'packages/*/src/**/*.bench.ts',
@@ -29,6 +30,7 @@ export default defineConfig({
 					},
 					include: ['packages/*/tests/**/*.test.ts'],
 					environment: 'node',
+					execArgv: ['--expose-gc'],
 					globalSetup: './vitest.setup.ydb.ts',
 					benchmark: {
 						include: ['packages/*/tests/**/*.bench.ts'],


### PR DESCRIPTION
## What

Adds `@ydbjs/telemetry`, an OpenTelemetry instrumentation that subscribes to the `node:diagnostics_channel` events emitted by `@ydbjs/core`, `@ydbjs/query`, `@ydbjs/auth`, and `@ydbjs/retry`, and converts them into OTel spans and metrics. Producer packages are aligned to a single naming scheme (`ydb:<subsystem>.<concept>.<action>`) and every event payload now carries a `DriverIdentity` envelope so multi-driver attribution works out of the box.

## Why

The SDK already publishes structured lifecycle events on `diagnostics_channel`, but consumers had to write the OTel adapter themselves. This PR ships that adapter — with parent/child span propagation, multi-driver tagging, leak-tested context tracking, and a metrics pipeline that mirrors the OTel database semantic conventions (`db.client.operation.duration`) so off-the-shelf dashboards work without bespoke configuration.

## Span hierarchy

The producer publishes nested `tracingChannel` events; `@ydbjs/telemetry` reconstructs the tree via `AsyncLocalStorage` bound to each scope. A typical retried-query trace renders as:

```
ydb.RunWithRetry                    INTERNAL · retry loop
└─ ydb.Try (attempt N)              INTERNAL · one per attempt
   ├─ ydb.AcquireSession            INTERNAL · opt-in
   │  └─ ydb.CreateSession          CLIENT   · Query.CreateSession
   ├─ ydb.Transaction               CLIENT
   │  ├─ ydb.Begin                  CLIENT   · Query.BeginTransaction
   │  ├─ ydb.ExecuteQuery           CLIENT   · Query.ExecuteQuery
   │  ├─ ydb.Commit                 CLIENT   · Query.CommitTransaction
   │  └─ ydb.Rollback               CLIENT   · Query.RollbackTransaction
   └─ ydb.ExecuteQuery              CLIENT   · one-shot query, no transaction
```

The auth refresh path piggybacks on the same retry loop when triggered eagerly:

```
ydb.RunWithRetry
└─ ydb.Try
   └─ ydb.TokenFetch                INTERNAL · ydb.auth.provider=<name>
```

A handful of spans appear as roots — they fire on driver-internal timers or fire-and-forget background work, with no parent channel active:

```
ydb.Discovery                       CLIENT   · Discovery.ListEndpoints   (periodic, driver timer)
ydb.DeleteSession                   CLIENT   · Query.DeleteSession       (background, fire-and-forget)
ydb.TokenFetch                      INTERNAL · ydb.auth.provider=<name>  (when fetched outside any request)
```

## Spans

| Span | Channel | Kind | Notable attributes |
| --- | --- | --- | --- |
| `ydb.Discovery` | `tracing:ydb:driver.discovery` | CLIENT | `db.operation.name=Discovery.ListEndpoints`, `ydb.discovery.{added,removed,total}_count`, `ydb.discovery.duration` |
| `ydb.RunWithRetry` | `tracing:ydb:retry.run` | INTERNAL | `ydb.idempotent`, `ydb.retry.attempts_total`, `ydb.retry.total_duration` |
| `ydb.Try` | `tracing:ydb:retry.attempt` | INTERNAL | `ydb.retry.attempt`, `ydb.idempotent` |
| `ydb.Transaction` | `tracing:ydb:query.transaction` | CLIENT | `ydb.isolation`, `ydb.idempotent` |
| `ydb.Begin` / `Commit` / `Rollback` | `tracing:ydb:query.{begin,commit,rollback}` | CLIENT | `db.operation.name`, `ydb.session.id`, `ydb.node.id`, `ydb.transaction.id` |
| `ydb.ExecuteQuery` | `tracing:ydb:query.execute` | CLIENT | `db.operation.name=Query.ExecuteQuery`, `ydb.session.id`, `ydb.node.id`, `ydb.idempotent`, `ydb.isolation`, `db.query.text` (opt-in) |
| `ydb.CreateSession` / `DeleteSession` | `tracing:ydb:query.session.{create,delete}` | CLIENT | `db.operation.name`, `ydb.session.id`, `ydb.node.id`, `ydb.session.close.reason`, `ydb.session.uptime` (delete) |
| `ydb.AcquireSession` | `tracing:ydb:query.session.acquire` | INTERNAL | opt-in via `emitAcquireSessionSpan` |
| `ydb.TokenFetch` | `tracing:ydb:auth.token.fetch` | INTERNAL | `ydb.auth.provider` |

Every span also carries identity (`db.system.name=ydb`, `db.namespace`, `server.address`, `server.port`) and, on error, `error.type` ∈ {`ydb_error`, `transport_error`, `<Error.name>`, `unknown`} plus `db.response.status_code` when the server returned a YDB status.

Connection-pool lifecycle events fold into the active span as `span.addEvent` when one is open:

| Event | Channel |
| --- | --- |
| `ydb.driver.connection.added` | `ydb:driver.connection.added` |
| `ydb.driver.connection.pessimized` / `unpessimized` | `ydb:driver.connection.{pessimized,unpessimized}` |
| `ydb.driver.connection.retired` / `removed` | `ydb:driver.connection.{retired,removed}` |

## Metrics

All instruments are emitted in seconds (OTel canonical) — the `ms → s` conversion lives exclusively in this package. Identity tags (`db.namespace`, `server.address`, `server.port`) are added to every data point when the source payload includes a driver.

### Synchronous

| Instrument | Kind | Unit | Extra tags |
| --- | --- | --- | --- |
| `db.client.operation.duration` | Histogram | `s` | `db.operation.name`, `error.type?` |
| `ydb.driver.connection.pessimizations` | Counter | `{event}` | — |
| `ydb.query.session.create.duration` | Histogram | `s` | — |
| `ydb.query.session.acquire.duration` | Histogram | `s` | — |
| `ydb.query.session.closed` | Counter | `{session}` | `ydb.session.close.reason` |
| `ydb.query.session.acquire.failures` | Counter | `{failure}` | `error.type` |
| `ydb.auth.token.fetch.duration` | Histogram | `s` | `ydb.auth.provider`, `error.type?` |
| `ydb.auth.token.fetch.failures` | Counter | `{failure}` | `ydb.auth.provider`, `error.type` |
| `ydb.auth.token.expirations` | Counter | `{expiration}` | `ydb.auth.provider` |
| `ydb.retry.attempts` | Counter | `{attempt}` | `ydb.idempotent`, `ydb.retry.outcome` ∈ {`success`, `retried`, `non_retryable`, `exhausted`} |
| `ydb.retry.duration` | Histogram | `s` | `ydb.idempotent`, `ydb.retry.outcome` |

### Observable

State is reconstructed from lifecycle events in per-driver registries; late-attaching subscribers miss the initial snapshot (register at process start).

| Instrument | Kind | Unit | Tags |
| --- | --- | --- | --- |
| `ydb.driver.connection.count` | UpDownCounter | `{connection}` | `ydb.connection.state` ∈ {`live`, `pessimized`} |
| `ydb.query.session.count` | UpDownCounter | `{session}` | `ydb.session.state` ∈ {`idle`, `acquired`, `creating`} |
| `ydb.query.session.acquire.pending` | UpDownCounter | `{request}` | — |
| `ydb.query.session.max` / `min` | Gauge | `{session}` | — |

Cardinality budget, opt-in `db.query.text`, deferred instruments, and the full sampler story are documented in `packages/telemetry/README.md`.

## Producer-side changes

| Package | Bump | Highlights |
| --- | --- | --- |
| `@ydbjs/telemetry` | new (minor) | The package itself: traces + metrics pipelines, semconv constants, per-driver state registries, leak/multi-driver/propagation tests. |
| `@ydbjs/query` | minor | New `SessionPool.minSize` option (reported as `ydb.query.session.min`; no eager warm-up yet); `Session.close()` now takes a `SessionCloseReason` (`pool_close` / `attach_failed` / `stream_closed` / `stream_error`); new lifecycle channels (`pool.opened/closed`, `acquired/released`, `waiter.enqueued/dequeued`, `session.delete`). |
| `@ydbjs/retry` | minor | New `ydb:retry.attempt.completed` event (per-attempt outcome counter source); `tracing:ydb:retry.run` ctx now carries `outcome` for end-to-end histogram tagging. |
| `@ydbjs/core` | patch | Channel renames `ydb:pool.connection.*` → `ydb:driver.connection.*` and `ydb:discovery.completed` → `ydb:driver.discovery.completed`; every event payload now carries `DriverIdentity`; `db.operation.name` values are service-prefixed. |

## Testing

- Unit tests: `npm test --workspaces` (471 unit tests across the monorepo, all green).
- Telemetry package suite (48 tests):
  - `tests/propagation.test.ts` — parent/child nesting, retry siblings, ms→s conversion on attributes.
  - `tests/metrics.test.ts` — every leaf-CLIENT histogram, every counter, every observable instrument; close-reason / outcome / error.type tagging.
  - `tests/leak.test.ts` — WeakMap reclamation under GC, orphaned `start` releases, idempotent `disable()`.
  - `tests/multi-driver.test.ts` — span/metric attribution across multiple `DriverIdentity` instances.
  - `tests/config.test.ts` — `captureQueryText` / `emitAcquireSessionSpan` flags, idempotent enable/disable.
- Producer-side coverage: updated `diagnostics.test.ts` in `@ydbjs/core`, `@ydbjs/query`, `@ydbjs/retry` for the new channel names, payload shapes, and `outcome` tagging.

## Checklist

- [x] Changeset added (`.changeset/telemetry-metrics-pipeline.md`).
- [x] README updated for every touched public surface (`packages/telemetry/README.md` is new; `core`, `query`, `retry` READMEs updated with the new channel names and payloads).
