### PR TITLE
Enable blocking Codecov coverage status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -92,10 +92,11 @@ coverage:
   status:
     project:
       default:
-        informational: true
+        target: auto       # do not drop below the current level...
+        threshold: 1%      # ...by more than 1%
     patch:
       default:
-        informational: true
+        target: 80%        # new/changed code in the PR diff must be >= 80% covered
 
 # Coverage still uploads and status checks stay, but Codecov must not post
 # PR comments — status/components are enough, the comment is just noise.


### PR DESCRIPTION
The `project` and `patch` coverage statuses were `informational: true`, so Codecov never failed a PR on coverage regressions. This switches them to blocking gates: `project` fails when overall coverage drops by more than 1% versus the base branch (`target: auto`, `threshold: 1%`), and `patch` requires the PR diff to be at least 80% covered.

Mirrors the gates already used in ydb-python-sdk, keeping coverage enforcement uniform across the native SDKs. Component and comment config is untouched.