### PR TITLE
Extend x-ydb-sdk-build-info with framework libraries

### DIFF
--- a/.changeset/core-build-info-libraries.md
+++ b/.changeset/core-build-info-libraries.md
@@ -1,0 +1,15 @@
+---
+'@ydbjs/core': minor
+---
+
+Let libraries layered on top of the SDK advertise themselves in the `x-ydb-sdk-build-info` header.
+
+Frameworks (e.g. `@ydbjs/drizzle-adapter`) call `driver[kRegisterLibrary](name, version)` after constructing or borrowing a `Driver`. Registered entries are appended after the native `ydb-js-sdk/<version>` token, separated by `;`, matching the server-side parser which keys off the leading native SDK token. Repeated registrations of the same `name/version` are deduplicated; the header string is built once per registration so the per-RPC middleware just reads a cached field.
+
+```ts
+import { Driver, kRegisterLibrary } from '@ydbjs/core'
+
+let driver = new Driver(connectionString)
+driver[kRegisterLibrary]('@ydbjs/drizzle-adapter', '0.1.0')
+// x-ydb-sdk-build-info: ydb-js-sdk/6.2.0;@ydbjs/drizzle-adapter/0.1.0
+```

--- a/.changeset/drizzle-adapter-build-info.md
+++ b/.changeset/drizzle-adapter-build-info.md
@@ -1,0 +1,5 @@
+---
+'@ydbjs/drizzle-adapter': patch
+---
+
+Advertise the adapter in `x-ydb-sdk-build-info`. `YdbDriver` now registers `@ydbjs/drizzle-adapter/<version>` on the underlying `Driver` for both owned and borrowed instances, so server-side telemetry can attribute traffic to the adapter without losing the native SDK identity (which stays first in the header).

--- a/packages/core/src/driver.test.ts
+++ b/packages/core/src/driver.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest'
 import { DiscoveryServiceDefinition } from '@ydbjs/api/discovery'
 import { createServer } from 'nice-grpc'
 
-import { Driver } from './driver.ts'
+import { Driver, kRegisterLibrary } from './driver.ts'
 import pkg from '../package.json' with { type: 'json' }
 
 test('database in pathname', async () => {
@@ -90,6 +90,49 @@ test('adds x-ydb-sdk-build-info header with current sdk version', async () => {
 		await client.listEndpoints({ database: driver.database })
 
 		expect(receivedBuildInfo).toBe(`ydb-js-sdk/${pkg.version}`)
+	} finally {
+		driver.close()
+		await server.shutdown()
+	}
+})
+
+test('appends registered libraries to x-ydb-sdk-build-info after the native sdk token', async () => {
+	let server = createServer()
+	let received: string[] = []
+	let discoveryService = {
+		listEndpoints: DiscoveryServiceDefinition.listEndpoints,
+		whoAmI: DiscoveryServiceDefinition.whoAmI,
+	}
+
+	server.add(discoveryService, {
+		async listEndpoints(_, context) {
+			received.push(context.metadata.get('x-ydb-sdk-build-info') ?? '')
+			return {}
+		},
+		async whoAmI() {
+			return {}
+		},
+	})
+
+	let port = await server.listen('127.0.0.1:0')
+	let driver = new Driver(`grpc://127.0.0.1:${port}/local`, {
+		'ydb.sdk.enable_discovery': false,
+	})
+
+	try {
+		let client = driver.createClient(discoveryService)
+
+		driver[kRegisterLibrary]('@ydbjs/drizzle-adapter', '1.2.3')
+		await client.listEndpoints({ database: driver.database })
+
+		driver[kRegisterLibrary]('@ydbjs/drizzle-adapter', '1.2.3')
+		driver[kRegisterLibrary]('@ydbjs/other', '0.1.0')
+		await client.listEndpoints({ database: driver.database })
+
+		expect(received[0]).toBe(`ydb-js-sdk/${pkg.version};@ydbjs/drizzle-adapter/1.2.3`)
+		expect(received[1]).toBe(
+			`ydb-js-sdk/${pkg.version};@ydbjs/drizzle-adapter/1.2.3;@ydbjs/other/0.1.0`
+		)
 	} finally {
 		driver.close()
 		await server.shutdown()

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -107,6 +107,8 @@ function databaseFromUrl(url: URL): string {
 	return ''
 }
 
+export const kRegisterLibrary: unique symbol = Symbol('ydbjs.core.registerLibrary')
+
 let defaultOptions: DriverOptions = {
 	'ydb.sdk.ready_timeout_ms': 30_000,
 	'ydb.sdk.token_timeout_ms': 10_000,
@@ -168,6 +170,9 @@ export class Driver implements Disposable {
 	#shutdown = new AbortController()
 
 	#credentialsProvider: CredentialsProvider = new AnonymousCredentialsProvider()
+
+	#libraries: Set<string> = new Set()
+	#buildInfo: string = `ydb-js-sdk/${pkg.version}`
 
 	// Construction time, used for `driver.ready.duration` and `driver.closed.uptime`.
 	#initAt: number
@@ -409,10 +414,17 @@ export class Driver implements Disposable {
 		return this.isSecure ? credentials.createSsl() : credentials.createInsecure()
 	}
 
+	[kRegisterLibrary](name: string, version: string): void {
+		let entry = `${name}/${version}`
+		if (this.#libraries.has(entry)) return
+		this.#libraries.add(entry)
+		this.#buildInfo = `${this.#buildInfo};${entry}`
+	}
+
 	#buildMiddleware(): ClientMiddleware {
 		let stamp: ClientMiddleware = (call, options) => {
 			let metadata = Metadata(options.metadata)
-				.set('x-ydb-sdk-build-info', `ydb-js-sdk/${pkg.version}`)
+				.set('x-ydb-sdk-build-info', this.#buildInfo)
 				.set('x-ydb-database', this.database)
 				.set('x-ydb-application-name', this.application)
 

--- a/third-parties/drizzle-adapter/src/ydb/driver.test.ts
+++ b/third-parties/drizzle-adapter/src/ydb/driver.test.ts
@@ -1,17 +1,18 @@
 import { test } from 'vitest'
 import * as assert from 'node:assert/strict'
-import { Driver } from '@ydbjs/core'
+import { kRegisterLibrary } from '@ydbjs/core'
 import { YdbDriver } from '../index.ts'
-import { createMockQueryFunction } from '../../tests/helpers/mock-driver.ts'
+import {
+	createBorrowedDriverStub,
+	createMockQueryFunction,
+} from '../../tests/helpers/mock-driver.ts'
+import pkg from '../../package.json' with { type: 'json' }
 
 test('wraps a borrowed Driver without owning it', async () => {
 	let readyCalls = 0
 	let closeCalls = 0
 	let signal = new AbortController().signal
-	let borrowedDriver = Object.create(Driver.prototype) as Driver & {
-		ready(signal?: AbortSignal): Promise<void>
-		close(): void
-	}
+	let borrowedDriver = createBorrowedDriverStub()
 
 	borrowedDriver.ready = async (incomingSignal?: AbortSignal) => {
 		readyCalls++
@@ -32,7 +33,7 @@ test('wraps a borrowed Driver without owning it', async () => {
 })
 
 test('forwards execute params and result meta', async () => {
-	let borrowedDriver = Object.create(Driver.prototype) as Driver
+	let borrowedDriver = createBorrowedDriverStub()
 	let driver = new YdbDriver(borrowedDriver)
 	let mockClient = createMockQueryFunction([{ pony: 'Twilight' }], [['Twilight', 7]])
 
@@ -71,7 +72,7 @@ test('forwards execute params and result meta', async () => {
 })
 
 test('begins transactions with mapped isolation', async () => {
-	let borrowedDriver = Object.create(Driver.prototype) as Driver
+	let borrowedDriver = createBorrowedDriverStub()
 	let driver = new YdbDriver(borrowedDriver)
 	let txQuery = createMockQueryFunction([{ ok: true }])
 	let beginCalls: unknown[][] = []
@@ -112,7 +113,7 @@ test('begins transactions with mapped isolation', async () => {
 })
 
 test('rejects multi-result-set responses', async () => {
-	let borrowedDriver = Object.create(Driver.prototype) as Driver
+	let borrowedDriver = createBorrowedDriverStub()
 	let driver = new YdbDriver(borrowedDriver)
 
 	;(driver as any).client = ((_text: string) => {
@@ -131,6 +132,21 @@ test('rejects multi-result-set responses', async () => {
 	}) as any
 
 	await assert.rejects(driver.execute('select 1; select 2', [], 'execute'), /2 result sets/)
+})
+
+test('registers itself in x-ydb-sdk-build-info via kRegisterLibrary', () => {
+	let calls: Array<[string, string]> = []
+	let borrowedDriver = createBorrowedDriverStub()
+	;(borrowedDriver as unknown as Record<symbol, unknown>)[kRegisterLibrary] = (
+		name: string,
+		version: string
+	) => {
+		calls.push([name, version])
+	}
+
+	new YdbDriver(borrowedDriver)
+
+	assert.deepEqual(calls, [['@ydbjs/drizzle-adapter', pkg.version]])
 })
 
 test('creates an executor from a remote callback', async () => {

--- a/third-parties/drizzle-adapter/src/ydb/driver.ts
+++ b/third-parties/drizzle-adapter/src/ydb/driver.ts
@@ -1,6 +1,8 @@
-import { Driver } from '@ydbjs/core'
+import { Driver, kRegisterLibrary } from '@ydbjs/core'
 import { type QueryClient, type TX, query as createQueryClient } from '@ydbjs/query'
 import { fromJs } from '@ydbjs/value'
+
+import pkg from '../../package.json' with { type: 'json' }
 export interface YdbTransactionConfig {
 	accessMode?: 'read only' | 'read write' | undefined
 	isolationLevel?: 'serializableReadWrite' | 'snapshotReadOnly' | undefined
@@ -163,6 +165,8 @@ export class YdbDriver implements YdbTransactionalExecutor {
 			this.driver = new Driver(arg.connectionString)
 			this.#ownsDriver = true
 		}
+
+		this.driver[kRegisterLibrary]('@ydbjs/drizzle-adapter', pkg.version)
 	}
 
 	// Lazy: avoid constructing SessionPool until the first query/transaction.

--- a/third-parties/drizzle-adapter/tests/helpers/mock-driver.ts
+++ b/third-parties/drizzle-adapter/tests/helpers/mock-driver.ts
@@ -1,3 +1,14 @@
+import { Driver, kRegisterLibrary } from '@ydbjs/core'
+
+// Object.create(Driver.prototype) skips constructor → no private fields.
+// Driver.prototype[kRegisterLibrary] reads #libraries, so YdbDriver's
+// constructor would TypeError on such a mock. Stub the symbol to no-op.
+export function createBorrowedDriverStub(): Driver {
+	let stub = Object.create(Driver.prototype) as Driver
+	;(stub as unknown as Record<symbol, unknown>)[kRegisterLibrary] = () => {}
+	return stub
+}
+
 export type MockQueryCall = {
 	text: string
 	params: Array<{ name: string; value: unknown }>


### PR DESCRIPTION
## Summary
- New `kRegisterLibrary` Symbol export from `@ydbjs/core`. Frameworks layered on top of the SDK call `driver[kRegisterLibrary](name, version)` to advertise themselves in the `x-ydb-sdk-build-info` header. Native `ydb-js-sdk/<version>` stays first (the server-side parser keys off it); registered entries are appended after, separated by `;`. Repeated registrations of the same `name/version` are deduplicated.
- The header string is rebuilt in the mutator and cached on the Driver, so the per-RPC middleware just reads a field — no spreads, joins, or per-call allocations on the hot path.
- `@ydbjs/drizzle-adapter` registers itself in `YdbDriver`'s constructor for both owned and borrowed driver branches, so traffic from the adapter is attributable regardless of who built the Driver.
- Sample header: `ydb-js-sdk/6.2.0;@ydbjs/drizzle-adapter/0.1.0`.

## Test plan
- [x] `cd packages/core && npx vitest run driver.test` — covers native-first ordering, append, dedup
- [x] `cd third-parties/drizzle-adapter && npx vitest run --project uni src/ydb/driver.test` — verifies YdbDriver registers `@ydbjs/drizzle-adapter` with its `package.json` version
- [x] `npx tsc --noEmit` in both packages