### PR TITLE
Pin fflate to 0.8.2 to unblock attw

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -39,7 +39,7 @@ runs:
 
     - name: Install global dependencies
       shell: bash
-      run: npm i -g turbo prettier typescript @arethetypeswrong/cli @changesets/cli @changesets/changelog-github
+      run: npm i -g turbo @changesets/cli @changesets/changelog-github
 
     - name: Install dependencies
       shell: bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"@types/node": "^25.9.1",
 				"@vitest/coverage-v8": "^5.0.0-beta.3",
 				"@vitest/ui": "^5.0.0-beta.3",
+				"fflate": "0.8.2",
 				"oxfmt": "^0.52.0",
 				"oxlint": "^1.66.0",
 				"turbo": "^2.9.14",
@@ -4090,9 +4091,9 @@
 			}
 		},
 		"node_modules/fflate": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
-			"integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+			"integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"@types/node": "^25.9.1",
 		"@vitest/coverage-v8": "^5.0.0-beta.3",
 		"@vitest/ui": "^5.0.0-beta.3",
+		"fflate": "0.8.2",
 		"oxfmt": "^0.52.0",
 		"oxlint": "^1.66.0",
 		"turbo": "^2.9.14",
@@ -40,8 +41,9 @@
 	},
 	"overrides": {
 		"@grpc/proto-loader": "npm:dry-uninstall",
-		"protobufjs": "npm:dry-uninstall",
 		"esbuild": "^0.28.0",
+		"fflate": "0.8.2",
+		"protobufjs": "npm:dry-uninstall",
 		"vite": "^8.0.0"
 	},
 	"packageManager": "npm@11.5.1"


### PR DESCRIPTION
## Summary

CI's `npm run attw` step has been failing on `main` since `fflate@0.8.3` released:

```
error while checking file:
Cannot read properties of undefined (reading 'filename')
```

`fflate@0.8.3` changed the `Gunzip` streaming API: a single input chunk can now produce multiple output chunks. `@arethetypeswrong/core`'s tarball extractor assumes 1-in-1-out and reads `data[0].filename` on the wrong shape, crashing on every package's `attw --pack`. The bug affects every published version of `@arethetypeswrong/cli` (0.17.x and 0.18.x) — pinning the CLI does not help, the transitive dep is what's broken.

Tracking upstream: [arethetypeswrong/arethetypeswrong.github.io#258](https://github.com/arethetypeswrong/arethetypeswrong.github.io/issues/258).

## Fix

- Add `fflate: "0.8.2"` to root `overrides` so the override resolves nested under `@arethetypeswrong/core` and any other consumer.
- Add `fflate: "0.8.2"` to root `devDependencies` so npm hoists it into `node_modules/fflate` — the lock keeps a single `fflate` entry.
- Drop `prettier`, `typescript`, and `@arethetypeswrong/cli` from the CI `npm i -g` step in `.github/actions/setup/action.yml`. They're already in workspace `devDependencies` and run via `node_modules/.bin/`, so a global install can only cause version drift (and was the channel through which CI ended up running attw with `fflate@0.8.3` unconstrained).
- Sort `overrides` keys alphabetically.

## Verification

- `npm run build`: 34/34 ✓
- `npm run attw`: 50/50 ✓
- `npm test`: 839 passed, 6 skipped, 0 failed
- `npm ls fflate` reports a single version

## Test plan

- [ ] CI `Run attw` step passes on this branch
- [ ] `npm ls fflate` after `npm ci` returns a single version on a fresh checkout