### PR TITLE
Fix unhandledRejection crash on failed background rediscovery

### DIFF
--- a/.changeset/driver-rediscovery-unhandled-rejection.md
+++ b/.changeset/driver-rediscovery-unhandled-rejection.md
@@ -1,0 +1,5 @@
+---
+'@ydbjs/core': patch
+---
+
+Fix process crash when a background rediscovery round fails. The periodic discovery loop scheduled its rounds as floating promises, so a terminally failed round (e.g. the discovery endpoint dropping mid-round until the per-round timeout aborted the retries) escalated to an `unhandledRejection` and killed the process. Failed background rounds are now caught and logged; the connection pool keeps serving last-known endpoints and the next interval tick retries.

--- a/packages/core/src/driver.test.ts
+++ b/packages/core/src/driver.test.ts
@@ -1,6 +1,13 @@
 import { expect, test } from 'vitest'
-import { DiscoveryServiceDefinition } from '@ydbjs/api/discovery'
-import { createServer } from 'nice-grpc'
+import { create } from '@bufbuild/protobuf'
+import { anyPack } from '@bufbuild/protobuf/wkt'
+import {
+	DiscoveryServiceDefinition,
+	EndpointInfoSchema,
+	ListEndpointsResultSchema,
+} from '@ydbjs/api/discovery'
+import { StatusIds_StatusCode } from '@ydbjs/api/operation'
+import { ServerError, Status, createServer } from 'nice-grpc'
 
 import { Driver, kRegisterLibrary } from './driver.ts'
 import pkg from '../package.json' with { type: 'json' }
@@ -135,6 +142,75 @@ test('appends registered libraries to x-ydb-sdk-build-info after the native sdk 
 		)
 	} finally {
 		driver.close()
+		await server.shutdown()
+	}
+})
+
+test('survives background rediscovery failure and keeps serving requests', async (tc) => {
+	let unhandled: unknown[] = []
+	let trap = (reason: unknown) => unhandled.push(reason)
+	process.on('unhandledRejection', trap)
+
+	let server = createServer()
+	let port = 0
+	let calls = 0
+	let discoveryService = {
+		listEndpoints: DiscoveryServiceDefinition.listEndpoints,
+		whoAmI: DiscoveryServiceDefinition.whoAmI,
+	}
+
+	server.add(discoveryService, {
+		// First round succeeds so the driver becomes ready; every later round
+		// fails like a node dropping mid-rediscovery.
+		async listEndpoints() {
+			calls += 1
+			if (calls > 1) {
+				throw new ServerError(Status.UNAVAILABLE, 'Connection dropped')
+			}
+			let result = create(ListEndpointsResultSchema, {
+				endpoints: [
+					create(EndpointInfoSchema, {
+						nodeId: 1,
+						address: '127.0.0.1',
+						port,
+						location: 'dc1',
+					}),
+				],
+			})
+			return {
+				operation: {
+					status: StatusIds_StatusCode.SUCCESS,
+					ready: true,
+					result: anyPack(ListEndpointsResultSchema, result),
+				},
+			} as any
+		},
+		async whoAmI() {
+			return {} as any
+		},
+	})
+
+	port = await server.listen('127.0.0.1:0')
+
+	try {
+		using driver = new Driver(`grpc://127.0.0.1:${port}/local`, {
+			'ydb.sdk.discovery_timeout_ms': 100,
+			'ydb.sdk.discovery_interval_ms': 150,
+		})
+		await driver.ready(tc.signal)
+
+		// Let several rediscovery ticks fail; without a rejection handler each
+		// one would surface as an unhandledRejection and kill the process.
+		await new Promise((resolve) => setTimeout(resolve, 500))
+		expect(calls).toBeGreaterThan(1)
+
+		// The pool still serves the endpoint from the last successful round.
+		let client = driver.createClient(discoveryService)
+		await client.whoAmI({}, { signal: tc.signal })
+
+		expect(unhandled).toEqual([])
+	} finally {
+		process.off('unhandledRejection', trap)
 		await server.shutdown()
 	}
 })

--- a/packages/core/src/driver.ts
+++ b/packages/core/src/driver.ts
@@ -459,7 +459,13 @@ export class Driver implements Disposable {
 
 		this.#rediscoverTimer = setInterval(() => {
 			if (this.#closed) return
-			void this.#discovery(this.#discoverySignal(timeout))
+			// A failed background round must not escalate to an unhandledRejection
+			// (which kills the process): the pool keeps serving last-known
+			// endpoints and the next tick retries. Subscribers still observe the
+			// failure via the tracing:ydb:driver.discovery error event.
+			this.#discovery(this.#discoverySignal(timeout)).catch((error) => {
+				dbg.log('background rediscovery failed: %O', error)
+			})
 		}, interval)
 
 		// Don't keep the process alive solely for rediscovery.


### PR DESCRIPTION
## What

Catch rejections from periodic background rediscovery rounds so a failed round no longer escalates to an `unhandledRejection` and kills the process.

## Why

`#startDiscoveryLoop` scheduled periodic rediscovery as a floating promise (`void this.#discovery(...)`). When a round failed terminally — e.g. a node dropping mid-round until the per-round `AbortSignal.timeout` aborted the retry loop — the rejection had no handler and crashed the process.

Reproduced in the `tests/slo` chaos harness (`docker compose --profile chaos`): chaos-monkey dropped a node and both workload processes died simultaneously with `[safety] unhandledRejection: ClientError: /Ydb.Discovery.V1.DiscoveryService/ListEndpoints UNAVAILABLE: Connection dropped`. A failed background round should be non-fatal by design: the connection pool keeps serving last-known endpoints and the next interval tick retries.

## Changes

- Periodic `#discovery` calls in `#startDiscoveryLoop` now catch rejections and log them via the driver debug logger
- No new diagnostics channel: subscribers already observe failed rounds via the existing `tracing:ydb:driver.discovery` error event (`tracePromise`)
- Patch changeset for `@ydbjs/core`

## Testing

- New regression test in `packages/core/src/driver.test.ts`: a fake discovery server succeeds on the first round (driver becomes ready), then fails every later round with `UNAVAILABLE: Connection dropped`; the test traps `process.on('unhandledRejection')`, asserts nothing was caught, and verifies the driver still serves requests from the last-known endpoint
- Verified the test fails on the unfixed code with exactly the chaos-repro error captured as an unhandled rejection
- `packages/core/src` unit tests pass (73/73); dependent `@ydbjs/query` / `@ydbjs/topic` unit tests pass (234/234); full suite ran on pre-push (822/822); `npm run build` and lint clean

## Checklist

- [x] Changeset added (if package changes)
- [ ] README updated (if public API changed) — no public API change