### PR TITLE
Unify async test assertions on a shared helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,40 @@ test('creates a node', async () => {
 })
 ```
 
+### Assertions
+
+**One canonical style: vitest `expect` matchers.** No `node:assert`, no chai `.to.*`. Every assertion in `*.test.ts` goes through `expect(...)`. The recurring async patterns each have ONE idiom — don't hand-roll a `.then()` capture:
+
+- **A rejecting promise** → `await expect(promise).rejects.*`. oxlint's `vitest(require-to-throw-message)` requires an argument to `.toThrow()`, so pass a matcher or assert the type.
+- **A resolving promise** ("must finish, not hang") → `await expect(promise).resolves.*`, bounded by the test timeout / `tc.signal` — not an ad-hoc `Promise.race([p, setTimeout(...)])`.
+- **"Still pending after a tick"** → the shared `track()` helper, co-located with `settle()` in each package's `*.fixtures.ts` — not a scattered `let flag = false; p.then(() => (flag = true))` probe.
+
+```typescript
+// DO
+await expect(pool.acquire()).rejects.toBeInstanceOf(EndpointsUnavailableError)
+await expect(commit).resolves.toBeUndefined() // liveness: resolves, does not hang
+
+let closing = pool.close()
+let draining = track(closing)
+await settle()
+expect(draining.settled).toBe(false) // still blocked on the in-flight call
+pool.callEnded(1n)
+await closing
+expect(draining.settled).toBe(true)
+
+// DON'T
+let err = await p.then(
+  () => undefined,
+  (e) => e
+) // ❌ hand-rolled reject capture
+let closed = false
+let closing = pool.close().then(() => {
+  closed = true
+}) // ❌ probe flag + trips promise(always-return)
+await settle()
+expect(closed).toBe(false)
+```
+
 ### Test Types
 
 - **Unit tests** (`npm run test:uni`) - fast, no external dependencies, always run

--- a/packages/coordination/src/client.test.ts
+++ b/packages/coordination/src/client.test.ts
@@ -95,10 +95,6 @@ test('does not hang when the external signal is already aborted by the time the 
 	let stream = await firstStreamP
 	stream.respond(sessionStartedResponse(1n))
 
-	let outcome = await Promise.race([
-		iterating.then(() => 'completed' as const),
-		new Promise<'hung'>((resolve) => setTimeout(() => resolve('hung'), 2000)),
-	])
-
-	expect(outcome).toBe('completed')
+	// The generator must finish, not hang on the synchronous-abort race.
+	await expect(iterating).resolves.toBeUndefined()
 }, 10_000)

--- a/packages/coordination/src/runtime/session-registry.test.ts
+++ b/packages/coordination/src/runtime/session-registry.test.ts
@@ -6,6 +6,7 @@ import {
 	SessionRequestRegistry,
 	createDeferred,
 } from './session-registry.ts'
+import { track } from './session-runtime.fixtures.ts'
 
 // ── createDeferred ─────────────────────────────────────────────────────────────
 
@@ -125,12 +126,10 @@ test('delete removes a pending request silently', async () => {
 	expect(registry.resolve(reqId, fakeResponse)).toBe(false)
 
 	// The deferred promise itself is never settled — that's intentional.
-	// Attach a no-op race so we can confirm nothing settled synchronously.
-	let settled = false
-	deferred.promise.finally(() => (settled = true))
+	let deferredState = track(deferred.promise)
 
 	await Promise.resolve()
-	expect(settled).toBe(false)
+	expect(deferredState.settled).toBe(false)
 })
 
 // ── SessionRequestRegistry — reconnect ────────────────────────────────────────

--- a/packages/coordination/src/runtime/session-runtime.fixtures.ts
+++ b/packages/coordination/src/runtime/session-runtime.fixtures.ts
@@ -148,6 +148,27 @@ export let settle = async function settle(ticks = 100): Promise<void> {
 	}
 }
 
+// Observe a promise's settlement without consuming it: after pumping microtasks
+// (`await settle()`), `settled` reports whether it resolved or rejected while the
+// caller still awaits the original promise for its value. Replaces the scattered
+// `let flag = false; p.then(() => (flag = true))` probe idiom.
+export type Settlement = { settled: boolean; rejected: boolean; reason?: unknown }
+
+export let track = function track(promise: Promise<unknown>): Settlement {
+	let state: Settlement = { settled: false, rejected: false }
+	void (async () => {
+		try {
+			await promise
+		} catch (reason) {
+			state.rejected = true
+			state.reason = reason
+		} finally {
+			state.settled = true
+		}
+	})()
+	return state
+}
+
 // Yield to the macrotask queue (timers, I/O callbacks) once.
 // Unlike Promise.resolve() microtasks, setImmediate yields between event loop
 // phases so that pending setTimeout callbacks (retry backoff, recovery window)

--- a/packages/coordination/src/runtime/session-runtime.test.ts
+++ b/packages/coordination/src/runtime/session-runtime.test.ts
@@ -6,6 +6,7 @@ import {
 	sessionStartedResponse,
 	sessionStoppedResponse,
 	settle,
+	track,
 	waitForStatus,
 } from './session-runtime.fixtures.ts'
 
@@ -80,11 +81,11 @@ test('waitReady blocks during reconnect after first ready', async () => {
 
 	// waitReady must block now; the old (resolved) readyDeferred should have been
 	// replaced with a fresh unresolved one when schedule_retry_backoff ran.
-	let resolved = false
-	let waitPromise = runtime.transport.waitReady().then(() => (resolved = true))
+	let waitReady = runtime.transport.waitReady()
+	let waiting = track(waitReady)
 
 	await settle()
-	expect(resolved).toBe(false)
+	expect(waiting.settled).toBe(false)
 
 	// Wait for the retry backoff (5 ms) to fire and open the second stream.
 	let secondStream = await secondStreamP
@@ -92,8 +93,8 @@ test('waitReady blocks during reconnect after first ready', async () => {
 	await waitForStatus(runtime, 'ready')
 
 	// waitReady must have unblocked by now.
-	await waitPromise
-	expect(resolved).toBe(true)
+	await waitReady
+	expect(waiting.settled).toBe(true)
 	expect(runtime.status).toBe('ready')
 
 	runtime.destroy()
@@ -219,19 +220,19 @@ test('close() waits for sessionStopped before resolving', async () => {
 
 	expect(runtime.status).toBe('ready')
 
-	let closed = false
-	let closePromise = runtime.close().then(() => (closed = true))
+	let closing = runtime.close()
+	let closingState = track(closing)
 
 	// FSM moves to closing; close() must still be pending until sessionStopped.
 	await waitForStatus(runtime, 'closing')
-	expect(closed).toBe(false)
+	expect(closingState.settled).toBe(false)
 
 	// Server acknowledges the graceful stop.
 	stream.respond(sessionStoppedResponse())
 	await waitForStatus(runtime, 'closed')
 
-	await closePromise
-	expect(closed).toBe(true)
+	await closing
+	expect(closingState.settled).toBe(true)
 })
 
 test('close() resolves via disconnect when server drops stream instead of sending stopped', async () => {

--- a/packages/core/src/endpoints/endpoints.contract.test.ts
+++ b/packages/core/src/endpoints/endpoints.contract.test.ts
@@ -23,6 +23,7 @@ import {
 	makeFakeDiscovery,
 	pile,
 	settle,
+	track,
 } from './endpoints.fixtures.ts'
 
 let setup = function setup(
@@ -327,23 +328,21 @@ test('close finalizes promptly without waiting the close deadline', async (tc) =
 })
 
 test('close waits for an in-flight call to drain, then finalizes', async (tc) => {
-	let closed = false
 	let h = setup([endpoint(1)], { closeDeadlineMs: 30_000 })
 	await h.pool.ready(tc.signal)
 	h.pool.acquire(1n)
 	h.pool.callStarted(1n) // simulate an in-flight RPC on node 1
 
-	let closing = h.pool.close().then(() => {
-		closed = true
-	})
+	let closing = h.pool.close()
+	let draining = track(closing)
 	await settle()
 	// The busy channel keeps close() pending.
-	expect(closed).toBe(false)
+	expect(draining.settled).toBe(false)
 	expect(h.connections.byNode(1n)!.closed).toBe(false)
 
 	h.pool.callEnded(1n) // the RPC finishes → channel drains → finalize
 	await closing
-	expect(closed).toBe(true)
+	expect(draining.settled).toBe(true)
 	expect(h.connections.byNode(1n)!.closed).toBe(true)
 })
 

--- a/packages/core/src/endpoints/endpoints.fixtures.ts
+++ b/packages/core/src/endpoints/endpoints.fixtures.ts
@@ -176,6 +176,27 @@ export let settle = async function settle(ticks = 50): Promise<void> {
 	for (let i = 0; i < ticks; i++) await Promise.resolve()
 }
 
+// Observe a promise's settlement without consuming it: after pumping microtasks
+// (`await settle()`), `settled` reports whether it resolved or rejected while the
+// caller still awaits the original promise for its value. Replaces the scattered
+// `let flag = false; p.then(() => (flag = true))` probe idiom.
+export type Settlement = { settled: boolean; rejected: boolean; reason?: unknown }
+
+export let track = function track(promise: Promise<unknown>): Settlement {
+	let state: Settlement = { settled: false, rejected: false }
+	void (async () => {
+		try {
+			await promise
+		} catch (reason) {
+			state.rejected = true
+			state.reason = reason
+		} finally {
+			state.settled = true
+		}
+	})()
+	return state
+}
+
 export type Captured = {
 	events: unknown[]
 	[Symbol.dispose](): void

--- a/packages/fsm/src/promise.fixtures.ts
+++ b/packages/fsm/src/promise.fixtures.ts
@@ -1,0 +1,20 @@
+// Observe a promise's settlement without consuming it: after pumping microtasks,
+// `settled` reports whether it resolved or rejected while the caller still awaits
+// the original promise for its value. Replaces the scattered
+// `let flag = false; p.then(() => (flag = true))` probe idiom.
+export type Settlement = { settled: boolean; rejected: boolean; reason?: unknown }
+
+export let track = function track(promise: Promise<unknown>): Settlement {
+	let state: Settlement = { settled: false, rejected: false }
+	void (async () => {
+		try {
+			await promise
+		} catch (reason) {
+			state.rejected = true
+			state.reason = reason
+		} finally {
+			state.settled = true
+		}
+	})()
+	return state
+}

--- a/packages/fsm/src/queue.test.ts
+++ b/packages/fsm/src/queue.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest'
+import { track } from './promise.fixtures.ts'
 import { AsyncPriorityQueue, AsyncQueue } from './queue.ts'
 
 test('processes priority items in descending order', async () => {
@@ -500,12 +501,11 @@ test('take does not deliver a buffered item while paused, then delivers on resum
 	queue.pause()
 	queue.push('a')
 
-	let settled = false
 	let pending = queue.take()
-	void pending.then(() => (settled = true))
+	let taken = track(pending)
 	// A microtask turn is enough for a wrongly-eager delivery to settle.
 	await Promise.resolve()
-	expect(settled).toBe(false)
+	expect(taken.settled).toBe(false)
 
 	queue.resume()
 	expect(await pending).toEqual({ value: 'a', done: false })

--- a/packages/fsm/src/runtime.test.ts
+++ b/packages/fsm/src/runtime.test.ts
@@ -4,6 +4,7 @@ import { setTimeout as sleep } from 'node:timers/promises'
 
 import { expect, test } from 'vitest'
 
+import { track } from './promise.fixtures.js'
 import { AsyncQueue } from './queue.js'
 import { createMachineRuntime } from './runtime.js'
 import type { EffectRuntime } from './types.js'
@@ -399,14 +400,10 @@ test('output iterator adds no microtask latency over the raw queue', async () =>
 	// number of microtask turns as one read straight from an AsyncQueue. A wrapper
 	// generator makes the runtime strictly slower and fails this.
 	let turnsToSettle = async (p: Promise<unknown>): Promise<number> => {
-		let settled = false
-		p.then(
-			() => (settled = true),
-			() => (settled = true)
-		)
+		let state = track(p)
 
 		let turns = 0
-		while (!settled && turns < 100) {
+		while (!state.settled && turns < 100) {
 			await Promise.resolve()
 			turns += 1
 		}

--- a/packages/topic/src/reader/reader.contract.test.ts
+++ b/packages/topic/src/reader/reader.contract.test.ts
@@ -658,14 +658,7 @@ test('resolves a pending commit covered by stop_partition committed_offset', asy
 	)
 	await settle()
 
-	let outcome = await Promise.race([
-		commit.then(
-			() => 'resolved',
-			() => 'rejected'
-		),
-		new Promise((resolve) => setTimeout(() => resolve('pending'), 500)),
-	])
-	expect(outcome).toBe('resolved')
+	await expect(commit).resolves.toBeUndefined()
 })
 
 test('sends a commit issued during a graceful stop and completes the handoff', async (tc) => {
@@ -1373,7 +1366,7 @@ test('answers a re-granted partition exactly once when the previous stream hook 
 		onPartitionSessionStart: () => {
 			let d = Promise.withResolvers<void>()
 			calls.push(d)
-			return d.promise.then(() => undefined)
+			return d.promise
 		},
 	})
 

--- a/packages/topic/src/reader/reader.fixtures.ts
+++ b/packages/topic/src/reader/reader.fixtures.ts
@@ -411,3 +411,24 @@ export let settle = async function settle(ticks = 100): Promise<void> {
 		await Promise.resolve()
 	}
 }
+
+// Observe a promise's settlement without consuming it: after pumping microtasks
+// (`await settle()`), `settled` reports whether it resolved or rejected while the
+// caller still awaits the original promise for its value. Replaces the scattered
+// `let flag = false; p.then(() => (flag = true))` probe idiom.
+export type Settlement = { settled: boolean; rejected: boolean; reason?: unknown }
+
+export let track = function track(promise: Promise<unknown>): Settlement {
+	let state: Settlement = { settled: false, rejected: false }
+	void (async () => {
+		try {
+			await promise
+		} catch (reason) {
+			state.rejected = true
+			state.reason = reason
+		} finally {
+			state.settled = true
+		}
+	})()
+	return state
+}

--- a/packages/topic/src/writer/writer.contract.test.ts
+++ b/packages/topic/src/writer/writer.contract.test.ts
@@ -14,6 +14,7 @@ import {
 	makeFakeTopicDriver,
 	settle,
 	tick,
+	track,
 	writeResponse,
 } from './writer.fixtures.ts'
 import { createTopicTxWriter, createTopicWriter } from './writer.ts'
@@ -195,12 +196,11 @@ test('does not fail a pending flush across a retryable reconnect', async () => {
 	await first.waitForWrite()
 
 	let flushed = writer.flush()
-	let settledEarly = false
-	void flushed.then(() => (settledEarly = true)).catch(() => (settledEarly = true))
+	let flush = track(flushed)
 
 	first.disconnect()
 	await settle()
-	expect(settledEarly).toBe(false)
+	expect(flush.settled).toBe(false)
 
 	let second = await waitForNextStream()
 	await second.waitForInit()
@@ -286,15 +286,15 @@ test('drains buffered messages before a graceful close resolves', async () => {
 	writer.write(bytes(1))
 	await stream.waitForWrite()
 
-	let closed = false
-	let closing = writer.close().then(() => (closed = true))
+	let closing = writer.close()
+	let closingState = track(closing)
 
 	await settle()
-	expect(closed).toBe(false)
+	expect(closingState.settled).toBe(false)
 
 	stream.respond(writeResponse([{ seqNo: 1n }]))
 	await closing
-	expect(closed).toBe(true)
+	expect(closingState.settled).toBe(true)
 })
 
 test('rejects pending flush when destroyed', async () => {
@@ -482,8 +482,8 @@ test('keeps draining a graceful close across a mid-close reconnect', async () =>
 	writer.write(bytes(1))
 	await first.waitForWrite()
 
-	let closed = false
-	let closing = writer.close().then(() => (closed = true))
+	let closing = writer.close()
+	let closingState = track(closing)
 
 	// Stream drops mid-close before the ack — the writer must reconnect and resend.
 	first.disconnect()
@@ -497,7 +497,7 @@ test('keeps draining a graceful close across a mid-close reconnect', async () =>
 	second.respond(writeResponse([{ seqNo: 1n }]))
 
 	await closing
-	expect(closed).toBe(true)
+	expect(closingState.settled).toBe(true)
 })
 
 test('publishes a reconnecting diagnostics event on a retryable disconnect', async () => {

--- a/packages/topic/src/writer/writer.fixtures.ts
+++ b/packages/topic/src/writer/writer.fixtures.ts
@@ -261,6 +261,27 @@ export let settle = async function settle(ticks = 100): Promise<void> {
 	}
 }
 
+// Observe a promise's settlement without consuming it: after pumping microtasks
+// (`await settle()`), `settled` reports whether it resolved or rejected while the
+// caller still awaits the original promise for its value. Replaces the scattered
+// `let flag = false; p.then(() => (flag = true))` probe idiom.
+export type Settlement = { settled: boolean; rejected: boolean; reason?: unknown }
+
+export let track = function track(promise: Promise<unknown>): Settlement {
+	let state: Settlement = { settled: false, rejected: false }
+	void (async () => {
+		try {
+			await promise
+		} catch (reason) {
+			state.rejected = true
+			state.reason = reason
+		} finally {
+			state.settled = true
+		}
+	})()
+	return state
+}
+
 export let tick = function tick(): Promise<void> {
 	let d = deferred<void>()
 	setTimeout(d.resolve, 0)

--- a/packages/topic/tests/reader-rebalance.test.ts
+++ b/packages/topic/tests/reader-rebalance.test.ts
@@ -11,6 +11,7 @@ import {
 import { Driver } from '@ydbjs/core'
 
 import { type TopicReader, createTopicReader } from '../src/reader/index.js'
+import { type Settlement, track } from '../src/reader/reader.fixtures.js'
 import { createTopicWriter } from '../src/writer/index.js'
 
 // First real-server rebalance coverage. A second read session on the same consumer
@@ -65,19 +66,6 @@ let waitUntil = async function waitUntil(predicate: () => boolean, ms: number): 
 	return predicate()
 }
 
-// Every commit() must settle — a hung commit is the failure mode this test guards
-// against. Handlers are attached immediately so a rejection is never unhandled.
-type CommitOutcome = { state: 'pending' | 'resolved' | 'rejected'; reason?: unknown }
-
-let trackCommit = function trackCommit(outcomes: CommitOutcome[], promise: Promise<void>): void {
-	let outcome: CommitOutcome = { state: 'pending' }
-	outcomes.push(outcome)
-	promise.then(
-		() => Object.assign(outcome, { state: 'resolved' as const }),
-		(reason: unknown) => Object.assign(outcome, { state: 'rejected' as const, reason })
-	)
-}
-
 let decoder = new TextDecoder()
 
 // Read continuously, committing every delivered batch (so a rebalance races real
@@ -85,7 +73,7 @@ let decoder = new TextDecoder()
 let runReadLoop = function runReadLoop(
 	reader: TopicReader,
 	received: Set<number>,
-	commits: CommitOutcome[],
+	commits: Settlement[],
 	errorBox: { error?: unknown },
 	signal: AbortSignal
 ): void {
@@ -96,7 +84,8 @@ let runReadLoop = function runReadLoop(
 					received.add(Number(decoder.decode(message.payload)))
 				}
 				if (batch.length > 0) {
-					trackCommit(commits, reader.commit(batch))
+					// track() handles the rejection so a reassign-race commit is never unhandled.
+					commits.push(track(reader.commit(batch)))
 				}
 			}
 		} catch (error) {
@@ -137,7 +126,7 @@ test(
 
 		let receivedA = new Set<number>()
 		let receivedB = new Set<number>()
-		let commits: CommitOutcome[] = []
+		let commits: Settlement[] = []
 		let errA: { error?: unknown } = {}
 		let errB: { error?: unknown } = {}
 
@@ -191,12 +180,12 @@ test(
 
 		// Every commit() settles — resolved, or rejected with the documented
 		// reassign-race errors. A pending commit here means a hang.
-		let settled = await waitUntil(() => commits.every((c) => c.state !== 'pending'), 10_000)
+		let settled = await waitUntil(() => commits.every((c) => c.settled), 10_000)
 		expect(settled, 'every commit() promise settled').toBe(true)
 		let documentedRejection =
 			/reassigned before commit was acknowledged|stopped or expired partition session|No active partition/
 		let undocumentedRejections = commits
-			.filter((outcome) => outcome.state === 'rejected')
+			.filter((outcome) => outcome.rejected)
 			.map((outcome) => String((outcome.reason as Error).message))
 			.filter((message) => !documentedRejection.test(message))
 		expect(undocumentedRejections).toEqual([])


### PR DESCRIPTION
## What

Standardize the test suite on a single async-assertion style — vitest `expect` matchers plus one shared promise-settlement helper — replacing scattered hand-rolled `.then()` idioms. Test-only; no product behavior changes.

## Why

The suite mixed several ad-hoc async-assertion idioms: bare `.then()` flag probes for "still pending", `Promise.race([p, setTimeout(...)])` timeouts for liveness, and a per-file re-invented `trackCommit`. This was inconsistent and tripped two oxlint warnings (`promise(always-return)`, `no-unmodified-loop-condition`). AGENTS.md already declares vitest `expect` the standard, but it wasn't enforced for the async cases.

## Changes

- Add a shared, dependency-free `track(promise) → { settled, rejected, reason? }` helper next to each package's `settle()` in `*.fixtures.ts` (core, coordination, topic writer + reader), plus a new `packages/fsm/src/promise.fixtures.ts`.
- Replace hand-rolled pending-probe flags (`let f = false; p.then(() => (f = true))`) with `track()` across endpoints, writer, session-runtime, session-registry, and fsm queue.
- Replace `Promise.race([p.then(...), setTimeout(...)])` liveness checks with `await expect(p).resolves.*`, bounded by the test timeout (coordination client, topic reader).
- Swap reader-rebalance's local `trackCommit` for the shared `track()`.
- Document the one canonical vitest-`expect` assertion style (rejects / resolves / pending-probe) in AGENTS.md Testing Rules.
- Net effect: clears both oxlint warnings (48 → 46 total); no behavior change.

Not a breaking change. Intentionally left as-is (documented in review, not the target anti-pattern): `session-pool` dual-outcome captures, the `election`/`mutex` integration probes with their justified heuristic sleeps, and the fsm `sleep().then('label')` race harness.

## Testing

- `npm run build` — passes (fixtures are compiled, so `track`/`Settlement` are type-checked).
- `npm run test:uni` — 1023 passed, 1 skipped.
- `reader-rebalance` integration test — run live against local YDB, passes.
- `npm run lint` — exit 0, 46 warnings (down from 48; `promise(always-return)` and `no-unmodified-loop-condition` cleared, none added).
- Edited test files type-checked clean.

## Checklist

- [ ] Changeset added — N/A: test-only change, no published/consumable API surface affected.
- [ ] README updated — N/A: no public API change.

Separate from the core-package refactor (#638).
