### PR TITLE
Credit @scarlettnik in drizzle-adapter 0.1.0 release notes

### DIFF
--- a/.changeset/drizzle-adapter-initial.md
+++ b/.changeset/drizzle-adapter-initial.md
@@ -4,6 +4,8 @@
 
 Initial release of `@ydbjs/drizzle-adapter` — a YDB adapter for [Drizzle ORM](https://orm.drizzle.team).
 
+Originally authored by [@scarlettnik](https://github.com/scarlettnik); rebased and polished for the 0.1.0 release.
+
 - `createDrizzle(...)` / `drizzle(...)` entry points (connection string, existing `Driver`, custom executor, or remote callback)
 - `ydbTable()` schema builder with YDB-specific column types, indexes, primary keys, unique constraints, table options, TTL, column families, partitioning
 - Full query builder surface: `select`, `insert`, `upsert`, `update`, `delete`, returning, joins, CTE, set operators, relational `db.query.*`, `$count`

--- a/third-parties/drizzle-adapter/CHANGELOG.md
+++ b/third-parties/drizzle-adapter/CHANGELOG.md
@@ -1,5 +1,1 @@
 # @ydbjs/drizzle-adapter
-
-## 0.1.0
-
-Initial version.


### PR DESCRIPTION
## What

Add a `@scarlettnik` attribution line to the pending `@ydbjs/drizzle-adapter` 0.1.0 changeset so it appears in the auto-generated CHANGELOG and the GitHub Release notes, and drop a stale pre-fill from the package CHANGELOG so the changesets bot can produce a clean entry.

## Why

`@scarlettnik` wrote the initial drizzle-adapter package (squash of their work landed on \`main\` as part of #613, with git-author preserved). The `@changesets/changelog-github` formatter, however, only thanks the author of the changeset markdown file — so without this tweak v0.1.0 publishes with `Thanks @polRk!` and no mention of the original author.

The stale `## 0.1.0 / Initial version.` block in \`third-parties/drizzle-adapter/CHANGELOG.md\` was a pre-fill from earlier in the branch; the bot prepends new entries rather than replacing existing ones, so leaving it caused PR #614 to produce a duplicate \`## 0.1.0\` heading with orphaned text underneath. Removing it now lets the bot regenerate a single clean entry.

## Changes

- \`.changeset/drizzle-adapter-initial.md\` — add "Originally authored by @scarlettnik; rebased and polished for the 0.1.0 release." after the headline.
- \`third-parties/drizzle-adapter/CHANGELOG.md\` — strip the pre-filled \`## 0.1.0 / Initial version.\` block; keep only the package title so the bot has a clean base.

## Testing

- \`turbo build + vitest\` via the repo pre-push hook — 611 tests across the workspace, green.

## Follow-up

After merge, the changesets bot will regenerate PR #614 (Version Packages) with the updated CHANGELOG entry. Merging #614 then publishes v0.1.0 with proper attribution in both CHANGELOG and GitHub Release.