### PR TITLE
Add tracked CLAUDE.md bridge to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## What

Add a git-tracked `CLAUDE.md` in the repository root containing a single line, `@AGENTS.md`, so Claude Code loads the project's `AGENTS.md` conventions automatically.

## Why

The only bridge from Claude Code to `AGENTS.md` was `CLAUDE.local.md` (also `@AGENTS.md`), but that file is **not tracked by git**. Claude Code's documented behavior is that an untracked `CLAUDE.local.md` lives only in the worktree where it was created — it does **not** propagate into isolated git worktrees. As a result, any session started in a fresh worktree does not pick up `AGENTS.md` on start unless the file is read manually, which is unreliable.

This gap already caused a concrete regression: a previous commit (`ci: disable Codecov PR comments`) violated the commit-message format defined in `AGENTS.md` — which requires a capitalized action verb without a conventional-commits type prefix (e.g. `Disable Codecov PR comments`, not `ci: ...`).

## Changes

- New tracked file `CLAUDE.md` with content `@AGENTS.md`

Because the file is tracked, it is present in every checkout and worktree, so agent sessions load the conventions automatically regardless of where they run. `CLAUDE.local.md` remains for any local-only overrides.

## Testing

- No code changes; documentation/config only
- Repository pre-push test suite passed (655 tests)

## Checklist

- [ ] Changeset — not applicable (no published package changes)
- [ ] README — not applicable