### PR TITLE
Split SLO workflow and gate report on success

### DIFF
--- a/.github/workflows/slo-report.yml
+++ b/.github/workflows/slo-report.yml
@@ -1,0 +1,40 @@
+name: slo-report
+
+on:
+  workflow_run:
+    workflows: ['SLO']
+    types:
+      - completed
+
+jobs:
+  publish-slo-report:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    name: Publish YDB SLO Report
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Publish YDB SLO Report
+        uses: ydb-platform/ydb-slo-action/report@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_run_id: ${{ github.event.workflow_run.id }}
+
+  remove-slo-label:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    name: Remove SLO Label
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove SLO label from PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+          REPO: ${{ github.event.workflow_run.repository.full_name }}
+        run: |
+          set -euo pipefail
+          PR=$(jq -r '.[0].number' <<<"$PRS")
+          gh pr edit "$PR" --repo "$REPO" --remove-label SLO

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -1,35 +1,10 @@
 name: SLO
 
 on:
-  push:
-    branches:
-      - main
-
   pull_request:
     types: [opened, reopened, synchronize, labeled]
     branches:
       - main
-
-  workflow_dispatch:
-    inputs:
-      github_issue:
-        description: 'GitHub issue number where the SLO results will be reported'
-        required: true
-      baseline_ref:
-        description: 'Baseline commit/branch/tag to compare against (leave empty to auto-detect merge-base with main)'
-        required: false
-      slo_workload_duration_seconds:
-        description: 'Duration of the SLO workload in seconds'
-        required: false
-        default: '600'
-      slo_workload_read_max_rps:
-        description: 'Maximum read RPS for the SLO workload'
-        required: false
-        default: '1000'
-      slo_workload_write_max_rps:
-        description: 'Maximum write RPS for the SLO workload'
-        required: false
-        default: '100'
 
 jobs:
   ydb-slo-action:
@@ -100,11 +75,7 @@ jobs:
         id: baseline
         run: |
           cd current
-          if [[ -n "${{ inputs.baseline_ref }}" ]]; then
-            BASELINE="${{ inputs.baseline_ref }}"
-          else
-            BASELINE=$(git merge-base HEAD origin/main)
-          fi
+          BASELINE=$(git merge-base HEAD origin/main)
           echo "sha=$BASELINE" >> $GITHUB_OUTPUT
 
           # Try to determine a human-readable ref name for baseline
@@ -162,35 +133,19 @@ jobs:
         uses: ydb-platform/ydb-slo-action/init@v2
         timeout-minutes: 30
         with:
-          github_issue: ${{ github.event.inputs.github_issue }}
+          github_issue: ${{ github.event.pull_request.number }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workload_name: ${{ matrix.sdk.name }}
-          workload_duration: ${{ inputs.slo_workload_duration_seconds || '600' }}
+          workload_duration: '600'
           workload_current_ref: ${{ github.head_ref || github.ref_name }}
           workload_current_image: ydb-app-current
           workload_current_command: >-
             ${{ matrix.sdk.command }}
-            --kv.read.rps=${{ inputs.slo_workload_read_max_rps || '1000' }}
-            --kv.write.rps=${{ inputs.slo_workload_write_max_rps || '100' }}
+            --kv.read.rps=1000
+            --kv.write.rps=100
           workload_baseline_ref: ${{ steps.baseline.outputs.ref }}
           workload_baseline_image: ydb-app-baseline
           workload_baseline_command: >-
             ${{ matrix.sdk.command }}
-            --kv.read.rps=${{ inputs.slo_workload_read_max_rps || '1000' }}
-            --kv.write.rps=${{ inputs.slo_workload_write_max_rps || '100' }}
-
-  ydb-slo-report:
-    if: always()
-    needs: ydb-slo-action
-    runs-on: ubuntu-latest
-    name: Publish YDB SLO Report
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Publish YDB SLO Report
-        uses: ydb-platform/ydb-slo-action/report@v2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          github_run_id: ${{ github.run_id }}
+            --kv.read.rps=1000
+            --kv.write.rps=100


### PR DESCRIPTION
## Summary
- Drop `push` and `workflow_dispatch` triggers from `slo.yml`; SLO tests now only run on PRs labeled `SLO`, so push events no longer queue a workflow whose report job fails with nothing to publish.
- Move report publication into a new `slo-report.yml` triggered via `workflow_run`, gated on `conclusion == 'success'`, and add a job that removes the `SLO` label from the PR after the run.
- Clean up dispatch-only inputs: baseline is always `merge-base HEAD origin/main`, `github_issue` is the PR number, RPS/duration are hardcoded defaults.

Mirrors the approach landed in ydb-platform/ydb-java-sdk#644.

## Test plan
- [ ] Push to a branch without the `SLO` label — no SLO workflow runs, no failing "Publish YDB SLO Report".
- [ ] Add the `SLO` label to a PR — `slo.yml` runs, `slo-report.yml` fires on completion and publishes the report.
- [ ] After the report runs, the `SLO` label is removed from the PR.