### PR TITLE
Tighten @ydbjs/core dep to ^6.2.0 and refresh OTel deps in @ydbjs/telemetry

### DIFF
--- a/.changeset/telemetry-dep-bumps.md
+++ b/.changeset/telemetry-dep-bumps.md
@@ -1,0 +1,12 @@
+---
+'@ydbjs/telemetry': patch
+---
+
+Tighten `@ydbjs/core` dependency to `^6.2.0` — the new `addClientMiddleware` API used to install the W3C trace context propagation middleware is only available there. Without this bump, installs that resolved `@ydbjs/core` to `6.1.x` would fail at runtime when `register()` tries to install the middleware.
+
+Refresh OpenTelemetry dependencies to current versions:
+
+- `@opentelemetry/api` `^1.9.0` → `^1.9.1`
+- `@opentelemetry/instrumentation` `^0.57.0` → `^0.218.0`
+- `@opentelemetry/semantic-conventions` `^1.32.0` → `^1.41.1`
+- dev deps (`@opentelemetry/core`, `@opentelemetry/context-async-hooks`, `@opentelemetry/sdk-metrics`, `@opentelemetry/sdk-trace-{base,node}`) aligned at `^2.7.1`

--- a/package-lock.json
+++ b/package-lock.json
@@ -824,35 +824,20 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation": {
-			"version": "0.57.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
-			"integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.218.0.tgz",
+			"integrity": "sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "0.57.2",
-				"@types/shimmer": "^1.2.0",
-				"import-in-the-middle": "^1.8.1",
-				"require-in-the-middle": "^7.1.1",
-				"semver": "^7.5.2",
-				"shimmer": "^1.2.1"
+				"@opentelemetry/api-logs": "0.218.0",
+				"import-in-the-middle": "^3.0.0",
+				"require-in-the-middle": "^8.0.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/instrumentation/node_modules/@opentelemetry/api-logs": {
-			"version": "0.57.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
-			"integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/api": "^1.3.0"
-			},
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/@opentelemetry/otlp-exporter-base": {
@@ -1028,57 +1013,6 @@
 				"@opentelemetry/api": ">=1.3.0 <1.10.0"
 			}
 		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation": {
-			"version": "0.218.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.218.0.tgz",
-			"integrity": "sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/api-logs": "0.218.0",
-				"import-in-the-middle": "^3.0.0",
-				"require-in-the-middle": "^8.0.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/cjs-module-lexer": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
-			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
-			"license": "MIT"
-		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/import-in-the-middle": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
-			"integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"acorn": "^8.15.0",
-				"acorn-import-attributes": "^1.9.5",
-				"cjs-module-lexer": "^2.2.0",
-				"module-details-from-path": "^1.0.4"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/require-in-the-middle": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
-			"integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.3.5",
-				"module-details-from-path": "^1.0.3"
-			},
-			"engines": {
-				"node": ">=9.3.0 || >=8.10.0 <9.0.0"
-			}
-		},
 		"node_modules/@opentelemetry/sdk-trace-base": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
@@ -1114,9 +1048,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
-			"integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+			"version": "1.41.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+			"integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
@@ -2732,12 +2666,6 @@
 				"undici-types": ">=7.24.0 <7.24.7"
 			}
 		},
-		"node_modules/@types/shimmer": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
-			"integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
-			"license": "MIT"
-		},
 		"node_modules/@types/unist": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -3560,6 +3488,7 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
 			"integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/cli-highlight": {
@@ -3762,15 +3691,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/es-errors": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/es-module-lexer": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
@@ -3858,15 +3778,6 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
-		"node_modules/function-bind": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -3883,18 +3794,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/hasown": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-			"license": "MIT",
-			"dependencies": {
-				"function-bind": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/hast-util-to-html": {
@@ -3981,31 +3880,25 @@
 			}
 		},
 		"node_modules/import-in-the-middle": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
-			"integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+			"integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"acorn": "^8.14.0",
+				"acorn": "^8.15.0",
 				"acorn-import-attributes": "^1.9.5",
-				"cjs-module-lexer": "^1.2.2",
-				"module-details-from-path": "^1.0.3"
-			}
-		},
-		"node_modules/is-core-module": {
-			"version": "2.16.2",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
-			"integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
-			"license": "MIT",
-			"dependencies": {
-				"hasown": "^2.0.3"
+				"cjs-module-lexer": "^2.2.0",
+				"module-details-from-path": "^1.0.4"
 			},
 			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
+				"node": ">=18"
 			}
+		},
+		"node_modules/import-in-the-middle/node_modules/cjs-module-lexer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+			"license": "MIT"
 		},
 		"node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
@@ -4767,12 +4660,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"license": "MIT"
-		},
 		"node_modules/pathe": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -4885,38 +4772,16 @@
 			}
 		},
 		"node_modules/require-in-the-middle": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
-			"integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+			"integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.3.5",
-				"module-details-from-path": "^1.0.3",
-				"resolve": "^1.22.8"
+				"module-details-from-path": "^1.0.3"
 			},
 			"engines": {
-				"node": ">=8.6.0"
-			}
-		},
-		"node_modules/resolve": {
-			"version": "1.22.12",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-			"integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"is-core-module": "^2.16.1",
-				"path-parse": "^1.0.7",
-				"supports-preserve-symlinks-flag": "^1.0.0"
-			},
-			"bin": {
-				"resolve": "bin/resolve"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
+				"node": ">=9.3.0 || >=8.10.0 <9.0.0"
 			}
 		},
 		"node_modules/rolldown": {
@@ -5000,6 +4865,7 @@
 		},
 		"node_modules/semver": {
 			"version": "7.7.4",
+			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -5024,12 +4890,6 @@
 				"@shikijs/vscode-textmate": "^10.0.2",
 				"@types/hast": "^3.0.4"
 			}
-		},
-		"node_modules/shimmer": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-			"license": "BSD-2-Clause"
 		},
 		"node_modules/siginfo": {
 			"version": "2.0.0",
@@ -5178,18 +5038,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
-			}
-		},
-		"node_modules/supports-preserve-symlinks-flag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/tabbable": {
@@ -6595,20 +6443,20 @@
 			"version": "6.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api": "^1.9.0",
-				"@opentelemetry/instrumentation": "^0.57.0",
-				"@opentelemetry/semantic-conventions": "^1.32.0",
+				"@opentelemetry/api": "^1.9.1",
+				"@opentelemetry/instrumentation": "^0.218.0",
+				"@opentelemetry/semantic-conventions": "^1.41.1",
 				"@ydbjs/api": "^6.0.0",
-				"@ydbjs/core": "^6.0.0",
+				"@ydbjs/core": "^6.2.0",
 				"@ydbjs/error": "^6.0.0",
 				"nice-grpc": "^2.1.13"
 			},
 			"devDependencies": {
 				"@opentelemetry/context-async-hooks": "^2.7.1",
-				"@opentelemetry/core": "^2.7.0",
-				"@opentelemetry/sdk-metrics": "^2.7.0",
-				"@opentelemetry/sdk-trace-base": "^2.0.0",
-				"@opentelemetry/sdk-trace-node": "^2.0.0",
+				"@opentelemetry/core": "^2.7.1",
+				"@opentelemetry/sdk-metrics": "^2.7.1",
+				"@opentelemetry/sdk-trace-base": "^2.7.1",
+				"@opentelemetry/sdk-trace-node": "^2.7.1",
 				"@types/debug": "^4.1.12"
 			},
 			"engines": {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -47,20 +47,20 @@
 		"attw": "attw --pack --profile esm-only"
 	},
 	"dependencies": {
-		"@opentelemetry/api": "^1.9.0",
-		"@opentelemetry/instrumentation": "^0.57.0",
-		"@opentelemetry/semantic-conventions": "^1.32.0",
+		"@opentelemetry/api": "^1.9.1",
+		"@opentelemetry/instrumentation": "^0.218.0",
+		"@opentelemetry/semantic-conventions": "^1.41.1",
 		"@ydbjs/api": "^6.0.0",
-		"@ydbjs/core": "^6.0.0",
+		"@ydbjs/core": "^6.2.0",
 		"@ydbjs/error": "^6.0.0",
 		"nice-grpc": "^2.1.13"
 	},
 	"devDependencies": {
 		"@opentelemetry/context-async-hooks": "^2.7.1",
-		"@opentelemetry/core": "^2.7.0",
-		"@opentelemetry/sdk-metrics": "^2.7.0",
-		"@opentelemetry/sdk-trace-base": "^2.0.0",
-		"@opentelemetry/sdk-trace-node": "^2.0.0",
+		"@opentelemetry/core": "^2.7.1",
+		"@opentelemetry/sdk-metrics": "^2.7.1",
+		"@opentelemetry/sdk-trace-base": "^2.7.1",
+		"@opentelemetry/sdk-trace-node": "^2.7.1",
 		"@types/debug": "^4.1.12"
 	},
 	"engines": {


### PR DESCRIPTION
## Summary

- `@ydbjs/telemetry@6.0.0` declared `@ydbjs/core: ^6.0.0`, but `register()` calls the new `addClientMiddleware` API that only exists in `@ydbjs/core@^6.2.0`. An install that resolved core to `6.1.x` (still satisfying `^6.0.0`) would throw at runtime when the W3C trace context propagation middleware is installed. Tightening the constraint to `^6.2.0` fixes this.
- Refresh OpenTelemetry deps to current versions — the 0.x line of `@opentelemetry/instrumentation` had multiple "majors" worth of releases since `0.57` (now `0.218`). `InstrumentationBase` API surface we use is unchanged; build + tests + attw all green locally.

## Test plan

- [x] `npm run build` — clean build of `@ydbjs/telemetry` with bumped deps
- [x] `npx vitest --run` — 52/52 tests pass
- [x] `npx attw --pack --profile esm-only` — ESM / bundler resolutions green on both `.` and `./register` subpaths