### PR TITLE
Add composable SQL fragments to @ydbjs/query

### DIFF
--- a/.changeset/query-sql-fragments.md
+++ b/.changeset/query-sql-fragments.md
@@ -1,0 +1,5 @@
+---
+'@ydbjs/query': minor
+---
+
+Add composable query fragments: `fragment` (and `sql.fragment`) builds a non-executable piece of YQL with its own bound parameters, and `join` (and `sql.join`) combines fragments with a separator. Fragments nest into other `sql`/`fragment` templates, with parameters renumbered automatically — enabling dynamic `WHERE`/`IN`/KNN clauses without hand-building parameter names.

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -17,7 +17,7 @@ import { loggers } from '@ydbjs/debug'
 
 import { Query } from './query.js'
 import { ctx } from './ctx.js'
-import { UnsafeString, identifier, unsafe, yql } from './yql.js'
+import { Fragment, UnsafeString, fragment, identifier, join, unsafe, yql } from './yql.js'
 import { SessionPool, type SessionPoolOptions, sessionAcquireCh } from './session-pool.js'
 
 type TransactionContext = {
@@ -116,6 +116,18 @@ export interface QueryClient extends SQL, AsyncDisposable {
 	identifier(value: string | { toString(): string }): UnsafeString
 
 	/**
+	 * Create a composable {@link Fragment} from a tagged template. A fragment is
+	 * not executable — splice it into another query or {@link QueryClient.join}
+	 * to build dynamic SQL while keeping values bound as parameters.
+	 *
+	 * @example ```ts
+	 * const cond = sql.fragment`${sql.identifier('age')} > ${18}`
+	 * sql`SELECT * FROM users WHERE ${cond}`
+	 * ```
+	 */
+	fragment(strings: TemplateStringsArray, ...values: unknown[]): Fragment
+
+	/**
 	 * Create an UnsafeString that will be injected into the query as-is.
 	 *
 	 * WARNING: Use only with trusted SQL fragments (e.g., migrations) and never
@@ -123,6 +135,17 @@ export interface QueryClient extends SQL, AsyncDisposable {
 	 * dynamic values.
 	 */
 	unsafe(value: string | { toString(): string }): UnsafeString
+
+	/**
+	 * Combine fragments into one, interleaving a separator. Empty list → empty
+	 * fragment; single fragment → no separator. A string separator is inserted
+	 * as raw SQL.
+	 *
+	 * @example ```ts
+	 * sql`... WHERE ${sql.join(conditions, ' AND ')}`
+	 * ```
+	 */
+	join(fragments: readonly Fragment[], separator?: Fragment | string): Fragment
 }
 
 let doImpl = function <T = unknown>(): Promise<T> {
@@ -427,6 +450,8 @@ export function query(driver: Driver, options?: QueryOptions): QueryClient {
 		transaction: txIml,
 		identifier: identifier,
 		unsafe: unsafe,
+		fragment: fragment,
+		join: join,
 		async [Symbol.asyncDispose]() {
 			await sessionPool.close()
 		},
@@ -434,5 +459,5 @@ export function query(driver: Driver, options?: QueryOptions): QueryClient {
 }
 
 export { type Query } from './query.ts'
-export { identifier, unsafe, UnsafeString } from './yql.js'
+export { identifier, unsafe, UnsafeString, fragment, join, Fragment } from './yql.js'
 export { type SessionPoolOptions } from './session-pool.js'

--- a/packages/query/src/yql.test.ts
+++ b/packages/query/src/yql.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from 'vitest'
 
 import { Int32 } from '@ydbjs/value/primitive'
-import { identifier, unsafe, yql } from './yql.ts'
+
+import { fragment, identifier, join, unsafe, yql } from './yql.ts'
 
 test('processes string template', () => {
 	let { text } = yql`SELECT 1;`
@@ -178,6 +179,16 @@ test('public exports identifier/unsafe behave correctly', async () => {
 	expect(pubUnsafe('ORDER BY created_at DESC').toString()).eq('ORDER BY created_at DESC')
 })
 
+test('public exports fragment/join compose into a query', async () => {
+	const { fragment: pubFragment, join: pubJoin } = await import('./index.ts')
+
+	let conds = [pubFragment`a = ${1}`, pubFragment`b = ${2}`]
+	let { text, params } = yql`WHERE ${pubJoin(conds, ' AND ')};`
+
+	expect(text).eq('WHERE a = $p0 AND b = $p1;')
+	expect(Object.keys(params)).toHaveLength(2)
+})
+
 test('handles various data types', () => {
 	let { text, params } = yql`SELECT ${true}, ${'hello'}, ${123}, ${123n};`
 
@@ -224,4 +235,76 @@ test('validates all parameters and reports first error', () => {
 		  • An object property doesn't exist
 		For intentional null database values, use YDB Optional type.]
 	`)
+})
+
+test('continues parameter numbering across a fragment boundary', () => {
+	let frag = fragment`b = ${10}`
+	let { text, params } = yql`SELECT ${1}, ${frag}, ${2};`
+
+	expect(text).eq('SELECT $p0, b = $p1, $p2;')
+	expect(Object.keys(params)).toHaveLength(3)
+})
+
+test('flattens a fragment nested inside another fragment', () => {
+	let inner = fragment`x = ${1}`
+	let outer = fragment`(${inner} AND y = ${2})`
+	let { text, params } = yql`WHERE ${outer};`
+
+	expect(text).eq('WHERE (x = $p0 AND y = $p1);')
+	expect(Object.keys(params)).toHaveLength(2)
+})
+
+test('joins fragments with a separator', () => {
+	let parts = [fragment`a = ${1}`, fragment`b = ${2}`, fragment`c = ${3}`]
+	let { text, params } = yql`WHERE ${join(parts, ' AND ')};`
+
+	expect(text).eq('WHERE a = $p0 AND b = $p1 AND c = $p2;')
+	expect(Object.keys(params)).toHaveLength(3)
+})
+
+test('joins an empty list into empty text', () => {
+	let { text, params } = yql`SELECT 1 ${join([])};`
+
+	expect(text).eq('SELECT 1 ;')
+	expect(Object.keys(params)).toHaveLength(0)
+})
+
+test('joins a single fragment without the separator', () => {
+	let { text, params } = yql`WHERE ${join([fragment`a = ${1}`], ' AND ')};`
+
+	expect(text).eq('WHERE a = $p0;')
+	expect(Object.keys(params)).toHaveLength(1)
+})
+
+test('handles identifier and unsafe inside a fragment', () => {
+	let frag = fragment`${identifier('col')} = ${5} ${unsafe('DESC')}`
+	let { text, params } = yql`ORDER BY ${frag};`
+
+	expect(text).eq('ORDER BY `col` = $p0 DESC;')
+	expect(Object.keys(params)).toHaveLength(1)
+})
+
+test('throws for undefined value inside a fragment', () => {
+	let frag = fragment`x = ${undefined}`
+
+	expect(() => void yql`WHERE ${frag};`).toThrow(/Undefined value/)
+})
+
+test('composes a dynamic KNN search with filter conditions', () => {
+	let meta = identifier('metadata')
+	let filter = { source: 'wiki', lang: 'en' }
+	let conds = Object.entries(filter).map(
+		([k, v]) => fragment`JSON_VALUE(${meta}, ${unsafe(`'$.${k}'`)}) = ${v}`
+	)
+	let where = fragment`WHERE ${join(conds, ' AND ')}`
+	let { text, params } = yql`
+		SELECT Knn::CosineSimilarity(${identifier('embedding')}, ${new Uint8Array([1, 2, 3])}) AS score
+		FROM ${identifier('vectors')} ${where}
+		ORDER BY score DESC LIMIT ${10};`
+
+	expect(text).toContain('Knn::CosineSimilarity(`embedding`, $p0)')
+	expect(text).toContain("JSON_VALUE(`metadata`, '$.source') = $p1")
+	expect(text).toContain("JSON_VALUE(`metadata`, '$.lang') = $p2")
+	expect(text).toContain('LIMIT $p3')
+	expect(Object.keys(params)).toHaveLength(4)
 })

--- a/packages/query/src/yql.ts
+++ b/packages/query/src/yql.ts
@@ -1,6 +1,15 @@
 import { type Value, fromJs } from '@ydbjs/value'
 
+// ──────────────────────────────────────────────────────────────────────────
+// Internal markers
+// ──────────────────────────────────────────────────────────────────────────
+
 const SymbolUnsafe = Symbol('unsafe')
+const SymbolFragment = Symbol('fragment')
+
+// ──────────────────────────────────────────────────────────────────────────
+// Value helpers
+// ──────────────────────────────────────────────────────────────────────────
 
 function isObject(value: unknown): boolean {
 	return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -28,63 +37,18 @@ function validateValue(value: unknown, index: number): void {
 	}
 }
 
-export class UnsafeString extends String {
-	[SymbolUnsafe] = true
+function toYdbValue(value: any): Value {
+	return isObject(value) && 'type' in value && 'kind' in (value as any)['type']
+		? (value as Value)
+		: fromJs(value as any)
 }
 
-export function yql<P extends any[] = unknown[]>(
-	strings: string | TemplateStringsArray,
-	...values: P
-): { text: string; params: Record<string, Value> } {
-	let text = ''
-	let params: Record<string, Value> = Object.assign({}, null)
+// ──────────────────────────────────────────────────────────────────────────
+// Raw SQL: identifiers and unsafe injection
+// ──────────────────────────────────────────────────────────────────────────
 
-	// Handle simple string case
-	if (typeof strings === 'string') {
-		return { text: strings, params }
-	}
-
-	// Handle template literal case
-	if (Array.isArray(strings)) {
-		let skipCount = 0
-
-		// Process parameters first to build params object and count skipped values
-		values.forEach((value, i) => {
-			// Enhanced validation with position info
-			validateValue(value, i)
-
-			if ((value as any)[SymbolUnsafe]) {
-				skipCount++
-				return
-			}
-
-			let ydbValue =
-				isObject(value) && 'type' in value && 'kind' in (value as any)['type']
-					? (value as Value)
-					: fromJs(value as any)
-			params[`$p${i - skipCount}`] = ydbValue
-		})
-
-		// Build text with proper parameter references
-		skipCount = 0
-		text = strings.reduce((prev, curr, i) => {
-			let value = values[i]
-
-			// This should never happen due to validation above, but keep for safety
-			if (value === undefined || value === null) {
-				return prev + curr
-			}
-
-			if ((value as any)[SymbolUnsafe]) {
-				skipCount++
-				return prev + curr + value.toString()
-			}
-
-			return prev + curr + `$p${i - skipCount}`
-		}, '')
-	}
-
-	return { text, params }
+export class UnsafeString extends String {
+	[SymbolUnsafe] = true
 }
 
 export function unsafe(value: string | { toString(): string }) {
@@ -96,4 +60,118 @@ export function identifier(path: string) {
 	// Example: my`table -> my``table
 	let escaped = path.replaceAll('`', '``')
 	return unsafe('`' + escaped + '`')
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Composable fragments
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * A composable, non-executable piece of a query: its own template text plus
+ * bound values, which may themselves be other fragments, `UnsafeString`s, or
+ * scalars. Parameter names are assigned only when the fragment is flattened
+ * into a query, so fragments nest without parameter-name collisions.
+ *
+ * Create with {@link fragment} or {@link join}; splice into a `yql`/`fragment`
+ * template like any other interpolated value.
+ */
+export class Fragment {
+	[SymbolFragment] = true
+
+	constructor(
+		readonly strings: readonly string[],
+		readonly values: readonly unknown[]
+	) {}
+}
+
+function isFragment(value: unknown): value is Fragment {
+	return isObject(value) && (value as any)[SymbolFragment] === true
+}
+
+/**
+ * Create a composable query {@link Fragment} from a tagged template. Unlike the
+ * query client's `sql\`\``, a fragment is not executable — it only nests into
+ * another `yql`/`fragment` template or {@link join}.
+ *
+ * @example ```ts
+ * const cond = fragment`${identifier('age')} > ${18}`
+ * sql`SELECT * FROM users WHERE ${cond}`
+ * ```
+ */
+export function fragment<P extends any[] = unknown[]>(
+	strings: TemplateStringsArray,
+	...values: P
+): Fragment {
+	return new Fragment(strings as readonly string[], values)
+}
+
+/**
+ * Combine fragments into one, interleaving a separator between them. An empty
+ * list yields an empty fragment; a single fragment is returned without a
+ * separator. The separator is structural SQL — a string is inserted as raw text.
+ *
+ * @example ```ts
+ * const where = join(conditions, ' AND ')
+ * sql`SELECT * FROM users WHERE ${where}`
+ * ```
+ */
+export function join(fragments: readonly Fragment[], separator: Fragment | string = ''): Fragment {
+	let sep = typeof separator === 'string' ? unsafe(separator) : separator
+	let values: unknown[] = []
+	for (let i = 0; i < fragments.length; i++) {
+		if (i > 0) values.push(sep)
+		values.push(fragments[i])
+	}
+
+	return new Fragment(new Array(values.length + 1).fill(''), values)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Query building
+// ──────────────────────────────────────────────────────────────────────────
+
+// Single recursive pass over the template tree. A shared counter assigns
+// `$p0..$pN` in traversal order across nested fragments — no renumbering.
+function flatten(
+	strings: readonly string[],
+	values: readonly unknown[],
+	params: Record<string, Value>,
+	counter: { n: number }
+): string {
+	let text = ''
+	for (let i = 0; i < strings.length; i++) {
+		text += strings[i]
+		if (i >= values.length) continue
+
+		let value = values[i]
+		validateValue(value, i)
+
+		if ((value as any)[SymbolUnsafe]) {
+			text += (value as UnsafeString).toString()
+		} else if (isFragment(value)) {
+			text += flatten(value.strings, value.values, params, counter)
+		} else {
+			let name = `$p${counter.n}`
+			params[name] = toYdbValue(value)
+			text += name
+			counter.n++
+		}
+	}
+
+	return text
+}
+
+export function yql<P extends any[] = unknown[]>(
+	strings: string | TemplateStringsArray,
+	...values: P
+): { text: string; params: Record<string, Value> } {
+	let params: Record<string, Value> = Object.assign({}, null)
+
+	if (typeof strings === 'string') {
+		return { text: strings, params }
+	}
+
+	let text = flatten(strings, values, params, { n: 0 })
+
+	return { text, params }
 }

--- a/packages/query/vitest.config.ts
+++ b/packages/query/vitest.config.ts
@@ -2,8 +2,29 @@ import { defineProject } from 'vitest/config'
 
 export default defineProject({
 	test: {
-		environment: 'node',
-		include: ['src/**/*.test.ts'],
-		name: 'query',
+		projects: [
+			{
+				test: {
+					name: {
+						label: 'uni',
+						color: 'yellow',
+					},
+					include: ['src/**/*.test.ts'],
+					environment: 'node',
+				},
+			},
+			{
+				test: {
+					name: {
+						label: 'int',
+						color: 'blue',
+					},
+					include: ['tests/**/*.test.ts'],
+					environment: 'node',
+					testTimeout: 30000,
+					globalSetup: '../../vitest.setup.ydb.ts',
+				},
+			},
+		],
 	},
 })


### PR DESCRIPTION
## What

Adds first-class **composable query fragments** to `@ydbjs/query`:

- `fragment` / `sql.fragment` — builds a non-executable piece of YQL carrying its own bound parameters.
- `join` / `sql.join` — combines fragments with a separator (string separators are inserted as raw SQL).

Fragments nest into any `sql`/`fragment` template; parameters are flattened and renumbered (`$p0..$pN`) in a single pass at the root, so nesting never collides. Mirrors the existing `identifier` / `unsafe` surface (standalone exports + client methods).

## Why

Building dynamic YQL (variable-length `WHERE`, `IN`, `Knn::*` search) previously had no composition primitive — consumers had to hand-build the parts array and fabricate a fake `TemplateStringsArray`, coupling to private invariants of `yql.ts`. `drizzle-orm`'s `sql` already supports this; `@ydbjs/query` now does too.

This unblocks a follow-up refactor of `@ydbjs/langchain`'s `similaritySearchVectorWithScore` (separate PR).

## Changes

- `yql.ts`: `Fragment`, recursive `flatten`, `fragment`, `join`; reorganized into logical blocks.
- `index.ts`: `fragment` / `join` client methods + re-export.
- `yql.test.ts`: fragment/join unit tests (numbering across boundaries, nesting, join edge cases, realistic KNN `WHERE`, public-export check). Fragment-free queries verified byte-for-byte unchanged.
- `vitest.config.ts`: aligned with the `coordination` package (`uni`/`int` projects).

## Notes

- No change to `Query` execution — fragments are a pure build-time concern.
- `@ydbjs/query` minor bump via changeset.