### PR TITLE
ci: report coverage to Codecov with per-package components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,4 +78,19 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - run: npm run build
-      - run: npm run test
+
+      - name: Test
+        if: matrix.node-version != 24
+        run: npm run test
+
+      - name: Test with coverage
+        if: matrix.node-version == 24
+        run: npm run coverage
+
+      - name: Upload coverage to Codecov
+        if: matrix.node-version == 24
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./coverage
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # YDB JavaScript SDK
 
-[![Docs](https://ydb.js.org/)](https://ydb.js.org/)
+[![Docs](https://ydb.js.org/)](https://ydb.js.org/) [![codecov](https://codecov.io/gh/ydb-platform/ydb-js-sdk/graph/badge.svg)](https://codecov.io/gh/ydb-platform/ydb-js-sdk)
 
 Modern, modular SDK for YDB in TypeScript/JavaScript.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,108 @@
+# Cross-repo uniform metric: every YDB SDK repo defines this same component_id,
+# so native-SDK coverage is queryable identically via the Codecov API
+# (?component_id=native-sdk), regardless of how each repo tags its uploads.
+#
+# This repo is an npm monorepo. The umbrella native-sdk component maps to the whole
+# packages tree (the generated gRPC bindings in packages/api are excluded from
+# coverage, so they carry no data). On top of that, every workspace gets its own
+# component for per-package visibility — a file matches both its package component
+# and the native-sdk umbrella, since Codecov allows a path to belong to many
+# components. Third-party framework adapters live under third-parties/* and get
+# their own components so they never dilute the native-sdk number.
+
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        informational: true
+
+  individual_components:
+    # Umbrella component — the whole native SDK (required, cross-repo metric).
+    - component_id: native-sdk
+      name: native-sdk
+      paths:
+        - packages/**
+
+    # Per-package components.
+    - component_id: abortable
+      name: '@ydbjs/abortable'
+      paths:
+        - packages/abortable/**
+    - component_id: auth
+      name: '@ydbjs/auth'
+      paths:
+        - packages/auth/**
+    - component_id: coordination
+      name: '@ydbjs/coordination'
+      paths:
+        - packages/coordination/**
+    - component_id: core
+      name: '@ydbjs/core'
+      paths:
+        - packages/core/**
+    - component_id: debug
+      name: '@ydbjs/debug'
+      paths:
+        - packages/debug/**
+    - component_id: error
+      name: '@ydbjs/error'
+      paths:
+        - packages/error/**
+    - component_id: fsm
+      name: '@ydbjs/fsm'
+      paths:
+        - packages/fsm/**
+    - component_id: query
+      name: '@ydbjs/query'
+      paths:
+        - packages/query/**
+    - component_id: retry
+      name: '@ydbjs/retry'
+      paths:
+        - packages/retry/**
+    - component_id: telemetry
+      name: '@ydbjs/telemetry'
+      paths:
+        - packages/telemetry/**
+    - component_id: topic
+      name: '@ydbjs/topic'
+      paths:
+        - packages/topic/**
+    - component_id: value
+      name: '@ydbjs/value'
+      paths:
+        - packages/value/**
+
+    # Third-party framework adapters — separate so they do not dilute native-sdk.
+    - component_id: auth-yandex-cloud
+      name: '@ydbjs/auth-yandex-cloud'
+      paths:
+        - third-parties/auth-yandex-cloud/**
+    - component_id: drizzle-adapter
+      name: '@ydbjs/drizzle-adapter'
+      paths:
+        - third-parties/drizzle-adapter/**
+    - component_id: langchain
+      name: '@ydbjs/langchain'
+      paths:
+        - third-parties/langchain/**
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+# Coverage still uploads and status checks stay, but Codecov must not post
+# PR comments — status/components are enough, the comment is just noise.
+comment: false
+
+# Coverage is collected once (Node 24 leg) and uploaded from CI; do not wait for
+# multiple uploads before building the report.
+codecov:
+  notify:
+    after_n_builds: 1

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"build": "turbo run build --output-logs=errors-only",
 		"attw": "turbo run attw",
 		"test": "vitest --run",
+		"coverage": "vitest --run --coverage",
 		"lint": "oxlint --fix",
 		"format": "oxfmt --write",
 		"version": "npx changeset version && npm install",

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -1,5 +1,7 @@
 # @ydbjs/auth
 
+[![codecov](https://codecov.io/gh/ydb-platform/ydb-js-sdk/graph/badge.svg?component=auth)](https://codecov.io/gh/ydb-platform/ydb-js-sdk)
+
 The `@ydbjs/auth` package provides authentication utilities for interacting with YDB services. It supports static credentials, token-based authentication, anonymous access, and VM metadata providers.
 
 ## Features

--- a/packages/coordination/README.md
+++ b/packages/coordination/README.md
@@ -1,5 +1,7 @@
 # @ydbjs/coordination
 
+[![codecov](https://codecov.io/gh/ydb-platform/ydb-js-sdk/graph/badge.svg?component=coordination)](https://codecov.io/gh/ydb-platform/ydb-js-sdk)
+
 Distributed coordination client for [YDB](https://ydb.tech): semaphores, mutexes, and leader elections built on top of YDB coordination nodes.
 
 ## Features

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,5 +1,7 @@
 # @ydbjs/core
 
+[![codecov](https://codecov.io/gh/ydb-platform/ydb-js-sdk/graph/badge.svg?component=core)](https://codecov.io/gh/ydb-platform/ydb-js-sdk)
+
 The `@ydbjs/core` package provides the core driver and connection management for YDB in JavaScript/TypeScript. It is the foundation for all YDB client operations, handling connection pooling, service client creation, authentication, and middleware.
 
 ## Features

--- a/packages/debug/README.md
+++ b/packages/debug/README.md
@@ -1,5 +1,7 @@
 # @ydbjs/debug
 
+[![codecov](https://codecov.io/gh/ydb-platform/ydb-js-sdk/graph/badge.svg?component=debug)](https://codecov.io/gh/ydb-platform/ydb-js-sdk)
+
 Centralized debug logging for YDB JavaScript SDK, inspired by Playwright's debug architecture.
 
 ## Features

--- a/packages/error/README.md
+++ b/packages/error/README.md
@@ -1,5 +1,7 @@
 # @ydbjs/error
 
+[![codecov](https://codecov.io/gh/ydb-platform/ydb-js-sdk/graph/badge.svg?component=error)](https://codecov.io/gh/ydb-platform/ydb-js-sdk)
+
 The `@ydbjs/error` package provides utilities for handling YDB-specific errors in JavaScript/TypeScript applications. It simplifies error classification and provides detailed error messages for better debugging and troubleshooting.
 
 ## Features

--- a/packages/fsm/README.md
+++ b/packages/fsm/README.md
@@ -1,5 +1,7 @@
 # @ydbjs/fsm
 
+[![codecov](https://codecov.io/gh/ydb-platform/ydb-js-sdk/graph/badge.svg?component=fsm)](https://codecov.io/gh/ydb-platform/ydb-js-sdk)
+
 `@ydbjs/fsm` is a lightweight async-first finite state machine runtime for YDB JavaScript SDK packages.
 
 It is designed for long-lived async workflows where predictable state transitions, explicit side effects, and safe shutdown semantics are required.

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -1,5 +1,7 @@
 # @ydbjs/query
 
+[![codecov](https://codecov.io/gh/ydb-platform/ydb-js-sdk/graph/badge.svg?component=query)](https://codecov.io/gh/ydb-platform/ydb-js-sdk)
+
 Read this in Russian: [README.ru.md](README.ru.md)
 
 The `@ydbjs/query` package provides a high-level, type-safe client for executing YQL queries and managing transactions in YDB. It features a tagged template API, automatic parameter binding, transaction helpers, and deep integration with the YDB type system.

--- a/packages/query/README.ru.md
+++ b/packages/query/README.ru.md
@@ -1,5 +1,7 @@
 # @ydbjs/query
 
+[![codecov](https://codecov.io/gh/ydb-platform/ydb-js-sdk/graph/badge.svg?component=query)](https://codecov.io/gh/ydb-platform/ydb-js-sdk)
+
 Читать на английском: [README.md](README.md)
 
 `@ydbjs/query` — высокоуровневый, типобезопасный клиент для выполнения YQL‑запросов и управления транзакциями в YDB. Поддерживает теговый шаблонный синтаксис, автоматическое связывание параметров, хелперы транзакций и глубокую интеграцию с типовой системой YDB.

--- a/packages/retry/README.md
+++ b/packages/retry/README.md
@@ -1,5 +1,7 @@
 # @ydbjs/retry
 
+[![codecov](https://codecov.io/gh/ydb-platform/ydb-js-sdk/graph/badge.svg?component=retry)](https://codecov.io/gh/ydb-platform/ydb-js-sdk)
+
 The `@ydbjs/retry` package provides utilities for implementing retry logic in your applications. It is designed to work seamlessly with YDB services, allowing you to handle transient errors and ensure reliable operations.
 
 ## Features

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -1,5 +1,7 @@
 # @ydbjs/telemetry
 
+[![codecov](https://codecov.io/gh/ydb-platform/ydb-js-sdk/graph/badge.svg?component=telemetry)](https://codecov.io/gh/ydb-platform/ydb-js-sdk)
+
 OpenTelemetry instrumentation for the YDB JavaScript SDK. Subscribes to
 `node:diagnostics_channel` events emitted by `@ydbjs/core`, `@ydbjs/query`,
 `@ydbjs/auth`, and `@ydbjs/retry`, and converts them into OTel **spans** and

--- a/packages/topic/README.md
+++ b/packages/topic/README.md
@@ -1,5 +1,7 @@
 # @ydbjs/topic
 
+[![codecov](https://codecov.io/gh/ydb-platform/ydb-js-sdk/graph/badge.svg?component=topic)](https://codecov.io/gh/ydb-platform/ydb-js-sdk)
+
 Read this in Russian: [README.ru.md](README.ru.md)
 
 High‑level, type‑safe clients for YDB Topics (publish–subscribe message streams) in JavaScript/TypeScript. Provides efficient streaming reads and writes, partition session management, offset commits, compression, and transaction‑aware readers/writers.

--- a/packages/topic/README.ru.md
+++ b/packages/topic/README.ru.md
@@ -1,5 +1,7 @@
 # @ydbjs/topic
 
+[![codecov](https://codecov.io/gh/ydb-platform/ydb-js-sdk/graph/badge.svg?component=topic)](https://codecov.io/gh/ydb-platform/ydb-js-sdk)
+
 Читать на английском: [README.md](README.md)
 
 Высокоуровневые, типобезопасные клиенты для YDB Topics (стриминговые очереди сообщений) на JavaScript/TypeScript. Поддерживаются эффективное потоковое чтение/запись, управление сессиями партиций, коммиты оффсетов, сжатие и транзакции.

--- a/packages/value/README.md
+++ b/packages/value/README.md
@@ -1,5 +1,7 @@
 # @ydbjs/value
 
+[![codecov](https://codecov.io/gh/ydb-platform/ydb-js-sdk/graph/badge.svg?component=value)](https://codecov.io/gh/ydb-platform/ydb-js-sdk)
+
 The `@ydbjs/value` package provides utilities for working with YDB values and types in JavaScript/TypeScript. It includes classes and functions for encoding, decoding, and converting YDB values to and from native JavaScript types.
 
 ## Features

--- a/third-parties/auth-yandex-cloud/README.md
+++ b/third-parties/auth-yandex-cloud/README.md
@@ -1,5 +1,7 @@
 # @ydbjs/auth-yandex-cloud
 
+[![codecov](https://codecov.io/gh/ydb-platform/ydb-js-sdk/graph/badge.svg?component=auth-yandex-cloud)](https://codecov.io/gh/ydb-platform/ydb-js-sdk)
+
 Yandex Cloud Service Account authentication provider for YDB. Supports authorized key JSON files and automatic IAM token management.
 
 ## Installation

--- a/third-parties/drizzle-adapter/README.md
+++ b/third-parties/drizzle-adapter/README.md
@@ -1,5 +1,7 @@
 # @ydbjs/drizzle-adapter
 
+[![codecov](https://codecov.io/gh/ydb-platform/ydb-js-sdk/graph/badge.svg?component=drizzle-adapter)](https://codecov.io/gh/ydb-platform/ydb-js-sdk)
+
 The `@ydbjs/drizzle-adapter` package wires [Drizzle ORM](https://orm.drizzle.team/) to YDB. It ships typed schema declarations with YDB-native column types, query builders that emit valid YQL, a relational `db.query.*` API, a migration runner with history and optional distributed locking, and ergonomic wrappers around YDB built-in functions and UDFs (Digest hashes, `CurrentUtc*`, `Knn::*`, set operators, pragmas, scripts).
 
 ## Features

--- a/third-parties/langchain/README.md
+++ b/third-parties/langchain/README.md
@@ -1,5 +1,7 @@
 # @ydbjs/langchain
 
+[![codecov](https://codecov.io/gh/ydb-platform/ydb-js-sdk/graph/badge.svg?component=langchain)](https://codecov.io/gh/ydb-platform/ydb-js-sdk)
+
 [YDB](https://ydb.tech) integration for [LangChain.js](https://js.langchain.com) — a `VectorStore` backed by YDB with KNN search support.
 
 ## Installation

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -65,6 +65,10 @@ export default defineConfig({
 		],
 		passWithNoTests: true,
 		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'lcov'],
+			reportsDirectory: './coverage',
+			include: ['packages/*/src/**', 'third-parties/*/src/**'],
 			exclude: [
 				'packages/api/**',
 				'examples/**',


### PR DESCRIPTION
Enables v8 coverage in vitest and uploads lcov to Codecov from the Node 24 CI leg (20/22 run plain tests). `codecov.yml` maps `packages/**` to a `native-sdk` component (cross-repo metric) plus one component per workspace. Adds component-filtered coverage badges to package READMEs and an overall badge to the root.