### PR TITLE
feat: add @ydbjs/langchain — YDB VectorStore for LangChain.js

### DIFF
--- a/.changeset/add-langchain-vectorstore.md
+++ b/.changeset/add-langchain-vectorstore.md
@@ -1,0 +1,5 @@
+---
+'@ydbjs/langchain': minor
+---
+
+Initial release: `YDBVectorStore` — a LangChain.js VectorStore backed by YDB with KNN search, metadata filtering, and approximate nearest-neighbour index support.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
 					{ text: 'Topic', link: '/guide/topic/' },
 					{ text: 'Coordination', link: '/guide/coordination/' },
 					{ text: 'Drizzle', link: '/guide/drizzle/' },
+					{ text: 'LangChain', link: '/guide/langchain/' },
 					{ text: 'Advanced', link: '/advanced/' },
 				],
 				sidebar: [
@@ -267,6 +268,15 @@ export default defineConfig({
 						],
 					},
 					{
+						text: 'LangChain',
+						items: [
+							{
+								text: 'Overview',
+								link: '/guide/langchain/',
+							},
+						],
+					},
+					{
 						text: 'Advanced',
 						items: [
 							{
@@ -309,6 +319,7 @@ export default defineConfig({
 					{ text: 'Topic', link: '/ru/guide/topic/' },
 					{ text: 'Coordination', link: '/ru/guide/coordination/' },
 					{ text: 'Drizzle', link: '/ru/guide/drizzle/' },
+					{ text: 'LangChain', link: '/ru/guide/langchain/' },
 					{ text: 'Расширенные темы', link: '/ru/advanced/' },
 				],
 				sidebar: [
@@ -560,6 +571,15 @@ export default defineConfig({
 										link: '/ru/guide/drizzle/#examples-vector-search',
 									},
 								],
+							},
+						],
+					},
+					{
+						text: 'LangChain',
+						items: [
+							{
+								text: 'Обзор',
+								link: '/ru/guide/langchain/',
 							},
 						],
 					},

--- a/docs/guide/langchain/index.md
+++ b/docs/guide/langchain/index.md
@@ -1,0 +1,204 @@
+---
+title: LangChain — YDB Vector Store
+description: 'YDB VectorStore for LangChain.js: KNN search, metadata filtering, and approximate nearest-neighbour index.'
+---
+
+# LangChain `@ydbjs/langchain`
+
+[YDB](https://ydb.tech) integration for [LangChain.js](https://js.langchain.com) — a `VectorStore` backed by YDB with KNN search support.
+
+## Installation
+
+```bash
+npm install @ydbjs/langchain @langchain/core
+```
+
+## Quick Start
+
+```typescript
+import { YDBVectorStore } from '@ydbjs/langchain'
+import { OpenAIEmbeddings } from '@langchain/openai'
+
+await using store = new YDBVectorStore(new OpenAIEmbeddings(), {
+  connectionString: 'grpc://localhost:2136/local',
+})
+
+await store.addDocuments([{ pageContent: 'LangChain supports YDB', metadata: { source: 'docs' } }])
+
+const results = await store.similaritySearch('YDB vector search', 4)
+console.log(results)
+```
+
+`await using` calls `store[Symbol.asyncDispose]()` automatically on scope exit — no need to call `store.close()` explicitly.
+
+## Driver Lifecycle
+
+### Store-managed Driver (connection string)
+
+The store creates and owns the Driver. Use `await using` or call `store.close()` when done.
+
+```typescript
+const store = new YDBVectorStore(embeddings, {
+  connectionString: 'grpc://localhost:2136/local',
+})
+// ...
+store.close()
+```
+
+### Caller-managed Driver
+
+Pass your own `Driver` instance — its lifecycle is yours to manage.
+
+```typescript
+import { Driver } from '@ydbjs/core'
+
+const driver = new Driver('grpc://localhost:2136/local')
+await driver.ready()
+
+const store = new YDBVectorStore(embeddings, { driver })
+// ...
+driver.close()
+```
+
+## Static Helpers
+
+```typescript
+// Create store and insert documents in one call
+const store = await YDBVectorStore.fromDocuments(docs, embeddings, {
+  connectionString: 'grpc://localhost:2136/local',
+})
+
+// Connect to an existing table without running CREATE TABLE
+const store = YDBVectorStore.fromExistingTable(embeddings, {
+  driver,
+  table: 'my_vectors',
+})
+```
+
+## Inserting Documents
+
+```typescript
+import { Document } from '@langchain/core/documents'
+
+const ids = await store.addDocuments([
+  new Document({ pageContent: 'first doc', metadata: { source: 'wiki' } }),
+  new Document({ pageContent: 'second doc', metadata: { source: 'docs' }, id: 'my-id' }),
+])
+// ids[0] → auto-generated UUID
+// ids[1] → 'my-id'
+```
+
+- Documents without an `id` receive a random UUID.
+- Re-inserting a document with the same `id` **replaces** it (UPSERT semantics).
+- Batches larger than 32 documents are split automatically.
+
+## Similarity Search
+
+```typescript
+// Returns Document[]
+const docs = await store.similaritySearch('query text', 4)
+
+// Returns [Document, score][]
+const scored = await store.similaritySearchWithScore('query text', 4)
+
+// Search using a pre-computed embedding vector
+const vectorResults = await store.similaritySearchVectorWithScore(queryVector, 4)
+```
+
+## Metadata Filtering
+
+Each key-value pair becomes a `JSON_VALUE` predicate; multiple pairs are combined with `AND`.
+
+```typescript
+const results = await store.similaritySearch('query', 4, {
+  source: 'docs',
+  lang: 'en',
+})
+```
+
+> **Note:** metadata filtering is incompatible with `indexEnabled: true`.
+
+## Search Strategies
+
+| Strategy                     | Sort | Best match    |
+| ---------------------------- | ---- | ------------- |
+| `CosineSimilarity` (default) | DESC | highest score |
+| `InnerProductSimilarity`     | DESC | highest score |
+| `CosineDistance`             | ASC  | lowest score  |
+| `EuclideanDistance`          | ASC  | lowest score  |
+| `ManhattanDistance`          | ASC  | lowest score  |
+
+```typescript
+import { YDBVectorStore, YDBSearchStrategy } from '@ydbjs/langchain'
+
+const store = new YDBVectorStore(embeddings, {
+  driver,
+  strategy: YDBSearchStrategy.EuclideanDistance,
+})
+```
+
+## Approximate Nearest-Neighbour Index
+
+Build a `vector_kmeans_tree` index for sub-linear search on large tables.
+
+```typescript
+const store = new YDBVectorStore(embeddings, {
+  driver,
+  indexEnabled: true,
+  vectorDimension: 1536, // skip auto-detect probe
+})
+
+await store.addDocuments(docs)
+await store.createVectorIndex() // build once after initial load
+```
+
+Tune the index with optional parameters:
+
+| Config option            | Default                    | Description                                     |
+| ------------------------ | -------------------------- | ----------------------------------------------- |
+| `indexName`              | `"langchain_vector_index"` | Name of the YDB index                           |
+| `indexConfigLevels`      | `2`                        | Tree depth (Recommended 1–3)                    |
+| `indexConfigClusters`    | `128`                      | k-means clusters per level (Recommended 64–512) |
+| `indexTreeSearchTopSize` | `1`                        | Leaf clusters visited at query time             |
+
+## Deleting Documents
+
+```typescript
+// Delete specific documents
+await store.delete({ ids: ['id1', 'id2'] })
+
+// Truncate the entire table
+await store.delete({ deleteAll: true })
+
+// Drop the table entirely (recreated on next write)
+await store.drop()
+```
+
+## Column Name Overrides
+
+Use `columnMap` when connecting to a table with a custom schema.
+
+```typescript
+const store = new YDBVectorStore(embeddings, {
+  driver,
+  table: 'my_vectors',
+  columnMap: {
+    id: 'doc_id',
+    document: 'doc_text',
+    embedding: 'doc_vec',
+    metadata: 'doc_meta',
+  },
+})
+```
+
+## Examples
+
+The repository contains a runnable example:
+
+- `examples/langchain` — compact TypeScript CLI example showing insert, search, metadata filter, delete, and search strategies.
+
+```bash
+cd examples/langchain
+npm install
+OPENAI_API_KEY=sk-... npm start
+```

--- a/docs/ru/guide/langchain/index.md
+++ b/docs/ru/guide/langchain/index.md
@@ -1,0 +1,206 @@
+---
+title: LangChain — YDB Vector Store
+description: 'YDB VectorStore для LangChain.js: KNN-поиск, фильтрация по метаданным и приближённый поиск ближайших соседей.'
+---
+
+# LangChain `@ydbjs/langchain`
+
+Интеграция [YDB](https://ydb.tech) для [LangChain.js](https://js.langchain.com) — `VectorStore` на базе YDB с поддержкой KNN-поиска.
+
+## Установка
+
+```bash
+npm install @ydbjs/langchain @langchain/core
+```
+
+## Быстрый старт
+
+```typescript
+import { YDBVectorStore } from '@ydbjs/langchain'
+import { OpenAIEmbeddings } from '@langchain/openai'
+
+await using store = new YDBVectorStore(new OpenAIEmbeddings(), {
+  connectionString: 'grpc://localhost:2136/local',
+})
+
+await store.addDocuments([
+  { pageContent: 'LangChain поддерживает YDB', metadata: { source: 'docs' } },
+])
+
+const results = await store.similaritySearch('YDB векторный поиск', 4)
+console.log(results)
+```
+
+`await using` автоматически вызывает `store[Symbol.asyncDispose]()` при выходе из области видимости — вызывать `store.close()` явно не нужно.
+
+## Управление жизненным циклом Driver
+
+### Driver, управляемый стором (connection string)
+
+Стор создаёт Driver и владеет им. Используйте `await using` или вызывайте `store.close()` по завершении.
+
+```typescript
+const store = new YDBVectorStore(embeddings, {
+  connectionString: 'grpc://localhost:2136/local',
+})
+// ...
+store.close()
+```
+
+### Driver, управляемый вызывающим кодом
+
+Передайте готовый экземпляр `Driver` — его жизненный цикл остаётся за вами.
+
+```typescript
+import { Driver } from '@ydbjs/core'
+
+const driver = new Driver('grpc://localhost:2136/local')
+await driver.ready()
+
+const store = new YDBVectorStore(embeddings, { driver })
+// ...
+driver.close()
+```
+
+## Статические хелперы
+
+```typescript
+// Создать стор и вставить документы за один вызов
+const store = await YDBVectorStore.fromDocuments(docs, embeddings, {
+  connectionString: 'grpc://localhost:2136/local',
+})
+
+// Подключиться к существующей таблице без CREATE TABLE
+const store = YDBVectorStore.fromExistingTable(embeddings, {
+  driver,
+  table: 'my_vectors',
+})
+```
+
+## Вставка документов
+
+```typescript
+import { Document } from '@langchain/core/documents'
+
+const ids = await store.addDocuments([
+  new Document({ pageContent: 'первый документ', metadata: { source: 'wiki' } }),
+  new Document({ pageContent: 'второй документ', metadata: { source: 'docs' }, id: 'my-id' }),
+])
+// ids[0] → автоматически сгенерированный UUID
+// ids[1] → 'my-id'
+```
+
+- Документы без явного `id` получают случайный UUID.
+- Повторная вставка документа с тем же `id` **заменяет** его (семантика UPSERT).
+- Батчи больше 32 документов разбиваются автоматически.
+
+## Поиск по сходству
+
+```typescript
+// Возвращает Document[]
+const docs = await store.similaritySearch('текст запроса', 4)
+
+// Возвращает [Document, score][]
+const scored = await store.similaritySearchWithScore('текст запроса', 4)
+
+// Поиск по готовому вектору эмбеддинга
+const vectorResults = await store.similaritySearchVectorWithScore(queryVector, 4)
+```
+
+## Фильтрация по метаданным
+
+Каждая пара ключ-значение превращается в предикат `JSON_VALUE`; несколько пар объединяются через `AND`.
+
+```typescript
+const results = await store.similaritySearch('запрос', 4, {
+  source: 'docs',
+  lang: 'ru',
+})
+```
+
+> **Примечание:** фильтрация по метаданным несовместима с `indexEnabled: true`.
+
+## Стратегии поиска
+
+| Стратегия                         | Сортировка | Лучшее совпадение  |
+| --------------------------------- | ---------- | ------------------ |
+| `CosineSimilarity` (по умолчанию) | DESC       | максимальный score |
+| `InnerProductSimilarity`          | DESC       | максимальный score |
+| `CosineDistance`                  | ASC        | минимальный score  |
+| `EuclideanDistance`               | ASC        | минимальный score  |
+| `ManhattanDistance`               | ASC        | минимальный score  |
+
+```typescript
+import { YDBVectorStore, YDBSearchStrategy } from '@ydbjs/langchain'
+
+const store = new YDBVectorStore(embeddings, {
+  driver,
+  strategy: YDBSearchStrategy.EuclideanDistance,
+})
+```
+
+## Приближённый поиск ближайших соседей (ANN-индекс)
+
+Создайте индекс `vector_kmeans_tree` для сублинейного поиска на больших таблицах.
+
+```typescript
+const store = new YDBVectorStore(embeddings, {
+  driver,
+  indexEnabled: true,
+  vectorDimension: 1536, // пропустить авто-определение размерности
+})
+
+await store.addDocuments(docs)
+await store.createVectorIndex() // построить один раз после начальной загрузки
+```
+
+Параметры настройки индекса:
+
+| Параметр                 | По умолчанию               | Описание                                            |
+| ------------------------ | -------------------------- | --------------------------------------------------- |
+| `indexName`              | `"langchain_vector_index"` | Имя индекса в YDB                                   |
+| `indexConfigLevels`      | `2`                        | Глубина дерева (Рекомендуется 1–3)                  |
+| `indexConfigClusters`    | `128`                      | Кластеров k-means на уровень (Рекомендуется 64–512) |
+| `indexTreeSearchTopSize` | `1`                        | Листовых кластеров при запросе                      |
+
+## Удаление документов
+
+```typescript
+// Удалить конкретные документы
+await store.delete({ ids: ['id1', 'id2'] })
+
+// Очистить всю таблицу
+await store.delete({ deleteAll: true })
+
+// Удалить таблицу целиком (будет пересоздана при следующей записи)
+await store.drop()
+```
+
+## Переопределение имён колонок
+
+Используйте `columnMap` при подключении к таблице с нестандартной схемой.
+
+```typescript
+const store = new YDBVectorStore(embeddings, {
+  driver,
+  table: 'my_vectors',
+  columnMap: {
+    id: 'doc_id',
+    document: 'doc_text',
+    embedding: 'doc_vec',
+    metadata: 'doc_meta',
+  },
+})
+```
+
+## Примеры
+
+В репозитории есть готовый пример:
+
+- `examples/langchain` — TypeScript CLI-пример со вставкой, поиском, фильтрацией по метаданным, удалением и демонстрацией стратегий поиска.
+
+```bash
+cd examples/langchain
+npm install
+OPENAI_API_KEY=sk-... npm start
+```

--- a/examples/langchain/index.ts
+++ b/examples/langchain/index.ts
@@ -1,0 +1,89 @@
+import { Document } from '@langchain/core/documents'
+import { OpenAIEmbeddings } from '@langchain/openai'
+import { YDBSearchStrategy, YDBVectorStore } from '@ydbjs/langchain'
+
+let connectionString = process.env.YDB_CONNECTION_STRING || 'grpc://localhost:2136/local'
+
+let embeddings = new OpenAIEmbeddings({
+	model: 'text-embedding-3-small',
+	apiKey: process.env.OPENAI_API_KEY,
+})
+
+// The store owns the Driver when constructed with connectionString.
+// `await using` calls store[Symbol.asyncDispose]() on scope exit.
+await using store = new YDBVectorStore(embeddings, {
+	connectionString,
+	table: 'langchain_example',
+	dropExistingTable: true,
+})
+
+// ── Insert documents ────────────────────────────────────────────────────────
+
+let docs = [
+	new Document({
+		pageContent: 'YDB is a distributed SQL database',
+		metadata: { source: 'docs', lang: 'en' },
+	}),
+	new Document({
+		pageContent: 'LangChain simplifies building LLM applications',
+		metadata: { source: 'docs', lang: 'en' },
+	}),
+	new Document({
+		pageContent: 'Vector search finds semantically similar content',
+		metadata: { source: 'wiki', lang: 'en' },
+	}),
+	new Document({
+		pageContent: 'YDB поддерживает векторный поиск через KNN UDF',
+		metadata: { source: 'docs', lang: 'ru' },
+	}),
+]
+
+let ids = await store.addDocuments(docs)
+console.log('Inserted IDs:', ids)
+
+// ── Similarity search ───────────────────────────────────────────────────────
+
+let results = await store.similaritySearchWithScore('distributed database', 3)
+console.log('\nTop matches for "distributed database":')
+for (let [doc, score] of results) {
+	console.log(`  [${score.toFixed(4)}] ${doc.pageContent}`)
+}
+
+// ── Metadata filter ─────────────────────────────────────────────────────────
+
+let enDocs = await store.similaritySearch('database', 10, { source: 'docs', lang: 'en' })
+console.log('\nEnglish docs-source results:')
+for (let doc of enDocs) {
+	console.log(`  ${doc.pageContent}`)
+}
+
+// ── Delete ──────────────────────────────────────────────────────────────────
+
+await store.delete({ ids: [ids[2]!] })
+console.log('\nDeleted one document. Remaining count after search:')
+
+let remaining = await store.similaritySearch('content', 10)
+console.log(' ', remaining.length, 'documents')
+
+// ── Search strategies ───────────────────────────────────────────────────────
+
+let distStore = new YDBVectorStore(embeddings, {
+	connectionString,
+	table: 'langchain_example_dist',
+	dropExistingTable: true,
+	strategy: YDBSearchStrategy.CosineDistance,
+})
+
+await distStore.addDocuments([
+	new Document({ pageContent: 'alpha', metadata: {} }),
+	new Document({ pageContent: 'beta', metadata: {} }),
+])
+
+let distResults = await distStore.similaritySearchWithScore('alpha', 2)
+console.log('\nCosineDistance results (lower = closer):')
+for (let [doc, score] of distResults) {
+	console.log(`  [${score.toFixed(4)}] ${doc.pageContent}`)
+}
+
+await distStore.drop()
+distStore.close()

--- a/examples/langchain/package.json
+++ b/examples/langchain/package.json
@@ -1,0 +1,33 @@
+{
+	"name": "@ydbjs/examples-langchain",
+	"version": "6.0.0",
+	"private": true,
+	"type": "module",
+	"publishConfig": {
+		"access": "restricted"
+	},
+	"scripts": {
+		"build:langchain": "npm run build --workspace=@ydbjs/langchain",
+		"prestart": "npm run build:langchain",
+		"start": "tsx index.ts",
+		"predev": "npm run build:langchain",
+		"dev": "DEBUG=ydbjs:* tsx index.ts",
+		"precheck": "npm run build:langchain",
+		"check": "tsc --noEmit",
+		"test": "npm run check"
+	},
+	"dependencies": {
+		"@langchain/openai": "^0.4.0",
+		"@ydbjs/langchain": "*"
+	},
+	"devDependencies": {
+		"@types/node": "^25.6.0",
+		"tsx": "^4.8.1",
+		"typescript": "^5.9.3"
+	},
+	"engines": {
+		"node": ">=20.19.0",
+		"npm": ">=10"
+	},
+	"engineStrict": true
+}

--- a/examples/langchain/tsconfig.json
+++ b/examples/langchain/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"declaration": false,
+		"declarationMap": false,
+		"sourceMap": false
+	},
+	"include": ["index.ts"],
+	"exclude": ["node_modules"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,6 +122,23 @@
 				"@ydbjs/fsm": "^6.1.1"
 			}
 		},
+		"examples/langchain": {
+			"name": "@ydbjs/examples-langchain",
+			"version": "6.0.0",
+			"dependencies": {
+				"@langchain/openai": "^0.4.0",
+				"@ydbjs/langchain": "*"
+			},
+			"devDependencies": {
+				"@types/node": "^25.6.0",
+				"tsx": "^4.8.1",
+				"typescript": "^5.9.3"
+			},
+			"engines": {
+				"node": ">=20.19.0",
+				"npm": ">=10"
+			}
+		},
 		"examples/query": {
 			"name": "@ydbjs/examples-query",
 			"version": "6.0.0",
@@ -402,6 +419,12 @@
 				"node": ">=14.17"
 			}
 		},
+		"node_modules/@cfworker/json-schema": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+			"integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+			"license": "MIT"
+		},
 		"node_modules/@colors/colors": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -472,448 +495,6 @@
 				"tslib": "^2.4.0"
 			}
 		},
-		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-			"integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"aix"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/android-arm": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-			"integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/android-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-			"integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/android-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-			"integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-			"integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-			"integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-			"integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-arm": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-			"integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-			"integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-			"integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-			"integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-			"integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-			"integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-			"integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-			"integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-			"integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-			"integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-			"integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-			"integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-			"integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-			"integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-			"integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/win32-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-			"integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/@grpc/grpc-js": {
 			"version": "1.14.3",
 			"license": "Apache-2.0",
@@ -971,6 +552,59 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/js-sdsl"
+			}
+		},
+		"node_modules/@langchain/core": {
+			"version": "0.3.80",
+			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
+			"integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
+			"license": "MIT",
+			"dependencies": {
+				"@cfworker/json-schema": "^4.0.2",
+				"ansi-styles": "^5.0.0",
+				"camelcase": "6",
+				"decamelize": "1.2.0",
+				"js-tiktoken": "^1.0.12",
+				"langsmith": "^0.3.67",
+				"mustache": "^4.2.0",
+				"p-queue": "^6.6.2",
+				"p-retry": "4",
+				"uuid": "^10.0.0",
+				"zod": "^3.25.32",
+				"zod-to-json-schema": "^3.22.3"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@langchain/core/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@langchain/openai": {
+			"version": "0.4.9",
+			"resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-0.4.9.tgz",
+			"integrity": "sha512-NAsaionRHNdqaMjVLPkFCyjUDze+OqRHghA1Cn4fPoAafz+FXcl9c7LlEl9Xo0FH6/8yiCl7Rw2t780C/SBVxQ==",
+			"license": "MIT",
+			"dependencies": {
+				"js-tiktoken": "^1.0.12",
+				"openai": "^4.87.3",
+				"zod": "^3.22.4",
+				"zod-to-json-schema": "^3.22.3"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@langchain/core": ">=0.3.39 <0.4.0"
 			}
 		},
 		"node_modules/@loaderkit/resolve": {
@@ -1652,9 +1286,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1672,9 +1303,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1692,9 +1320,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1712,9 +1337,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1732,9 +1354,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1752,9 +1371,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1772,9 +1388,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1792,9 +1405,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1999,9 +1609,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2019,9 +1626,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2039,9 +1643,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2059,9 +1660,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2079,9 +1677,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2099,9 +1694,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2119,9 +1711,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2139,9 +1728,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3119,17 +2705,38 @@
 			"version": "25.9.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
 			"integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": ">=7.24.0 <7.24.7"
 			}
+		},
+		"node_modules/@types/node-fetch": {
+			"version": "2.6.13",
+			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+			"integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"form-data": "^4.0.4"
+			}
+		},
+		"node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"license": "MIT"
 		},
 		"node_modules/@types/unist": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
 			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
 			"license": "MIT"
 		},
 		"node_modules/@types/web-bluetooth": {
@@ -3708,6 +3315,10 @@
 			"resolved": "examples/fsm",
 			"link": true
 		},
+		"node_modules/@ydbjs/examples-langchain": {
+			"resolved": "examples/langchain",
+			"link": true
+		},
 		"node_modules/@ydbjs/examples-query": {
 			"resolved": "examples/query",
 			"link": true
@@ -3730,6 +3341,10 @@
 		},
 		"node_modules/@ydbjs/fsm": {
 			"resolved": "packages/fsm",
+			"link": true
+		},
+		"node_modules/@ydbjs/langchain": {
+			"resolved": "third-parties/langchain",
 			"link": true
 		},
 		"node_modules/@ydbjs/query": {
@@ -3756,6 +3371,18 @@
 			"resolved": "packages/value",
 			"link": true
 		},
+		"node_modules/abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"license": "MIT",
+			"dependencies": {
+				"event-target-shim": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6.5"
+			}
+		},
 		"node_modules/abort-controller-x": {
 			"version": "0.4.3",
 			"license": "MIT"
@@ -3779,6 +3406,18 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^8"
+			}
+		},
+		"node_modules/agentkeepalive": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+			"integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+			"license": "MIT",
+			"dependencies": {
+				"humanize-ms": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
 			}
 		},
 		"node_modules/ansi-escapes": {
@@ -3814,7 +3453,6 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
@@ -3853,6 +3491,12 @@
 				"js-tokens": "^10.0.0"
 			}
 		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"license": "MIT"
+		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
 			"funding": [
@@ -3881,6 +3525,31 @@
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/ccount": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -3906,7 +3575,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
@@ -4012,7 +3680,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
@@ -4025,8 +3692,19 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"license": "MIT",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/comma-separated-tokens": {
 			"version": "2.0.3",
@@ -4047,6 +3725,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"node_modules/console-table-printer": {
+			"version": "2.15.3",
+			"resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.3.tgz",
+			"integrity": "sha512-4COV3+d6zksjyG7onhubXXyzKdtCfw6nz8Xtmn+SGlK+aXURPhsm9KGFRD4diqjhEkD/NTahyaZ322dxH00eCQ==",
+			"license": "MIT",
+			"dependencies": {
+				"simple-wcswidth": "^1.1.2"
 			}
 		},
 		"node_modules/convert-source-map": {
@@ -4084,6 +3771,24 @@
 				"supports-color": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/dequal": {
@@ -4243,6 +3948,20 @@
 				}
 			}
 		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -4283,12 +4002,57 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/es-module-lexer": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
 			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/esbuild": {
 			"version": "0.28.0",
@@ -4350,6 +4114,21 @@
 				"@types/estree": "^1.0.0"
 			}
 		},
+		"node_modules/event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/eventemitter3": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+			"license": "MIT"
+		},
 		"node_modules/expect-type": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4400,6 +4179,41 @@
 				"tabbable": "^6.4.0"
 			}
 		},
+		"node_modules/form-data": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+			"license": "MIT",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/form-data-encoder": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+			"integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+			"license": "MIT"
+		},
+		"node_modules/formdata-node": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+			"integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+			"license": "MIT",
+			"dependencies": {
+				"node-domexception": "1.0.0",
+				"web-streams-polyfill": "4.0.0-beta.3"
+			},
+			"engines": {
+				"node": ">= 12.20"
+			}
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"dev": true,
@@ -4412,6 +4226,15 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -4422,12 +4245,99 @@
 				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"license": "MIT",
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/hast-util-to-html": {
@@ -4513,6 +4423,15 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/humanize-ms": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.0.0"
+			}
+		},
 		"node_modules/import-in-the-middle": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
@@ -4577,10 +4496,53 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/js-tiktoken": {
+			"version": "1.0.21",
+			"resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+			"integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.5.1"
+			}
+		},
 		"node_modules/js-tokens": {
 			"version": "10.0.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/langsmith": {
+			"version": "0.3.87",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
+			"integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/uuid": "^10.0.0",
+				"chalk": "^4.1.2",
+				"console-table-printer": "^2.12.1",
+				"p-queue": "^6.6.2",
+				"semver": "^7.6.3",
+				"uuid": "^10.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "*",
+				"@opentelemetry/exporter-trace-otlp-proto": "*",
+				"@opentelemetry/sdk-trace-base": "*",
+				"openai": "*"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@opentelemetry/exporter-trace-otlp-proto": {
+					"optional": true
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"optional": true
+				},
+				"openai": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/lightningcss": {
 			"version": "1.32.0",
@@ -4931,6 +4893,15 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/mdast-util-to-hast": {
 			"version": "13.2.1",
 			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
@@ -5047,6 +5018,27 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/minisearch": {
 			"version": "7.2.0",
 			"dev": true,
@@ -5071,6 +5063,15 @@
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"license": "MIT"
+		},
+		"node_modules/mustache": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+			"integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+			"license": "MIT",
+			"bin": {
+				"mustache": "bin/mustache"
+			}
 		},
 		"node_modules/mz": {
 			"version": "2.7.0",
@@ -5117,6 +5118,26 @@
 				"ts-error": "^1.0.6"
 			}
 		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
 		"node_modules/node-emoji": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
@@ -5131,6 +5152,26 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/object-assign": {
@@ -5172,6 +5213,51 @@
 				"regex": "^6.1.0",
 				"regex-recursion": "^6.0.2"
 			}
+		},
+		"node_modules/openai": {
+			"version": "4.104.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+			"integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/node": "^18.11.18",
+				"@types/node-fetch": "^2.6.4",
+				"abort-controller": "^3.0.0",
+				"agentkeepalive": "^4.2.1",
+				"form-data-encoder": "1.7.2",
+				"formdata-node": "^4.3.2",
+				"node-fetch": "^2.6.7"
+			},
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.23.8"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/openai/node_modules/@types/node": {
+			"version": "18.19.130",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+			"integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
+		},
+		"node_modules/openai/node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"license": "MIT"
 		},
 		"node_modules/oxfmt": {
 			"version": "0.51.0",
@@ -5264,6 +5350,56 @@
 				"oxlint-tsgolint": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/p-queue": {
+			"version": "6.6.2",
+			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+			"integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+			"license": "MIT",
+			"dependencies": {
+				"eventemitter3": "^4.0.4",
+				"p-timeout": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/p-timeout": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+			"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+			"license": "MIT",
+			"dependencies": {
+				"p-finally": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/pako": {
@@ -5418,6 +5554,15 @@
 				"node": ">=9.3.0 || >=8.10.0 <9.0.0"
 			}
 		},
+		"node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/rolldown": {
 			"version": "1.0.0-rc.16",
 			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
@@ -5499,7 +5644,6 @@
 		},
 		"node_modules/semver": {
 			"version": "7.7.4",
-			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -5531,6 +5675,12 @@
 			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/simple-wcswidth": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
+			"integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
+			"license": "MIT"
 		},
 		"node_modules/sirv": {
 			"version": "3.0.2",
@@ -5648,7 +5798,6 @@
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
@@ -5766,6 +5915,12 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"license": "MIT"
+		},
 		"node_modules/trim-lines": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -5842,7 +5997,6 @@
 			"version": "7.24.6",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
 			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/unicode-emoji-modifier-base": {
@@ -5926,6 +6080,20 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/validate-npm-package-name": {
@@ -6764,6 +6932,31 @@
 				}
 			}
 		},
+		"node_modules/web-streams-polyfill": {
+			"version": "4.0.0-beta.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+			"integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
 		"node_modules/why-is-node-running": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -6859,6 +7052,24 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
 			}
 		},
 		"node_modules/zwitch": {
@@ -7210,6 +7421,468 @@
 			},
 			"peerDependencies": {
 				"drizzle-orm": "^0.45.2"
+			}
+		},
+		"third-parties/langchain": {
+			"name": "@ydbjs/langchain",
+			"version": "0.1.0",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ydbjs/core": "^6.3.0",
+				"@ydbjs/query": "^6.1.0",
+				"@ydbjs/value": "^6.0.7"
+			},
+			"devDependencies": {
+				"@langchain/core": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=20.19.0",
+				"npm": ">=10"
+			},
+			"peerDependencies": {
+				"@langchain/core": ">=0.2.0"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+			"integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+			"integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+			"integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+			"integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+			"integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+			"integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+			"integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+			"integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+			"integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+			"integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+			"integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+			"integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+			"integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+			"integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+			"integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+			"integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+			"integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+			"integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+			"integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+			"integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+			"integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+			"integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+			"integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		}
 	}

--- a/third-parties/langchain/.gitignore
+++ b/third-parties/langchain/.gitignore
@@ -1,0 +1,2 @@
+.turbo
+dist

--- a/third-parties/langchain/.npmignore
+++ b/third-parties/langchain/.npmignore
@@ -1,0 +1,10 @@
+/.turbo
+
+/src
+/tests
+/coverage
+
+/*.yaml
+/*.json
+*.tsbuildinfo
+vitest.config.ts

--- a/third-parties/langchain/CHANGELOG.md
+++ b/third-parties/langchain/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @ydbjs/langchain
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release: `YDBVectorStore` — a LangChain.js VectorStore backed by YDB with KNN search support.

--- a/third-parties/langchain/README.md
+++ b/third-parties/langchain/README.md
@@ -1,0 +1,115 @@
+# @ydbjs/langchain
+
+[YDB](https://ydb.tech) integration for [LangChain.js](https://js.langchain.com) — a `VectorStore` backed by YDB with KNN search support.
+
+## Installation
+
+```bash
+npm install @ydbjs/langchain @langchain/core
+```
+
+## Usage
+
+### Using a connection string
+
+The store creates and owns the driver. Call `store.close()` when done.
+
+```typescript
+import { YDBVectorStore } from '@ydbjs/langchain'
+import { OpenAIEmbeddings } from '@langchain/openai'
+
+const store = new YDBVectorStore(new OpenAIEmbeddings(), {
+  connectionString: 'grpc://localhost:2136/local',
+})
+
+await store.addDocuments([{ pageContent: 'LangChain supports YDB', metadata: { source: 'docs' } }])
+
+const results = await store.similaritySearch('YDB vector search', 4)
+console.log(results)
+
+store.close()
+```
+
+### Using a pre-built Driver
+
+Pass your own `Driver` instance — its lifecycle is yours to manage.
+
+```typescript
+import { Driver } from '@ydbjs/core'
+import { YDBVectorStore } from '@ydbjs/langchain'
+import { OpenAIEmbeddings } from '@langchain/openai'
+
+const driver = new Driver('grpc://localhost:2136/local')
+await driver.ready()
+
+const store = new YDBVectorStore(new OpenAIEmbeddings(), { driver })
+
+await store.addDocuments([{ pageContent: 'LangChain supports YDB', metadata: { source: 'docs' } }])
+
+const results = await store.similaritySearch('YDB vector search', 4)
+console.log(results)
+
+driver.close()
+```
+
+### Static helpers
+
+```typescript
+// Create store and insert documents in one call
+const store = await YDBVectorStore.fromDocuments(docs, embeddings, {
+  connectionString: 'grpc://localhost:2136/local',
+})
+
+// Connect to an existing table without running CREATE TABLE
+const store = YDBVectorStore.fromExistingTable(embeddings, {
+  driver,
+  table: 'my_vectors',
+})
+```
+
+### Metadata filtering
+
+```typescript
+// Each key-value pair becomes a JSON_VALUE predicate; multiple pairs use AND.
+// Note: incompatible with indexEnabled: true.
+const results = await store.similaritySearch('query', 4, {
+  source: 'docs',
+  lang: 'en',
+})
+```
+
+### Approximate nearest-neighbour index
+
+```typescript
+const store = new YDBVectorStore(embeddings, {
+  driver,
+  indexEnabled: true,
+  vectorDimension: 1536, // set to skip the auto-detect probe
+})
+
+await store.addDocuments(docs)
+await store.createVectorIndex() // build once after the initial load
+```
+
+## Search strategies
+
+| Strategy                     | Sort order | Best match    |
+| ---------------------------- | ---------- | ------------- |
+| `CosineSimilarity` (default) | DESC       | highest score |
+| `InnerProductSimilarity`     | DESC       | highest score |
+| `CosineDistance`             | ASC        | lowest score  |
+| `EuclideanDistance`          | ASC        | lowest score  |
+| `ManhattanDistance`          | ASC        | lowest score  |
+
+```typescript
+import { YDBVectorStore, YDBSearchStrategy } from '@ydbjs/langchain'
+
+const store = new YDBVectorStore(embeddings, {
+  driver,
+  strategy: YDBSearchStrategy.EuclideanDistance,
+})
+```
+
+## License
+
+Apache-2.0

--- a/third-parties/langchain/package.json
+++ b/third-parties/langchain/package.json
@@ -1,0 +1,66 @@
+{
+	"name": "@ydbjs/langchain",
+	"version": "0.1.0",
+	"description": "YDB integration for LangChain.js — VectorStore backed by YDB.",
+	"keywords": [
+		"database",
+		"langchain",
+		"vector-store",
+		"ydb",
+		"yql"
+	],
+	"homepage": "https://github.com/ydb-platform/ydb-js-sdk/tree/main/third-parties/langchain#readme",
+	"bugs": {
+		"url": "https://github.com/ydb-platform/ydb-js-sdk/issues"
+	},
+	"license": "Apache-2.0",
+	"author": "YDB Team <team@ydb.tech> (https://ydb.tech)",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/ydb-platform/ydb-js-sdk.git",
+		"directory": "third-parties/langchain"
+	},
+	"files": [
+		"dist",
+		"README.md",
+		"CHANGELOG.md"
+	],
+	"type": "module",
+	"sideEffects": false,
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"publishConfig": {
+		"access": "public",
+		"registry": "https://registry.npmjs.org/"
+	},
+	"scripts": {
+		"clean": "rm -rf dist",
+		"build": "tsc",
+		"test": "vitest --run",
+		"test:unit": "vitest --run --project uni",
+		"test:int": "vitest --run --project int",
+		"attw": "attw --pack --profile esm-only"
+	},
+	"dependencies": {
+		"@ydbjs/core": "^6.3.0",
+		"@ydbjs/query": "^6.1.0",
+		"@ydbjs/value": "^6.0.7"
+	},
+	"peerDependencies": {
+		"@langchain/core": ">=0.2.0"
+	},
+	"devDependencies": {
+		"@langchain/core": "^0.3.0"
+	},
+	"engines": {
+		"node": ">=20.19.0",
+		"npm": ">=10"
+	},
+	"engineStrict": true
+}

--- a/third-parties/langchain/src/index.ts
+++ b/third-parties/langchain/src/index.ts
@@ -1,0 +1,9 @@
+export {
+	YDBVectorStore,
+	YDBSearchStrategy,
+	type YDBSearchStrategyType,
+	type YDBColumnMap,
+	type YDBVectorStoreBaseConfig,
+	type YDBVectorStoreConfig,
+	type YDBFilter,
+} from './vectorstore.js'

--- a/third-parties/langchain/src/vectorstore.ts
+++ b/third-parties/langchain/src/vectorstore.ts
@@ -1,0 +1,674 @@
+import { Driver, type DriverOptions } from '@ydbjs/core'
+import {
+	type QueryClient,
+	type UnsafeString,
+	query as createQueryClient,
+	identifier,
+} from '@ydbjs/query'
+import { Uint64 } from '@ydbjs/value/primitive'
+import type { EmbeddingsInterface } from '@langchain/core/embeddings'
+import { VectorStore } from '@langchain/core/vectorstores'
+import { Document } from '@langchain/core/documents'
+
+/**
+ * KNN search strategy passed to the YDB `Knn::*` UDF.
+ *
+ * **Similarity strategies** (suffix `Similarity`) return higher values for
+ * more similar vectors. Results are sorted **DESC** — the best match is first.
+ *
+ * **Distance strategies** (suffix `Distance`) return lower values for closer
+ * vectors. Results are sorted **ASC** — the best match is first.
+ *
+ * | Strategy |
+ * |---|
+ * | `CosineSimilarity` |
+ * | `InnerProductSimilarity` |
+ * | `CosineDistance` |
+ * | `EuclideanDistance` |
+ * | `ManhattanDistance` |
+ */
+export const YDBSearchStrategy = {
+	CosineSimilarity: 'CosineSimilarity',
+	InnerProductSimilarity: 'InnerProductSimilarity',
+	CosineDistance: 'CosineDistance',
+	ManhattanDistance: 'ManhattanDistance',
+	EuclideanDistance: 'EuclideanDistance',
+} as const
+
+export type YDBSearchStrategyType = (typeof YDBSearchStrategy)[keyof typeof YDBSearchStrategy]
+
+/**
+ * Mapping from logical field names to physical column names in the YDB table.
+ * Override any field via `columnMap` in the store config when the table
+ * schema uses non-default names.
+ */
+export interface YDBColumnMap {
+	/** Primary key column — stores the document ID. Default: `"id"`. */
+	id: string
+	/** Column that holds the document text (`Utf8`). Default: `"document"`. */
+	document: string
+	/** Column that holds the packed `Float32` embedding bytes (`String`). Default: `"embedding"`. */
+	embedding: string
+	/** Column that holds arbitrary document metadata as JSON. Default: `"metadata"`. */
+	metadata: string
+}
+
+/** Common options, independent of how the driver is provided. */
+export interface YDBVectorStoreBaseConfig {
+	/** YDB table name. Defaults to `"langchain_vectors"`. */
+	table?: string
+	/**
+	 * Override individual column names when the table was not created by this
+	 * store (e.g. you have an existing schema). Only the fields you specify are
+	 * overridden — omitted fields keep their defaults.
+	 */
+	columnMap?: Partial<YDBColumnMap>
+	/**
+	 * Vector similarity/distance function used in KNN search.
+	 * Defaults to `YDBSearchStrategy.CosineSimilarity`.
+	 * See {@link YDBSearchStrategy} for the full list and sort-order semantics.
+	 */
+	strategy?: YDBSearchStrategyType
+	/**
+	 * When `true`, the table is dropped and recreated on the first operation.
+	 * Useful during development or testing. Defaults to `false`.
+	 */
+	dropExistingTable?: boolean
+	/**
+	 * Number of dimensions in the embedding vectors.
+	 * When omitted the store embeds a short probe string on first use to detect
+	 * the dimension automatically — set this to avoid the extra round-trip.
+	 */
+	vectorDimension?: number
+	/**
+	 * Enable the `vector_kmeans_tree` approximate nearest-neighbour index.
+	 * When `true`, call {@link YDBVectorStore.createVectorIndex} after inserting
+	 * the initial batch of documents.
+	 * Defaults to `false` (exact scan).
+	 */
+	indexEnabled?: boolean
+	/** Name of the vector index. Defaults to `"langchain_vector_index"`. */
+	indexName?: string
+	/**
+	 * Number of tree levels in the k-means index. Recommended range: 1–3.
+	 * Higher values improve recall at the cost of slower index build time.
+	 * Defaults to `2`.
+	 */
+	indexConfigLevels?: number
+	/**
+	 * Number of k-means clusters per tree level. Recommended range: 64–512.
+	 * Larger values yield finer partitions and better recall, but require
+	 * more memory and a longer build. Defaults to `128`.
+	 */
+	indexConfigClusters?: number
+	/**
+	 * `KMeansTreeSearchTopSize` PRAGMA value — how many leaf clusters are
+	 * visited during an indexed search. Higher values improve recall at the
+	 * cost of latency. Defaults to `1`.
+	 */
+	indexTreeSearchTopSize?: number
+}
+
+/**
+ * Pass either a pre-built Driver (you manage its lifecycle) or a connection
+ * string (the store creates and owns the Driver; call `store.close()` when done).
+ */
+export type YDBVectorStoreConfig = YDBVectorStoreBaseConfig &
+	(
+		| {
+				/** A ready-to-use Driver instance from `@ydbjs/core`. */
+				driver: Driver
+				connectionString?: never
+				driverOptions?: never
+		  }
+		| {
+				/**
+				 * YDB connection string, e.g. `"grpc://localhost:2136/local"`.
+				 * The store creates a Driver internally; call `store.close()` to release it.
+				 */
+				connectionString: string
+				/** Additional Driver options (auth, TLS, …). */
+				driverOptions?: DriverOptions
+				driver?: never
+		  }
+	)
+
+/**
+ * Metadata filter for similarity search.
+ *
+ * Each key-value pair is translated to a
+ * `JSON_VALUE(metadata, '$.key') = 'value'` condition.
+ * Multiple entries are combined with `AND`.
+ *
+ * **Limitations:**
+ * - Values must be strings (JSON scalars are compared as text).
+ * - Cannot be used together with `indexEnabled: true` — the vector index
+ *   does not support pre-filtering.
+ */
+export type YDBFilter = Record<string, string>
+
+function vectorToBytes(vector: number[]): Uint8Array {
+	const YDB_VECTOR_MARKER = 0x01
+	let result = new Uint8Array(vector.length * 4 + 1)
+	let view = new DataView(result.buffer)
+	for (let i = 0; i < vector.length; i++) {
+		view.setFloat32(i * 4, vector[i]!, true) // little-endian
+	}
+	result[vector.length * 4] = YDB_VECTOR_MARKER
+	return result
+}
+
+/**
+ * Escapes a string value for use inside a YQL JSON path literal (e.g. `'$.key'`).
+ * JSON path keys cannot be passed as bound parameters in YQL, so escaping is
+ * the only option here. This function is intentionally NOT used for regular
+ * string values — those must be passed as bound query parameters instead.
+ */
+function escJsonPathKey(value: string): string {
+	return value.replace(/'/g, "''")
+}
+
+/**
+ * LangChain vector store backed by YDB.
+ *
+ * Uses `@ydbjs/core` (Driver) and `@ydbjs/query` (tagged-template YQL
+ * client) — both are bundled as regular dependencies of this package.
+ *
+ * Embeddings are stored as packed little-endian `Float32` bytes in a
+ * `String` column and searched with the built-in `Knn::*` UDFs.
+ *
+ * @example Using a connection string (store manages the Driver):
+ * ```typescript
+ * import { YDBVectorStore } from "@ydbjs/langchain";
+ * import { OpenAIEmbeddings } from "@langchain/openai";
+ *
+ * const store = new YDBVectorStore(new OpenAIEmbeddings(), {
+ *   connectionString: "grpc://localhost:2136/local",
+ * });
+ * await store.addDocuments([
+ *   { pageContent: "LangChain supports YDB", metadata: { source: "docs" } },
+ * ]);
+ * const results = await store.similaritySearch("YDB", 4);
+ * store.close();
+ * ```
+ *
+ * @example Using a pre-built Driver (caller manages its lifecycle):
+ * ```typescript
+ * import { Driver } from "@ydbjs/core";
+ * import { YDBVectorStore } from "@ydbjs/langchain";
+ * import { OpenAIEmbeddings } from "@langchain/openai";
+ *
+ * const driver = new Driver("grpc://localhost:2136/local");
+ * await driver.ready();
+ * const store = new YDBVectorStore(new OpenAIEmbeddings(), { driver });
+ * await store.addDocuments([
+ *   { pageContent: "LangChain supports YDB", metadata: { source: "docs" } },
+ * ]);
+ * const results = await store.similaritySearch("YDB", 4);
+ * driver.close();
+ * ```
+ */
+export class YDBVectorStore extends VectorStore {
+	declare FilterType: YDBFilter
+
+	#driver: Driver
+
+	#ownedDriver: boolean
+
+	#sql: QueryClient
+
+	#table: string
+
+	#columnMap: YDBColumnMap
+
+	#strategy: YDBSearchStrategyType
+
+	#sortOrder: 'ASC' | 'DESC'
+
+	#dropExistingTable: boolean
+
+	#vectorDimension?: number
+
+	#indexEnabled: boolean
+
+	#indexName: string
+
+	#indexConfigLevels: number
+
+	#indexConfigClusters: number
+
+	#indexTreeSearchTopSize: number
+
+	#isInitialized = false
+
+	_vectorstoreType(): string {
+		return 'ydb'
+	}
+
+	constructor(embeddings: EmbeddingsInterface, config: YDBVectorStoreConfig) {
+		super(embeddings, config)
+
+		if ('connectionString' in config) {
+			if (!config.connectionString) {
+				throw new Error('connectionString must be a non-empty string')
+			}
+			this.#driver = new Driver(config.connectionString, config.driverOptions)
+			this.#ownedDriver = true
+		} else {
+			this.#driver = (config as { driver: Driver }).driver
+			this.#ownedDriver = false
+		}
+
+		this.#sql = createQueryClient(this.#driver)
+		this.#table = config.table ?? 'langchain_vectors'
+		this.#columnMap = {
+			id: 'id',
+			document: 'document',
+			embedding: 'embedding',
+			metadata: 'metadata',
+			...config.columnMap,
+		}
+		this.#strategy = config.strategy ?? YDBSearchStrategy.CosineSimilarity
+		if (!Object.values(YDBSearchStrategy).includes(this.#strategy)) {
+			throw new Error(
+				`Unknown search strategy: "${this.#strategy}". Valid values: ${Object.values(YDBSearchStrategy).join(', ')}`
+			)
+		}
+		this.#sortOrder = this.#strategy.endsWith('Similarity') ? 'DESC' : 'ASC'
+		this.#dropExistingTable = config.dropExistingTable ?? false
+		if (config.vectorDimension !== undefined) {
+			this.#vectorDimension = config.vectorDimension
+		}
+		this.#indexEnabled = config.indexEnabled ?? false
+		this.#indexName = config.indexName ?? 'langchain_vector_index'
+		this.#indexConfigLevels = config.indexConfigLevels ?? 2
+		this.#indexConfigClusters = config.indexConfigClusters ?? 128
+		this.#indexTreeSearchTopSize = config.indexTreeSearchTopSize ?? 1
+		if (!Number.isSafeInteger(this.#indexConfigLevels) || this.#indexConfigLevels < 1) {
+			throw new Error(
+				`indexConfigLevels must be a positive integer, got: ${this.#indexConfigLevels}`
+			)
+		}
+		if (!Number.isSafeInteger(this.#indexConfigClusters) || this.#indexConfigClusters < 1) {
+			throw new Error(
+				`indexConfigClusters must be a positive integer, got: ${this.#indexConfigClusters}`
+			)
+		}
+		if (
+			!Number.isSafeInteger(this.#indexTreeSearchTopSize) ||
+			this.#indexTreeSearchTopSize < 1
+		) {
+			throw new Error(
+				`indexTreeSearchTopSize must be a positive integer, got: ${this.#indexTreeSearchTopSize}`
+			)
+		}
+	}
+
+	get #t(): UnsafeString {
+		return identifier(this.#table)
+	}
+
+	async #ensureTable(): Promise<void> {
+		await this.#driver.ready()
+		if (this.#isInitialized) return
+
+		let { id, document: doc, embedding: emb, metadata: meta } = this.#columnMap
+
+		if (this.#dropExistingTable) {
+			await this.#sql`DROP TABLE IF EXISTS ${this.#t}`
+		}
+
+		await this.#sql`
+      CREATE TABLE IF NOT EXISTS ${this.#t} (
+        ${identifier(id)}   Utf8,
+        ${identifier(doc)}  Utf8,
+        ${identifier(emb)}  String,
+        ${identifier(meta)} Json,
+        PRIMARY KEY (${identifier(id)})
+      )`
+
+		this.#isInitialized = true
+	}
+
+	#getIndexStrategy(): string {
+		switch (this.#strategy) {
+			case YDBSearchStrategy.CosineSimilarity:
+				return "similarity = 'cosine'"
+			case YDBSearchStrategy.InnerProductSimilarity:
+				return "similarity = 'inner_product'"
+			case YDBSearchStrategy.CosineDistance:
+				return "distance = 'cosine'"
+			case YDBSearchStrategy.EuclideanDistance:
+				return "distance = 'euclidean'"
+			case YDBSearchStrategy.ManhattanDistance:
+				return "distance = 'manhattan'"
+			default:
+				throw new Error(`Unsupported search strategy: ${String(this.#strategy)}`)
+		}
+	}
+
+	/**
+	 * Insert or replace documents using pre-computed embedding vectors.
+	 *
+	 * Uses `UPSERT` semantics: if a document with the same ID already exists it
+	 * is overwritten, not duplicated.  Documents without an explicit `id` receive
+	 * a random UUID.
+	 *
+	 * @param vectors - Embedding vectors, one per document (same order).
+	 * @param documents - Documents to store.
+	 * @returns The ID of every inserted/updated document (same order as input).
+	 */
+	async addVectors(vectors: number[][], documents: Document[]): Promise<string[]> {
+		if (vectors.length !== documents.length) {
+			throw new Error(
+				`vectors.length (${vectors.length}) must equal documents.length (${documents.length})`
+			)
+		}
+		if (vectors.length === 0) return []
+		await this.#ensureTable()
+
+		let { id, document: doc, embedding: emb, metadata: meta } = this.#columnMap
+		let cols = [id, doc, emb, meta].map(identifier).join(', ')
+
+		let ids: string[] = []
+		let batchSize = 32
+
+		for (let i = 0; i < vectors.length; i += batchSize) {
+			let batch = documents.slice(i, i + batchSize).map((d, j) => {
+				let docId = d.id ?? crypto.randomUUID()
+				ids.push(docId)
+				return {
+					id: docId,
+					document: d.pageContent,
+					embedding: vectorToBytes(vectors[i + j]!),
+					metadata: JSON.stringify(d.metadata ?? {}),
+				}
+			})
+
+			// Batches are sent sequentially to avoid overwhelming the server.
+			// oxlint-disable-next-line no-await-in-loop
+			await this.#sql`
+        UPSERT INTO ${this.#t} (${this.#sql.unsafe(cols)})
+        SELECT id, document, embedding, CAST(metadata AS Json)
+        FROM AS_TABLE(${batch})`
+		}
+
+		return ids
+	}
+
+	/**
+	 * Embed and store documents.
+	 *
+	 * Embeds each document's `pageContent` with the configured embeddings model,
+	 * then delegates to {@link addVectors}.  Uses `UPSERT` semantics.
+	 *
+	 * @param documents - Documents to embed and store.
+	 * @returns The ID of every inserted/updated document (same order as input).
+	 */
+	async addDocuments(documents: Document[]): Promise<string[]> {
+		let texts = documents.map((d) => d.pageContent)
+		let vectors = await this.embeddings.embedDocuments(texts)
+		return this.addVectors(vectors, documents)
+	}
+
+	/**
+	 * Find the `k` documents most similar to a pre-computed query vector.
+	 *
+	 * @param query - The query embedding vector.
+	 * @param k - Maximum number of results to return.
+	 * @param filter - Optional metadata filter (see {@link YDBFilter}).
+	 *   Cannot be combined with `indexEnabled: true`.
+	 * @returns Pairs of `[document, score]` sorted by the configured strategy:
+	 *   descending for similarity strategies, ascending for distance strategies.
+	 */
+	async similaritySearchVectorWithScore(
+		query: number[],
+		k: number,
+		filter?: this['FilterType']
+	): Promise<[Document, number][]> {
+		if (!Number.isSafeInteger(k) || k < 0) {
+			throw new Error(`k must be a non-negative integer, got: ${k}`)
+		}
+		await this.#ensureTable()
+
+		let { id, document: doc, embedding: emb, metadata: meta } = this.#columnMap
+
+		if (filter && Object.keys(filter).length > 0 && this.#indexEnabled) {
+			throw new Error('Cannot use metadata filter with vector index enabled.')
+		}
+
+		let pragmaClause = ''
+		let viewClause = ''
+		if (this.#indexEnabled) {
+			pragmaClause = `PRAGMA ydb.KMeansTreeSearchTopSize = "${this.#indexTreeSearchTopSize}"; `
+			viewClause = `VIEW ${identifier(this.#indexName)}`
+		}
+
+		let embeddingBytes = vectorToBytes(query)
+		let filterEntries = Object.entries(filter ?? {})
+
+		// Build the query dynamically so that the embedding bytes, every filter
+		// value, AND the LIMIT are passed as bound parameters (not interpolated
+		// into SQL text). Stable query text across different k values means YDB
+		// can reuse its compiled query plan.
+		//
+		// JSON path keys (e.g. `$.key`) cannot be parameterised in YQL and are
+		// escaped with escJsonPathKey instead.
+		//
+		// This uses the standard tagged-template calling convention:
+		//   sql`a ${v1} b ${v2} c`  ≡  sql(["a ", " b ", " c"], v1, v2)
+		let sqlParts: string[] = []
+		let boundValues: unknown[] = [embeddingBytes] // becomes $p0
+
+		sqlParts.push(
+			`${pragmaClause}SELECT ` +
+				`${identifier(id)} AS id, ` +
+				`${identifier(doc)} AS document, ` +
+				`${identifier(meta)} AS metadata, ` +
+				`Knn::${this.#strategy}(${identifier(emb)}, `
+			// $p0 (embeddingBytes) is appended next by the template engine
+		)
+
+		let afterEmb = `) AS score FROM ${this.#t} ${viewClause}`
+
+		if (filterEntries.length > 0) {
+			let [firstKey, firstValue] = filterEntries[0]!
+			sqlParts.push(
+				`${afterEmb} WHERE JSON_VALUE(${identifier(meta)}, '$.${escJsonPathKey(firstKey)}') = `
+				// $p1 appended next
+			)
+			boundValues.push(firstValue)
+
+			for (let i = 1; i < filterEntries.length; i++) {
+				let [key, value] = filterEntries[i]!
+				sqlParts.push(
+					` AND JSON_VALUE(${identifier(meta)}, '$.${escJsonPathKey(key)}') = `
+					// $p{i+1} appended next
+				)
+				boundValues.push(value)
+			}
+			sqlParts.push(` ORDER BY score ${this.#sortOrder} LIMIT `)
+		} else {
+			sqlParts.push(`${afterEmb} ORDER BY score ${this.#sortOrder} LIMIT `)
+		}
+		// LIMIT as a Uint64 bound parameter — query text stays stable for any k value.
+		boundValues.push(new Uint64(BigInt(k)))
+		sqlParts.push('')
+
+		let tpl = Object.freeze(
+			Object.assign(sqlParts, { raw: sqlParts })
+		) as unknown as TemplateStringsArray
+
+		let resultSets = await this.#sql(tpl, ...boundValues)
+
+		// resultSets is an array of result sets; the first one holds our rows.
+		let rows = (resultSets as Array<Array<Record<string, unknown>>>)[0] ?? []
+
+		return rows.map((row) => [
+			new Document({
+				pageContent: String(row.document),
+				metadata:
+					typeof row.metadata === 'string'
+						? JSON.parse(row.metadata)
+						: ((row.metadata as Record<string, unknown>) ?? {}),
+				id: String(row.id),
+			}),
+			Number(row.score),
+		])
+	}
+
+	/**
+	 * Delete documents from the store.
+	 *
+	 * @param params.ids - Delete only the documents with these IDs.
+	 * @param params.deleteAll - When `true`, truncate the entire table.
+	 *   Takes precedence over `ids`.
+	 */
+	override async delete(params: { ids?: string[]; deleteAll?: boolean }): Promise<void> {
+		await this.#ensureTable()
+		if (params.deleteAll) {
+			await this.#sql`DELETE FROM ${this.#t}`
+		} else if (params.ids && params.ids.length > 0) {
+			// Pass the ID list as a bound List<Utf8> parameter — YQL supports
+			// `WHERE col IN $list_param` directly, no subquery needed.
+			let col = identifier(this.#columnMap.id)
+			await this.#sql`DELETE FROM ${this.#t} WHERE ${col} IN ${params.ids}`
+		}
+	}
+
+	/**
+	 * Drop the backing YDB table (`DROP TABLE IF EXISTS`).
+	 * All data is permanently deleted. The store can be reused after this call —
+	 * the table will be recreated on the next write.
+	 */
+	async drop(): Promise<void> {
+		await this.#driver.ready()
+		await this.#sql`DROP TABLE IF EXISTS ${this.#t}`
+		this.#isInitialized = false
+	}
+
+	/**
+	 * Build a `vector_kmeans_tree` approximate nearest-neighbour index on the
+	 * embedding column.
+	 *
+	 * **When to call:** after inserting the initial batch of documents and before
+	 * the store goes into production.  Documents added after index creation are
+	 * still searchable — YDB scans them without the index, then merges results.
+	 *
+	 * **Trade-off:** the index enables sub-linear search at the cost of recall.
+	 * Tune `indexConfigLevels`, `indexConfigClusters`, and
+	 * `indexTreeSearchTopSize` to balance speed vs. accuracy.
+	 *
+	 * Requires `indexEnabled: true` in the store config.
+	 * Throws if the index already exists (re-building requires dropping first).
+	 */
+	async createVectorIndex(): Promise<void> {
+		if (!this.#indexEnabled) {
+			throw new Error('Cannot create vector index: indexEnabled is false in config.')
+		}
+		await this.#ensureTable()
+
+		let dim = this.#vectorDimension ?? (await this.embeddings.embedQuery('test')).length
+		if (!Number.isSafeInteger(dim) || dim < 1) {
+			throw new Error(`vector dimension must be a positive integer, got: ${dim}`)
+		}
+
+		await this.#sql`
+      ALTER TABLE ${this.#t}
+      ADD INDEX ${identifier(this.#indexName)}
+      GLOBAL USING vector_kmeans_tree
+      ON (${identifier(this.#columnMap.embedding)})
+      WITH (
+        ${this.#sql.unsafe(this.#getIndexStrategy())},
+        vector_type = 'float',
+        vector_dimension=${this.#sql.unsafe(String(dim))},
+        levels=${this.#sql.unsafe(String(this.#indexConfigLevels))},
+        clusters=${this.#sql.unsafe(String(this.#indexConfigClusters))}
+      )`
+	}
+
+	/**
+	 * Close the internally-created Driver.
+	 * No-op when an external `driver` was provided — the caller owns its lifecycle.
+	 */
+	close(): void {
+		if (this.#ownedDriver) {
+			this.#driver.close()
+		}
+	}
+
+	[Symbol.dispose](): void {
+		this.close()
+	}
+
+	[Symbol.asyncDispose](): PromiseLike<void> {
+		return Promise.resolve(this.close())
+	}
+
+	/**
+	 * Create a store, embed the provided texts, and insert them in one step.
+	 *
+	 * @param texts - Raw text strings to embed and store.
+	 * @param metadatas - A single metadata object (applied to all texts) or one
+	 *   object per text.
+	 * @param embeddings - Embeddings model used to vectorise the texts.
+	 * @param config - Store configuration (connection + table options).
+	 * @returns A ready-to-use store containing the inserted documents.
+	 */
+	static override async fromTexts(
+		texts: string[],
+		metadatas: object | object[],
+		embeddings: EmbeddingsInterface,
+		config: YDBVectorStoreConfig
+	): Promise<YDBVectorStore> {
+		let docs = texts.map(
+			(text, i) =>
+				new Document({
+					pageContent: text,
+					metadata: Array.isArray(metadatas) ? metadatas[i] : metadatas,
+				})
+		)
+		return YDBVectorStore.fromDocuments(docs, embeddings, config)
+	}
+
+	/**
+	 * Create a store, embed the provided documents, and insert them in one step.
+	 *
+	 * @param docs - Documents to embed and store.
+	 * @param embeddings - Embeddings model used to vectorise the document text.
+	 * @param config - Store configuration (connection + table options).
+	 * @returns A ready-to-use store containing the inserted documents.
+	 */
+	static override async fromDocuments(
+		docs: Document[],
+		embeddings: EmbeddingsInterface,
+		config: YDBVectorStoreConfig
+	): Promise<YDBVectorStore> {
+		let store = new YDBVectorStore(embeddings, config)
+		await store.addDocuments(docs)
+		return store
+	}
+
+	/**
+	 * Connect to an existing YDB table without running `CREATE TABLE`.
+	 *
+	 * Use this when the table was created by a previous store instance or by
+	 * external tooling and you want to search or insert without re-initialising
+	 * the schema. The column names and vector strategy must match those used
+	 * when the table was first created.
+	 *
+	 * @param embeddings - Embeddings model (must produce the same dimension as
+	 *   the stored vectors).
+	 * @param config - Store configuration. Omit `dropExistingTable` — it has no
+	 *   effect here since `CREATE TABLE` is never called.
+	 * @returns A store instance whose table-creation step is already marked done.
+	 */
+	static fromExistingTable(
+		embeddings: EmbeddingsInterface,
+		config: YDBVectorStoreConfig
+	): YDBVectorStore {
+		let store = new YDBVectorStore(embeddings, config)
+		store.#isInitialized = true
+		return store
+	}
+}

--- a/third-parties/langchain/tests/vectorstore.int.test.ts
+++ b/third-parties/langchain/tests/vectorstore.int.test.ts
@@ -1,0 +1,423 @@
+import { afterAll, beforeAll, expect, inject, test } from 'vitest'
+import { Driver } from '@ydbjs/core'
+import { Document } from '@langchain/core/documents'
+import { FakeEmbeddings, SyntheticEmbeddings } from '@langchain/core/utils/testing'
+import { YDBSearchStrategy, YDBVectorStore } from '../src/index.ts'
+
+const CONNECTION_STRING = inject('connectionString')
+const TABLE = `langchain_int_test_${Date.now()}`
+const embeddings = new FakeEmbeddings()
+
+let driver: Driver
+
+beforeAll(async () => {
+	driver = new Driver(CONNECTION_STRING)
+	await driver.ready()
+})
+
+afterAll(async () => {
+	try {
+		const store = YDBVectorStore.fromExistingTable(embeddings, { driver, table: TABLE })
+		await store.drop()
+	} catch {
+		// table may not exist if an earlier test already dropped it
+	}
+	driver.close()
+})
+
+function makeStore(overrides: Record<string, unknown> = {}) {
+	return new YDBVectorStore(embeddings, { driver, table: TABLE, ...overrides })
+}
+
+// ── basic CRUD ───────────────────────────────────────────────────────
+
+test('fromTexts creates store, inserts, and searches', async () => {
+	const store = await YDBVectorStore.fromTexts(
+		['cat sat on mat', 'dog ran in park', 'fish swam in sea'],
+		[{ animal: 'cat' }, { animal: 'dog' }, { animal: 'fish' }],
+		embeddings,
+		{ driver, table: TABLE, dropExistingTable: true }
+	)
+
+	const results = await store.similaritySearch('cat', 2)
+	expect(results.length).toBe(2)
+	expect(results[0].pageContent).toBeDefined()
+})
+
+test('fromDocuments inserts and retrieves document content', async () => {
+	const docs = [
+		new Document({ pageContent: 'doc A', metadata: { n: 1 } }),
+		new Document({ pageContent: 'doc B', metadata: { n: 2 } }),
+	]
+	const store = await YDBVectorStore.fromDocuments(docs, embeddings, {
+		driver,
+		table: TABLE,
+		dropExistingTable: true,
+	})
+
+	const results = await store.similaritySearch('anything', 2)
+	expect(results).toHaveLength(2)
+	const contents = results.map((r) => r.pageContent)
+	expect(contents).toContain('doc A')
+	expect(contents).toContain('doc B')
+})
+
+test('addDocuments returns IDs and results carry score and metadata', async () => {
+	const store = makeStore({ dropExistingTable: true })
+
+	const docs = [
+		new Document({
+			pageContent: 'LangChain is a framework for LLM apps',
+			metadata: { source: 'docs', lang: 'en' },
+		}),
+		new Document({
+			pageContent: 'YDB is a distributed database',
+			metadata: { source: 'docs', lang: 'en' },
+		}),
+		new Document({
+			pageContent: 'TypeScript is a typed superset of JavaScript',
+			metadata: { source: 'wiki', lang: 'en' },
+		}),
+	]
+
+	const ids = await store.addDocuments(docs)
+	expect(ids).toHaveLength(3)
+
+	const results = await store.similaritySearchWithScore('database', 2)
+	expect(results).toHaveLength(2)
+
+	const [topDoc, topScore] = results[0]
+	expect(topDoc.pageContent).toBeDefined()
+	expect(typeof topScore).toBe('number')
+	expect(topDoc.metadata).toHaveProperty('source')
+	expect(topDoc.id).toBeDefined()
+})
+
+test('explicit document ID is preserved', async () => {
+	const store = makeStore({ dropExistingTable: true })
+
+	const ids = await store.addDocuments([
+		new Document({ pageContent: 'with explicit id', metadata: {}, id: 'my-custom-id' }),
+		new Document({ pageContent: 'without explicit id', metadata: {} }),
+	])
+
+	expect(ids[0]).toBe('my-custom-id')
+	expect(ids[1]).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+
+	const results = await store.similaritySearch('anything', 10)
+	const result = results.find((r) => r.id === 'my-custom-id')
+	expect(result).toBeDefined()
+	expect(result!.pageContent).toBe('with explicit id')
+})
+
+test('UPSERT replaces existing document on same ID', async () => {
+	const store = makeStore({ dropExistingTable: true })
+
+	await store.addDocuments([
+		new Document({ pageContent: 'original content', metadata: {}, id: 'upsert-id' }),
+	])
+	await store.addDocuments([
+		new Document({ pageContent: 'updated content', metadata: {}, id: 'upsert-id' }),
+	])
+
+	const results = await store.similaritySearch('anything', 10)
+	expect(results).toHaveLength(1)
+	expect(results[0].pageContent).toBe('updated content')
+})
+
+test('splits large batch insert into chunks of 32', async () => {
+	const store = makeStore({ dropExistingTable: true })
+
+	const docs = Array.from(
+		{ length: 35 },
+		(_, i) => new Document({ pageContent: `document ${i}`, metadata: { i } })
+	)
+
+	const ids = await store.addDocuments(docs)
+	expect(ids).toHaveLength(35)
+
+	const results = await store.similaritySearch('document', 35)
+	expect(results).toHaveLength(35)
+})
+
+test('searches by raw embedding vector', async () => {
+	const store = makeStore({ dropExistingTable: true })
+
+	await store.addDocuments([
+		new Document({ pageContent: 'alpha', metadata: {} }),
+		new Document({ pageContent: 'beta', metadata: {} }),
+	])
+
+	const queryVector = [0.1, 0.2, 0.3, 0.4]
+	const results = await store.similaritySearchVectorWithScore(queryVector, 2)
+	expect(results).toHaveLength(2)
+	expect(results[0][0]).toBeInstanceOf(Document)
+	expect(typeof results[0][1]).toBe('number')
+})
+
+// ── metadata filter ───────────────────────────────────────────────────
+
+test('metadata filter returns only matching documents', async () => {
+	const store = makeStore({ dropExistingTable: true })
+
+	await store.addDocuments([
+		new Document({ pageContent: 'wiki 1', metadata: { source: 'wiki' } }),
+		new Document({ pageContent: 'wiki 2', metadata: { source: 'wiki' } }),
+		new Document({ pageContent: 'wiki 3', metadata: { source: 'wiki' } }),
+		new Document({ pageContent: 'docs 1', metadata: { source: 'docs' } }),
+		new Document({ pageContent: 'docs 2', metadata: { source: 'docs' } }),
+	])
+
+	const wikiResults = await store.similaritySearch('anything', 10, { source: 'wiki' })
+	expect(wikiResults).toHaveLength(3)
+	expect(wikiResults.every((r) => r.metadata.source === 'wiki')).toBe(true)
+
+	const docsResults = await store.similaritySearch('anything', 10, { source: 'docs' })
+	expect(docsResults).toHaveLength(2)
+	expect(docsResults.every((r) => r.metadata.source === 'docs')).toBe(true)
+})
+
+test('multi-key metadata filter narrows results to all matching keys', async () => {
+	const store = makeStore({ dropExistingTable: true })
+
+	await store.addDocuments([
+		new Document({ pageContent: 'wiki en', metadata: { source: 'wiki', lang: 'en' } }),
+		new Document({ pageContent: 'wiki fr', metadata: { source: 'wiki', lang: 'fr' } }),
+		new Document({ pageContent: 'docs en', metadata: { source: 'docs', lang: 'en' } }),
+	])
+
+	const results = await store.similaritySearch('anything', 10, { source: 'wiki', lang: 'en' })
+	expect(results).toHaveLength(1)
+	expect(results[0].pageContent).toBe('wiki en')
+})
+
+test('metadata filter with no matches returns empty array', async () => {
+	const store = makeStore({ dropExistingTable: true })
+
+	await store.addDocuments([
+		new Document({ pageContent: 'some doc', metadata: { source: 'wiki' } }),
+	])
+
+	const results = await store.similaritySearch('anything', 10, { source: 'nonexistent' })
+	expect(results).toHaveLength(0)
+})
+
+// ── delete ────────────────────────────────────────────────────────────
+
+test('delete by IDs removes specific documents', async () => {
+	const store = makeStore({ dropExistingTable: true })
+
+	const ids = await store.addDocuments([
+		new Document({ pageContent: 'keep me', metadata: {} }),
+		new Document({ pageContent: 'delete me', metadata: {} }),
+		new Document({ pageContent: 'keep me too', metadata: {} }),
+	])
+
+	await store.delete({ ids: [ids[1]] })
+
+	const results = await store.similaritySearch('anything', 10)
+	expect(results).toHaveLength(2)
+
+	const contents = results.map((r) => r.pageContent)
+	expect(contents).not.toContain('delete me')
+	expect(contents).toContain('keep me')
+	expect(contents).toContain('keep me too')
+})
+
+test('delete all clears the table', async () => {
+	const store = makeStore({ dropExistingTable: true })
+
+	await store.addDocuments([
+		new Document({ pageContent: 'one', metadata: {} }),
+		new Document({ pageContent: 'two', metadata: {} }),
+	])
+
+	await store.delete({ deleteAll: true })
+
+	const results = await store.similaritySearch('anything', 10)
+	expect(results).toHaveLength(0)
+})
+
+// ── metadata round-trip ───────────────────────────────────────────────
+
+test('metadata types survive JSON round-trip', async () => {
+	const store = makeStore({ dropExistingTable: true })
+
+	await store.addDocuments([
+		new Document({
+			pageContent: 'round-trip',
+			metadata: { str: 'hello', num: 42, flag: true, nested: { x: 1 } },
+		}),
+	])
+
+	const results = await store.similaritySearch('anything', 1)
+	expect(results).toHaveLength(1)
+	expect(results[0].metadata).toEqual({ str: 'hello', num: 42, flag: true, nested: { x: 1 } })
+})
+
+// ── auxiliary methods ─────────────────────────────────────────────────
+
+test('fromExistingTable connects without CREATE TABLE', async () => {
+	const store1 = makeStore({ dropExistingTable: true })
+	await store1.addDocuments([
+		new Document({ pageContent: 'persisted', metadata: { key: 'val' } }),
+	])
+
+	const store2 = YDBVectorStore.fromExistingTable(embeddings, { driver, table: TABLE })
+	const results = await store2.similaritySearch('persisted', 1)
+	expect(results).toHaveLength(1)
+	expect(results[0].pageContent).toBe('persisted')
+	expect(results[0].metadata).toEqual({ key: 'val' })
+})
+
+test('custom column map stores and retrieves documents', async () => {
+	const customTable = `${TABLE}_custom`
+	const store = new YDBVectorStore(embeddings, {
+		driver,
+		table: customTable,
+		dropExistingTable: true,
+		columnMap: {
+			id: 'doc_id',
+			document: 'doc_text',
+			embedding: 'doc_vec',
+			metadata: 'doc_meta',
+		},
+	})
+
+	await store.addDocuments([new Document({ pageContent: 'custom columns', metadata: { x: 1 } })])
+
+	const results = await store.similaritySearch('custom', 1)
+	expect(results).toHaveLength(1)
+	expect(results[0].pageContent).toBe('custom columns')
+	expect(results[0].metadata).toEqual({ x: 1 })
+
+	await store.drop()
+})
+
+test('drop removes the table', async () => {
+	const tmpTable = `${TABLE}_drop`
+	const store = new YDBVectorStore(embeddings, { driver, table: tmpTable })
+
+	await store.addDocuments([new Document({ pageContent: 'bye', metadata: {} })])
+	await store.drop()
+
+	const store2 = new YDBVectorStore(embeddings, { driver, table: tmpTable })
+	const ids = await store2.addDocuments([
+		new Document({ pageContent: 'hello again', metadata: {} }),
+	])
+	expect(ids).toHaveLength(1)
+
+	await store2.drop()
+})
+
+// ── search strategies ─────────────────────────────────────────────────
+
+test('CosineSimilarity returns highest score first (DESC)', async () => {
+	// SyntheticEmbeddings produces content-based vectors, so semantically
+	// similar texts get closer vectors — unlike FakeEmbeddings which is fixed.
+	const synth = new SyntheticEmbeddings({ vectorSize: 4 })
+	const store = new YDBVectorStore(synth, {
+		driver,
+		table: TABLE,
+		dropExistingTable: true,
+		strategy: YDBSearchStrategy.CosineSimilarity,
+	})
+
+	await store.addDocuments([
+		new Document({ pageContent: 'cat', metadata: {} }),
+		new Document({ pageContent: 'xyz', metadata: {} }),
+	])
+
+	const results = await store.similaritySearchWithScore('cat', 2)
+	expect(results).toHaveLength(2)
+	// Similarity: higher = better → descending
+	expect(results[0][1]).toBeGreaterThanOrEqual(results[1][1])
+	expect(results[0][0].pageContent).toBe('cat')
+})
+
+test('CosineDistance returns lowest score first (ASC)', async () => {
+	const synth = new SyntheticEmbeddings({ vectorSize: 4 })
+	const store = new YDBVectorStore(synth, {
+		driver,
+		table: TABLE,
+		dropExistingTable: true,
+		strategy: YDBSearchStrategy.CosineDistance,
+	})
+
+	await store.addDocuments([
+		new Document({ pageContent: 'cat', metadata: {} }),
+		new Document({ pageContent: 'xyz', metadata: {} }),
+	])
+
+	const results = await store.similaritySearchWithScore('cat', 2)
+	expect(results).toHaveLength(2)
+	// Distance: lower = better → ascending
+	expect(results[0][1]).toBeLessThanOrEqual(results[1][1])
+	expect(results[0][0].pageContent).toBe('cat')
+})
+
+// ── connectionString mode ─────────────────────────────────────────────
+
+test('connectionString mode creates driver internally and close() releases it', async () => {
+	const connTable = `${TABLE}_connstr`
+	const store = new YDBVectorStore(embeddings, {
+		connectionString: CONNECTION_STRING,
+		table: connTable,
+	})
+
+	const ids = await store.addDocuments([
+		new Document({ pageContent: 'via connection string', metadata: {} }),
+	])
+	expect(ids).toHaveLength(1)
+
+	const results = await store.similaritySearch('anything', 1)
+	expect(results[0].pageContent).toBe('via connection string')
+
+	await store.drop()
+	store.close()
+})
+
+// ── vector index ──────────────────────────────────────────────────────
+
+test('createVectorIndex builds index and search uses it', async () => {
+	const indexTable = `${TABLE}_index`
+	const store = new YDBVectorStore(embeddings, {
+		driver,
+		table: indexTable,
+		dropExistingTable: true,
+		indexEnabled: true,
+		indexName: 'test_vec_idx',
+		vectorDimension: 4,
+	})
+
+	await store.addDocuments([
+		new Document({ pageContent: 'indexed alpha', metadata: {} }),
+		new Document({ pageContent: 'indexed beta', metadata: {} }),
+		new Document({ pageContent: 'indexed gamma', metadata: {} }),
+	])
+
+	await store.createVectorIndex()
+
+	const results = await store.similaritySearch('indexed', 3)
+	expect(results).toHaveLength(3)
+	expect(results[0].pageContent).toBeDefined()
+
+	await store.drop()
+})
+
+test('createVectorIndex throws when indexEnabled is false', async () => {
+	const store = makeStore({ indexEnabled: false })
+	await expect(store.createVectorIndex()).rejects.toThrow('indexEnabled is false')
+})
+
+test('search with filter and indexEnabled throws', async () => {
+	const store = makeStore({ dropExistingTable: true, indexEnabled: true })
+
+	await store.addDocuments([new Document({ pageContent: 'test', metadata: { k: 'v' } })])
+
+	await expect(
+		store.similaritySearchVectorWithScore([0.1, 0.2, 0.3, 0.4], 1, { k: 'v' })
+	).rejects.toThrow('Cannot use metadata filter with vector index enabled')
+
+	await store.drop()
+})

--- a/third-parties/langchain/tsconfig.json
+++ b/third-parties/langchain/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"rootDir": "src"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["dist/**/*", "**/*.test.ts", "vitest.config.ts"]
+}

--- a/third-parties/langchain/vitest.config.ts
+++ b/third-parties/langchain/vitest.config.ts
@@ -1,0 +1,32 @@
+import { defineProject } from 'vitest/config'
+
+export default defineProject({
+	test: {
+		projects: [
+			{
+				test: {
+					name: {
+						label: 'uni',
+						color: 'yellow',
+					},
+					include: ['src/**/*.test.ts'],
+					environment: 'node',
+				},
+			},
+			{
+				test: {
+					name: {
+						label: 'int',
+						color: 'blue',
+					},
+					include: ['tests/**/*.test.ts'],
+					environment: 'node',
+					globalSetup: '../../vitest.setup.ydb.ts',
+					testTimeout: 60000,
+					hookTimeout: 30000,
+					maxConcurrency: 1,
+				},
+			},
+		],
+	},
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,6 +35,8 @@ export default defineConfig({
 					environment: 'node',
 					execArgv: ['--expose-gc'],
 					globalSetup: './vitest.setup.ydb.ts',
+					testTimeout: 60000,
+					hookTimeout: 30000,
 					benchmark: {
 						include: [
 							'packages/*/tests/**/*.bench.ts',


### PR DESCRIPTION
Adds `@ydbjs/langchain` to `third-parties/` — a standalone LangChain.js `VectorStore` backed by YDB with KNN search, metadata filtering, approximate nearest-neighbour index support, and both driver-managed and connection-string modes.

Motivated by https://github.com/langchain-ai/langchainjs-community/pull/37, which was closed when `@langchain/community` was sunset in favour of standalone packages.

Also fixes a broken pre-commit hook: `oxlint` 1.56.0 does not support `--no-error-on-unmatched-pattern` (added in the deps update by mistake — only `oxfmt` has this flag).